### PR TITLE
(feat) add GitHub Copilot support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
     && rm -rf /var/lib/apt/lists/*
 
 # AI CLI tools
-RUN npm install -g @anthropic-ai/claude-code @google/gemini-cli @zed-industries/claude-agent-acp @zed-industries/codex-acp
+RUN npm install -g @anthropic-ai/claude-code @github/copilot @google/gemini-cli @zed-industries/claude-agent-acp @zed-industries/codex-acp
 
 # Chromium for Kaleido/Plotly
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/condor/acp/client.py
+++ b/condor/acp/client.py
@@ -20,6 +20,7 @@ log = logging.getLogger(__name__)
 ACP_COMMANDS: dict[str, str] = {
     "claude-code": "claude-agent-acp",
     "gemini": "gemini --experimental-acp",
+    "copilot": "copilot --acp",
 }
 
 

--- a/condor/preferences.py
+++ b/condor/preferences.py
@@ -158,7 +158,7 @@ class TradingAgentPrefs(TypedDict, total=False):
 
 
 class AgentPrefs(TypedDict, total=False):
-    default_agent: str       # "claude-code", "gemini", "codex"
+    default_agent: str       # "claude-code", "gemini", "codex", "copilot"
     show_tool_calls: bool    # Show tool call indicators (default True)
 
 

--- a/condor/trading_agent/README.md
+++ b/condor/trading_agent/README.md
@@ -95,7 +95,7 @@ trading_agents/
 3. **Read journal context** — `learnings.md`, `summary`, and the last 3 decisions.
 4. **Get risk state** from `RiskEngine` (exposure, drawdown, open count). If the agent is blocked, log it and return without invoking the LLM.
 5. **Build the prompt** via `build_tick_prompt(...)`, optionally appending any user directives queued via `inject_directive()`.
-6. **Spawn an ACP session** for the strategy's `agent_key` (claude-code, gemini, …) with MCP servers wired in (Hummingbot tools, market data, notifications, journal writes). Stream events, capture text and tool calls.
+6. **Spawn an ACP session** for the strategy's `agent_key` (claude-code, gemini, copilot…) with MCP servers wired in (Hummingbot tools, market data, notifications, journal writes). Stream events, capture text and tool calls.
 7. **Persist** — for sessions, write `snapshot_N.md`, append a tick to the journal, and update the running summary. For dry-runs / run-once, write a flat `experiment_N.md`.
 
 ### Run modes

--- a/condor/trading_agent/engine.py
+++ b/condor/trading_agent/engine.py
@@ -282,7 +282,7 @@ class TickEngine:
             )
             self._pending_directives.clear()
 
-        # 6. Create agent client (ACP for Claude/Gemini, PydanticAI for open-source models)
+        # 6. Create agent client (ACP for Claude/Gemini/Copilot, PydanticAI for open-source models)
         from handlers.agents._shared import (
             build_mcp_servers_for_agent,
             build_mcp_servers_for_session,

--- a/condor/trading_agent/strategy.py
+++ b/condor/trading_agent/strategy.py
@@ -97,7 +97,7 @@ class Strategy:
     id: str
     name: str
     description: str
-    agent_key: str  # "claude-code", "gemini", or pydantic-ai model like "ollama:llama3.1"
+    agent_key: str  # "claude-code", "gemini", "copilot" or pydantic-ai model like "ollama:llama3.1"
     instructions: str  # The strategy logic text for the LLM
     skills: list[str] = field(default_factory=list)  # Optional skill names
     default_config: dict[str, Any] = field(default_factory=dict)

--- a/handlers/agents/_shared.py
+++ b/handlers/agents/_shared.py
@@ -9,6 +9,7 @@ log = logging.getLogger(__name__)
 AGENT_OPTIONS: dict[str, dict[str, str]] = {
     "claude-code": {"label": "Claude Code"},
     "gemini": {"label": "Gemini CLI"},
+    "copilot": {"label": "GitHub Copilot CLI"},
     "ollama:llama3.1": {"label": "Ollama — Llama 3.1"},
     "ollama:qwen3:32b": {"label": "Ollama — Qwen 3 32B"},
     "ollama:qwen2.5:72b": {"label": "Ollama — Qwen 2.5 72B"},

--- a/handlers/agents/session.py
+++ b/handlers/agents/session.py
@@ -34,7 +34,7 @@ _health_bot: Bot | None = None
 @dataclass
 class AgentSession:
     chat_id: int
-    agent_key: str  # "claude-code", "gemini", "codex"
+    agent_key: str  # "claude-code", "gemini", "codex", "copilot"
     client: ACPClient
     mode: str = "condor"  # "condor", "agent_builder"
     is_busy: bool = False

--- a/mcp_servers/condor/server.py
+++ b/mcp_servers/condor/server.py
@@ -796,7 +796,7 @@ async def manage_trading_agent(
         name: Strategy name (for create/update) or routine name (for run_routine).
         description: Strategy description (for create/update).
         instructions: Strategy instructions text (for create/update).
-        agent_key: Default LLM for the strategy (for create/update). Examples: "claude-code", "gemini", "ollama:llama3.1", "ollama:qwen3:32b", "groq:llama-3.3-70b-versatile". Default "claude-code".
+        agent_key: Default LLM for the strategy (for create/update). Examples: "claude-code", "gemini", "copilot", "ollama:llama3.1", "ollama:qwen3:32b", "groq:llama-3.3-70b-versatile". Default "claude-code".
         skills: List of optional skill names to enable (for create/update).
         config: Agent config overrides (for create/update/start) or routine config (for run_routine).
             For start_agent, supports: agent_key (override strategy default), model_base_url (for LM Studio/vLLM),


### PR DESCRIPTION
This feature is meant to add GitHub Copilot support to Condor.
Copilot supports [many models](https://docs.github.com/fr/copilot/reference/ai-models/supported-models) including Claude and Gemini.