### PR TITLE
Add SSL suppor for condor Hummingbot API

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -15,6 +15,21 @@ from aiohttp import ClientTimeout
 
 logger = logging.getLogger(__name__)
 
+def _build_server_url(server: dict) -> str:
+    """Build the full URL for a server, supporting http and https."""
+    host = server.get("host", "localhost")
+    port = server.get("port", 8000)
+
+    # If host already includes protocol, use it as-is
+    if host.startswith(("http://", "https://")):
+        # If port is 443 for https or 80 for http, don't add it
+        if (host.startswith("https://") and port == 443) or (host.startswith("http://") and port == 80):
+            return host.rstrip("/")
+        return f"{host.rstrip('/')}:{port}"
+
+    # Default to http unless port is 443
+    protocol = "https" if port == 443 else "http"
+    return f"{protocol}://{host}:{port}"
 
 class UserRole(str, Enum):
     """User roles in the system"""
@@ -385,7 +400,7 @@ class ConfigManager:
 
         # Create new client
         server = self._data["servers"][name]
-        base_url = f"http://{server['host']}:{server['port']}"
+        base_url = _build_server_url(server)
         client = HummingbotAPIClient(
             base_url=base_url,
             username=server["username"],
@@ -448,7 +463,7 @@ class ConfigManager:
             return {"status": "error", "message": "Server not found"}
 
         server = self._data["servers"][name]
-        base_url = f"http://{server['host']}:{server['port']}"
+        base_url = _build_server_url(server)
 
         client = HummingbotAPIClient(
             base_url=base_url,

--- a/handlers/agents/_shared.py
+++ b/handlers/agents/_shared.py
@@ -6,6 +6,22 @@ from typing import Any
 
 log = logging.getLogger(__name__)
 
+def _build_server_url(server: dict) -> str:
+    """Build the full URL for a server, supporting http and https."""
+    host = server.get("host", "localhost")
+    port = server.get("port", 8000)
+
+    # If host already includes protocol, use it as-is
+    if host.startswith(("http://", "https://")):
+        # If port is 443 for https or 80 for http, don't add it
+        if (host.startswith("https://") and port == 443) or (host.startswith("http://") and port == 80):
+            return host.rstrip("/")
+        return f"{host.rstrip('/')}:{port}"
+
+    # Default to http unless port is 443
+    protocol = "https" if port == 443 else "http"
+    return f"{protocol}://{host}:{port}"
+
 AGENT_OPTIONS: dict[str, dict[str, str]] = {
     "claude-code": {"label": "Claude Code"},
     "gemini": {"label": "Gemini CLI"},
@@ -389,7 +405,7 @@ def build_mcp_servers_for_session(
         )
         return [condor]
 
-    api_url = f"http://{server['host']}:{server['port']}"
+    api_url = _build_server_url(server)
 
     mcp_hummingbot = {
         "name": "mcp-hummingbot",
@@ -436,7 +452,7 @@ def build_mcp_servers_for_agent(
         )
         return [condor]
 
-    api_url = f"http://{server['host']}:{server['port']}"
+    api_url = _build_server_url(server)
 
     mcp_hummingbot = {
         "name": "mcp-hummingbot",

--- a/mcp_servers/hummingbot_api/server.py
+++ b/mcp_servers/hummingbot_api/server.py
@@ -9,6 +9,19 @@ from typing import Any, Literal
 
 from mcp.server.fastmcp import FastMCP
 
+def _build_server_url(host: str, port: int) -> str:
+    """Build the full URL for a server, supporting http and https."""
+    # If host already includes protocol, use it as-is
+    if host.startswith(("http://", "https://")):
+        # If port is 443 for https or 80 for http, don't add it
+        if (host.startswith("https://") and port == 443) or (host.startswith("http://") and port == 80):
+            return host.rstrip("/")
+        return f"{host.rstrip('/')}:{port}"
+
+    # Default to http unless port is 443
+    protocol = "https" if port == 443 else "http"
+    return f"{protocol}://{host}:{port}"
+
 from mcp_servers.hummingbot_api.formatters import (
     format_active_bots_as_table,
     format_bot_logs_as_table,
@@ -152,7 +165,7 @@ async def configure_server(
 
     new_config = ServerConfig(
         name=final_name,
-        url=f"http://{final_host}:{final_port}",
+        url=_build_server_url(final_host, final_port),
         username=final_username,
         password=final_password,
     )


### PR DESCRIPTION
This commit adds SSL/HTTPS support to the Hummingbot API connections in Condor.

Changes:
- Added _build_server_url() helper function to handle both HTTP and HTTPS protocols
- Function automatically detects protocol from host string if present
- Defaults to HTTPS when port is 443, otherwise uses HTTP
- Replaced hardcoded HTTP URLs with dynamic URL building in:
- config_manager.py (2 locations)
- _shared.py (2 locations)
- server.py (1 location)

This enables secure HTTPS connections for Hummingbot API servers running on port 443.