### PR TITLE
Update Node.js 24 LTS at Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ WORKDIR /app
 # uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-# Node.js 20 LTS (via NodeSource – includes npm)
+# Node.js 24 LTS (via NodeSource – includes npm)
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
npm run build was failed at cd /condor/frontend/ after use Node.js 20 LTS. After update node --version v24.15.0 LTS and npm --version 11.12.1 it was fixed. Please Update Node.js 24 LTS at Dockerfile

 
