### PR TITLE
Add MarketData page and responsive UI updates

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -3,7 +3,7 @@ import {
   Activity,
   Bot,
   Brain,
-  FileText,
+  CandlestickChart,
   Swords,
   Zap,
   LogOut,
@@ -30,7 +30,7 @@ const NAV_ITEMS = [
   { to: "/executors", icon: Activity, label: "Executors" },
   { to: "/agents", icon: Brain, label: "Agents" },
   { to: "/routines", icon: Zap, label: "Routines" },
-  { to: "/reports", icon: FileText, label: "Reports" },
+  { to: "/market", icon: CandlestickChart, label: "Market" },
 ] as const;
 
 export function AppShell() {
@@ -39,123 +39,145 @@ export function AppShell() {
   const { pathname } = useLocation();
   const { theme, toggleTheme } = useTheme();
   const [collapsed, setCollapsed] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   // Prefetch core data (executors, bots) and subscribe to WS channels early
   usePrefetchData();
 
-  return (
-    <div className="flex h-screen">
-      {/* Sidebar */}
-      <aside
-        className={`flex flex-col border-r border-[var(--color-border)] bg-[var(--color-surface)] transition-all duration-200 ${
-          collapsed ? "w-14" : "w-56"
-        }`}
-      >
-        <div className="flex items-center justify-between border-b border-[var(--color-border)] p-4">
-          {collapsed ? (
-            <button
-              onClick={() => setCollapsed(false)}
-              className="rounded p-1 text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
-              title="Expand sidebar"
-            >
-              <PanelLeftOpen className="h-5 w-5" />
-            </button>
-          ) : (
-            <>
-              <h1 className="flex items-center gap-2 text-lg font-bold tracking-tight">
-                <img src="/condor_old.jpeg" alt="Condor" className="h-7 w-7 rounded-full" />
-                Condor
-              </h1>
-              <button
-                onClick={() => setCollapsed(true)}
-                className="rounded p-1 text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
-                title="Collapse sidebar"
-              >
-                <PanelLeftClose className="h-4 w-4" />
-              </button>
-            </>
-          )}
-        </div>
-
-        {!collapsed && (
-          <div className="border-b border-[var(--color-border)] p-3">
-            <ServerSelector />
-          </div>
+  const SidebarContent = ({ isMobile = false }) => (
+    <>
+      <div className="flex items-center justify-between border-b border-[var(--color-border)] p-4">
+        <h1 className="flex items-center gap-2 text-lg font-bold tracking-tight">
+          <img src="/condor_old.jpeg" alt="Condor" className="h-7 w-7 rounded-full" />
+          {(!collapsed || isMobile) && "Condor"}
+        </h1>
+        {!isMobile && (
+          <button
+            onClick={() => setCollapsed(!collapsed)}
+            className="rounded p-1 text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+          >
+            {collapsed ? <PanelLeftOpen className="h-5 w-5" /> : <PanelLeftClose className="h-4 w-4" />}
+          </button>
         )}
+        {isMobile && (
+          <button
+            onClick={() => setMobileMenuOpen(false)}
+            className="rounded p-1 text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+          >
+            <PanelLeftClose className="h-5 w-5" />
+          </button>
+        )}
+      </div>
 
-        <nav className="flex-1 p-2">
-          {NAV_ITEMS.map(({ to, icon: Icon, label }) => (
-            <NavLink
-              key={to}
-              to={to}
-              end={to === "/"}
-              title={collapsed ? label : undefined}
-              className={({ isActive }) =>
-                `flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors ${
-                  collapsed ? "justify-center" : ""
-                } ${
-                  isActive
-                    ? "bg-[var(--color-primary)]/15 text-[var(--color-primary)]"
-                    : "text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
-                }`
-              }
-            >
-              <Icon className="h-4 w-4 shrink-0" />
-              {!collapsed && label}
-            </NavLink>
-          ))}
-        </nav>
+      {(!collapsed || isMobile) && (
+        <div className="border-b border-[var(--color-border)] p-3">
+          <ServerSelector />
+        </div>
+      )}
 
-        <div className="border-t border-[var(--color-border)] p-3">
-          {collapsed ? (
-            <div className="flex flex-col items-center gap-2">
-              <button
-                onClick={toggleTheme}
-                className="rounded p-1 text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-accent)]"
-                title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
-              >
+      <nav className="flex-1 p-2 overflow-y-auto">
+        {NAV_ITEMS.map(({ to, icon: Icon, label }) => (
+          <NavLink
+            key={to}
+            to={to}
+            end={to === "/"}
+            onClick={() => isMobile && setMobileMenuOpen(false)}
+            title={collapsed && !isMobile ? label : undefined}
+            className={({ isActive }) =>
+              `flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors ${
+                collapsed && !isMobile ? "justify-center" : ""
+              } ${
+                isActive
+                  ? "bg-[var(--color-primary)]/15 text-[var(--color-primary)]"
+                  : "text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+              }`
+            }
+          >
+            <Icon className="h-4 w-4 shrink-0" />
+            {(!collapsed || isMobile) && label}
+          </NavLink>
+        ))}
+      </nav>
+
+      <div className="border-t border-[var(--color-border)] p-3">
+        {collapsed && !isMobile ? (
+          <div className="flex flex-col items-center gap-2">
+            <button onClick={toggleTheme} className="p-1 text-[var(--color-text-muted)] hover:text-[var(--color-accent)]">
+              {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+            </button>
+            <button onClick={logout} className="p-1 text-[var(--color-text-muted)] hover:text-[var(--color-red)]">
+              <LogOut className="h-4 w-4" />
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center justify-between text-sm">
+            <span className="truncate text-[var(--color-text-muted)] font-medium mr-2">
+              {user?.first_name || user?.username || "User"}
+            </span>
+            <div className="flex items-center gap-1">
+              <button onClick={toggleTheme} className="p-1.5 text-[var(--color-text-muted)] hover:text-[var(--color-accent)]">
                 {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
               </button>
-              <button
-                onClick={logout}
-                className="rounded p-1 text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-red)]"
-                title="Logout"
-              >
+              <button onClick={logout} className="p-1.5 text-[var(--color-text-muted)] hover:text-[var(--color-red)]">
                 <LogOut className="h-4 w-4" />
               </button>
             </div>
-          ) : (
-            <div className="flex items-center justify-between text-sm">
-              <span className="truncate text-[var(--color-text-muted)]">
-                {user?.first_name || user?.username || "User"}
-              </span>
-              <div className="flex items-center gap-1">
-                <button
-                  onClick={toggleTheme}
-                  className="rounded p-1 text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-accent)]"
-                  title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
-                >
-                  {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
-                </button>
-                <button
-                  onClick={logout}
-                  className="rounded p-1 text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-red)]"
-                  title="Logout"
-                >
-                  <LogOut className="h-4 w-4" />
-                </button>
-              </div>
-            </div>
-          )}
-        </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+
+  return (
+    <div className="flex h-screen overflow-hidden bg-[var(--color-bg)]">
+      {/* Desktop Sidebar */}
+      <aside
+        className={`hidden md:flex flex-col border-r border-[var(--color-border)] bg-[var(--color-surface)] transition-all duration-200 ${
+          collapsed ? "w-14" : "w-56"
+        }`}
+      >
+        <SidebarContent />
       </aside>
 
-      {/* Main content */}
-      <main className="flex-1 overflow-auto p-6">
-        <ErrorBoundary resetKey={pathname + server}>
-          <Outlet />
-        </ErrorBoundary>
-      </main>
+      {/* Mobile Sidebar Overlay */}
+      {mobileMenuOpen && (
+        <div 
+          className="fixed inset-0 z-50 bg-black/50 md:hidden"
+          onClick={() => setMobileMenuOpen(false)}
+        >
+          <aside 
+            className="flex h-full w-64 flex-col bg-[var(--color-surface)] shadow-xl animate-in slide-in-from-left duration-200"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <SidebarContent isMobile />
+          </aside>
+        </div>
+      )}
+
+      {/* Main content area */}
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {/* Mobile Header */}
+        <header className="flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-surface)] p-3 md:hidden">
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setMobileMenuOpen(true)}
+              className="rounded p-1 text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]"
+            >
+              <PanelLeftOpen className="h-6 w-6" />
+            </button>
+            <span className="font-bold">Condor</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <ServerSelector />
+          </div>
+        </header>
+
+        <main className="flex-1 overflow-auto p-4 md:p-6">
+          <ErrorBoundary resetKey={pathname + server}>
+            <Outlet />
+          </ErrorBoundary>
+        </main>
+      </div>
     </div>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -90,3 +90,14 @@ body {
 ::-webkit-scrollbar-thumb:hover {
   background: var(--color-text-muted);
 }
+
+/* Hide scrollbar for Chrome, Safari and Opera */
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+/* Hide scrollbar for IE, Edge and Firefox */
+.no-scrollbar {
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -1,11 +1,14 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowLeft,
+  Brain,
   Clock,
   FlaskConical,
+  Lightbulb,
+  Save,
   Zap,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { AgentControls } from "@/components/agent/AgentControls";
@@ -18,11 +21,94 @@ import { api } from "@/lib/api";
 
 const TABS = [
   { id: "overview", label: "Overview", icon: Zap },
+  { id: "strategy", label: "Strategy", icon: Brain },
+  { id: "learnings", label: "Learnings", icon: Lightbulb },
   { id: "sessions", label: "Sessions", icon: Clock },
   { id: "experiments", label: "Dry-Run", icon: FlaskConical },
 ] as const;
 
 type TabId = (typeof TABS)[number]["id"];
+
+// ── Strategy Tab (Markdown Editor) ──
+
+function StrategyTab({ slug, content }: { slug: string; content: string }) {
+  const queryClient = useQueryClient();
+  const [value, setValue] = useState(content);
+  const [dirty, setDirty] = useState(false);
+
+  const saveMut = useMutation({
+    mutationFn: () => api.updateAgentMd(slug, value),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agent", slug] });
+      setDirty(false);
+    },
+  });
+
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setValue(e.target.value);
+    setDirty(true);
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-[var(--color-text-muted)]">agent.md</span>
+        <button
+          onClick={() => saveMut.mutate()}
+          disabled={!dirty || saveMut.isPending}
+          className="flex items-center gap-1.5 rounded-lg bg-[var(--color-primary)] px-3 py-1.5 text-xs font-semibold text-white transition-all disabled:opacity-30"
+        >
+          <Save className="h-3.5 w-3.5" />
+          {saveMut.isPending ? "Saving..." : "Save"}
+        </button>
+      </div>
+      <textarea
+        value={value}
+        onChange={handleChange}
+        spellCheck={false}
+        className="min-h-[500px] w-full resize-y rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-4 font-mono text-sm leading-relaxed text-[var(--color-text)] outline-none transition-colors focus:border-[var(--color-primary)]/50"
+      />
+    </div>
+  );
+}
+
+// ── Learnings Tab ──
+
+function LearningsTab({ slug, content }: { slug: string; content: string }) {
+  const queryClient = useQueryClient();
+  const [value, setValue] = useState(content);
+  const [dirty, setDirty] = useState(false);
+
+  const saveMut = useMutation({
+    mutationFn: () => api.updateAgentLearnings(slug, value),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agent", slug] });
+      setDirty(false);
+    },
+  });
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-[var(--color-text-muted)]">learnings.md — persists across sessions</span>
+        <button
+          onClick={() => saveMut.mutate()}
+          disabled={!dirty || saveMut.isPending}
+          className="flex items-center gap-1.5 rounded-lg bg-[var(--color-primary)] px-3 py-1.5 text-xs font-semibold text-white transition-all disabled:opacity-30"
+        >
+          <Save className="h-3.5 w-3.5" />
+          {saveMut.isPending ? "Saving..." : "Save"}
+        </button>
+      </div>
+      <textarea
+        value={value}
+        onChange={(e) => { setValue(e.target.value); setDirty(true); }}
+        spellCheck={false}
+        className="min-h-[400px] w-full resize-y rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-4 font-mono text-sm leading-relaxed text-[var(--color-text)] outline-none transition-colors focus:border-[var(--color-primary)]/50"
+      />
+    </div>
+  );
+}
 
 // ── Main Page ──
 
@@ -55,7 +141,7 @@ export function AgentDetail() {
   const serverName = (agent.config.server_name as string) || "";
 
   return (
-    <div className="w-full">
+    <div className="mx-auto w-full max-w-7xl">
       {/* Header */}
       <div className="mb-6">
         <button
@@ -82,12 +168,12 @@ export function AgentDetail() {
       </div>
 
       {/* Tab bar */}
-      <div className="mb-6 flex gap-1 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-1">
+      <div className="mb-6 flex gap-1 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-1 overflow-x-auto no-scrollbar">
         {TABS.map(({ id, label, icon: Icon }) => (
           <button
             key={id}
             onClick={() => setActiveTab(id)}
-            className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-all ${
+            className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-all whitespace-nowrap ${
               activeTab === id
                 ? "bg-[var(--color-primary)]/15 text-[var(--color-primary)]"
                 : "text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
@@ -101,6 +187,8 @@ export function AgentDetail() {
 
       {/* Tab content */}
       {activeTab === "overview" && <OverviewTab agent={agent} />}
+      {activeTab === "strategy" && <StrategyTab slug={slug!} content={agent.agent_md} />}
+      {activeTab === "learnings" && <LearningsTab slug={slug!} content={agent.learnings} />}
       {activeTab === "sessions" && (
         <SessionsTab
           slug={slug!}

--- a/frontend/src/pages/Bots.tsx
+++ b/frontend/src/pages/Bots.tsx
@@ -1,9 +1,15 @@
-import { Archive, Bot, FlaskConical, Loader2, TerminalSquare } from "lucide-react";
+import { Archive, Bot, Code2, FileText, FlaskConical, Loader2 } from "lucide-react";
 import { lazy, Suspense, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 
 const ActiveBotsTab = lazy(() =>
   import("@/pages/tabs/ActiveBotsTab").then((m) => ({ default: m.ActiveBotsTab })),
+);
+const ControllersTab = lazy(() =>
+  import("@/pages/tabs/ControllersTab").then((m) => ({ default: m.ControllersTab })),
+);
+const ConfigsTab = lazy(() =>
+  import("@/pages/tabs/ConfigsTab").then((m) => ({ default: m.ConfigsTab })),
 );
 const ArchivedBotsTab = lazy(() =>
   import("@/pages/tabs/ArchivedBotsTab").then((m) => ({ default: m.ArchivedBotsTab })),
@@ -11,15 +17,13 @@ const ArchivedBotsTab = lazy(() =>
 const BacktestingTab = lazy(() =>
   import("@/pages/tabs/BacktestingTab").then((m) => ({ default: m.BacktestingTab })),
 );
-const EditorTab = lazy(() =>
-  import("@/pages/tabs/EditorTab").then((m) => ({ default: m.EditorTab })),
-);
 
 const TABS = [
   { key: "active", label: "Active", icon: Bot },
+  { key: "controllers", label: "Controllers", icon: Code2 },
+  { key: "configs", label: "Configs", icon: FileText },
   { key: "archived", label: "Archived", icon: Archive },
   { key: "backtest", label: "Backtest", icon: FlaskConical },
-  { key: "editor", label: "Editor", icon: TerminalSquare },
 ] as const;
 
 type TabKey = (typeof TABS)[number]["key"];
@@ -35,6 +39,7 @@ function FallbackSpinner() {
 export function Bots() {
   const [searchParams, setSearchParams] = useSearchParams();
   const currentTab = (searchParams.get("tab") as TabKey) || "active";
+  // Track which tabs have been visited so we keep them mounted
   const visitedRef = useRef<Set<TabKey>>(new Set([currentTab]));
   visitedRef.current.add(currentTab);
 
@@ -49,12 +54,12 @@ export function Bots() {
   return (
     <div className="space-y-6">
       {/* Tab bar */}
-      <div className="flex items-center gap-1 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-1 w-fit">
+      <div className="flex items-center gap-1 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-1 w-full md:w-fit overflow-x-auto no-scrollbar">
         {TABS.map(({ key, label, icon: Icon }) => (
           <button
             key={key}
             onClick={() => setTab(key)}
-            className={`flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+            className={`flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors whitespace-nowrap ${
               currentTab === key
                 ? "bg-[var(--color-bg)] text-[var(--color-text)] shadow-sm"
                 : "text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
@@ -73,6 +78,16 @@ export function Bots() {
             <ActiveBotsTab />
           </div>
         )}
+        {visitedRef.current.has("controllers") && (
+          <div style={{ display: currentTab === "controllers" ? undefined : "none" }}>
+            <ControllersTab />
+          </div>
+        )}
+        {visitedRef.current.has("configs") && (
+          <div style={{ display: currentTab === "configs" ? undefined : "none" }}>
+            <ConfigsTab />
+          </div>
+        )}
         {visitedRef.current.has("archived") && (
           <div style={{ display: currentTab === "archived" ? undefined : "none" }}>
             <ArchivedBotsTab />
@@ -81,11 +96,6 @@ export function Bots() {
         {visitedRef.current.has("backtest") && (
           <div style={{ display: currentTab === "backtest" ? undefined : "none" }}>
             <BacktestingTab />
-          </div>
-        )}
-        {visitedRef.current.has("editor") && (
-          <div style={{ display: currentTab === "editor" ? undefined : "none" }}>
-            <EditorTab />
           </div>
         )}
       </Suspense>

--- a/frontend/src/pages/CreateExecutor.tsx
+++ b/frontend/src/pages/CreateExecutor.tsx
@@ -4,21 +4,17 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import {
   ArrowLeft,
   ArrowUpDown,
-  BarChart3,
   CheckCircle,
   Grid3X3,
   Layers,
   Loader2,
   Rocket,
-  Settings2,
   TrendingUp,
 } from "lucide-react";
 
 import { ExchangeSelector } from "@/components/market/ExchangeSelector";
 import { PairSelector, useTradingRules } from "@/components/market/PairSelector";
 import { PriceTicker } from "@/components/market/PriceTicker";
-import { TradingRulesInfo } from "@/components/market/TradingRulesInfo";
-import { MarketDepthPanel } from "@/components/market/MarketDepthPanel";
 import { GridChart } from "@/components/grid/GridChart";
 import { GridConfigPanel, useGridValidation } from "@/components/grid/GridConfigPanel";
 import { PositionConfigPanel, usePositionConfig } from "@/components/executor/PositionConfigPanel";
@@ -201,7 +197,6 @@ export function CreateExecutor() {
   const isSpot = isSpotConnector(connector);
 
   const [successId, setSuccessId] = useState<string | null>(null);
-  const [rightPanel, setRightPanel] = useState<"config" | "depth">("config");
 
   const { data: connectors = [] } = useQuery({
     queryKey: ["connected-exchanges", server],
@@ -209,12 +204,9 @@ export function CreateExecutor() {
     enabled: !!server,
   });
 
-  // WS for executor data (candle streams are managed by candleStore)
-  const wsChannels = useMemo(
-    () => server ? [`executors:${server}`] : [],
-    [server],
-  );
-  useCondorWebSocket(wsChannels, server);
+  // WS subscription for executor data
+  const execChannels = useMemo(() => server ? [`executors:${server}`] : [], [server]);
+  useCondorWebSocket(execChannels, server);
 
   // Main controller data (executors + positions filtered by connector/pair)
   const { executors: mainExecutors, overlays: mainOverlays, positions: mainPositions, isLoadingPositions } =
@@ -279,11 +271,6 @@ export function CreateExecutor() {
     if (inc >= 1) return 0;
     return Math.max(0, Math.ceil(-Math.log10(inc)));
   }, [rulesData, pair]);
-
-  const selectedRule = useMemo(
-    () => rulesData?.rules?.find((r) => r.trading_pair === pair),
-    [rulesData, pair],
-  );
 
   // ── Active config derived values ──
   const activeValidation = useMemo(() => {
@@ -404,47 +391,49 @@ export function CreateExecutor() {
   }
 
   return (
-    <div className="-m-6 flex h-[calc(100%+3rem)] flex-col">
+    <div className="-m-4 md:-m-6 flex h-[calc(100%+2rem)] md:h-[calc(100%+3rem)] flex-col">
       {/* Top Bar */}
-      <div className="flex items-center border-b border-[var(--color-border)] bg-[var(--color-surface)]">
-        {/* Back button */}
-        <button
-          onClick={() => navigate(-1)}
-          className="flex items-center gap-1 border-r border-[var(--color-border)] px-3 py-2.5 text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]"
-        >
-          <ArrowLeft className="h-3.5 w-3.5" />
-        </button>
+      <div className="flex flex-col md:flex-row md:items-center border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+        <div className="flex items-center border-b md:border-b-0 md:border-r border-[var(--color-border)]">
+          {/* Back button */}
+          <button
+            onClick={() => navigate(-1)}
+            className="flex items-center gap-1 border-r border-[var(--color-border)] px-3 py-2.5 text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+          </button>
 
-        {/* Pair + Exchange */}
-        <div className="flex items-center border-r border-[var(--color-border)]">
-          <PairSelector
-            server={server}
-            connector={connector}
-            value={pair}
-            onChange={(v) => gridDispatch({ type: "SET_PAIR", value: v })}
-          />
-          <div className="relative border-l border-[var(--color-border)]">
-            <ExchangeSelector
-              connectors={connectors}
-              value={connector}
-              onChange={(v) => gridDispatch({ type: "SET_CONNECTOR", value: v })}
+          {/* Pair + Exchange */}
+          <div className="flex items-center flex-1">
+            <PairSelector
+              server={server}
+              connector={connector}
+              value={pair}
+              onChange={(v) => gridDispatch({ type: "SET_PAIR", value: v })}
             />
+            <div className="relative border-l border-[var(--color-border)]">
+              <ExchangeSelector
+                connectors={connectors}
+                value={connector}
+                onChange={(v) => gridDispatch({ type: "SET_CONNECTOR", value: v })}
+              />
+            </div>
           </div>
         </div>
 
         {/* Price ticker */}
-        <div className="flex flex-1 items-center px-4 py-2">
+        <div className="flex items-center px-4 py-2 border-b md:border-b-0 md:border-r border-[var(--color-border)]">
           <PriceTicker server={server} connector={connector} pair={pair} />
         </div>
 
         {/* Interval + Range */}
-        <div className="flex items-center gap-3 border-l border-[var(--color-border)] px-4 py-2">
-          <div className="flex overflow-hidden rounded-md border border-[var(--color-border)]">
+        <div className="flex items-center gap-3 px-4 py-2 overflow-x-auto no-scrollbar flex-nowrap shrink-0">
+          <div className="flex shrink-0 overflow-hidden rounded-md border border-[var(--color-border)] flex-nowrap">
             {INTERVALS.map((iv) => (
               <button
                 key={iv}
                 onClick={() => gridDispatch({ type: "SET_FIELD", field: "interval", value: iv })}
-                className={`px-2.5 py-1 text-xs ${
+                className={`px-2 md:px-2.5 py-1 text-[10px] md:text-xs whitespace-nowrap ${
                   gridState.interval === iv
                     ? "bg-[var(--color-primary)] text-white"
                     : "bg-[var(--color-bg)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]"
@@ -455,14 +444,14 @@ export function CreateExecutor() {
             ))}
           </div>
 
-          <div className="flex items-center gap-1.5">
-            <span className="text-[10px] text-[var(--color-text-muted)]">Range:</span>
-            <div className="flex overflow-hidden rounded-md border border-[var(--color-border)]">
+          <div className="flex shrink-0 items-center gap-1.5 flex-nowrap">
+            <span className="text-[10px] text-[var(--color-text-muted)] whitespace-nowrap">Range:</span>
+            <div className="flex overflow-hidden rounded-md border border-[var(--color-border)] flex-nowrap">
               {LOOKBACK_OPTIONS.map((opt) => (
                 <button
                   key={opt.label}
                   onClick={() => gridDispatch({ type: "SET_FIELD", field: "lookbackSeconds", value: opt.seconds })}
-                  className={`px-2 py-1 text-xs ${
+                  className={`px-1.5 md:px-2 py-1 text-[10px] md:text-xs whitespace-nowrap ${
                     gridState.lookbackSeconds === opt.seconds
                       ? "bg-[var(--color-primary)] text-white"
                       : "bg-[var(--color-bg)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]"
@@ -477,18 +466,17 @@ export function CreateExecutor() {
       </div>
 
       {/* Main Area: Chart + Right Panel */}
-      <div className="flex min-h-0 flex-1">
+      <div className="flex min-h-0 flex-1 flex-col md:flex-row overflow-y-auto md:overflow-hidden">
         {/* Chart + Bottom Pane */}
-        <div className="min-w-0 flex-1 flex flex-col border-r border-[var(--color-border)]">
-          <div className="flex-1 min-h-0 overflow-hidden bg-[var(--color-surface)]">
+        <div className="min-w-0 flex-1 flex flex-col border-b md:border-b-0 md:border-r border-[var(--color-border)]">
+          <div className="h-[350px] md:flex-1 min-h-0 overflow-hidden bg-[var(--color-surface)] shrink-0">
             <GridChart
-              key={`${connector}:${pair}:${gridState.interval}`}
+              key={`${connector}:${pair}:${gridState.interval}:${gridState.lookbackSeconds}`}
               server={server}
               connector={connector}
               pair={pair}
               interval={gridState.interval}
               lookbackSeconds={gridState.lookbackSeconds}
-
               startPrice={chartProps.startPrice}
               endPrice={chartProps.endPrice}
               limitPrice={chartProps.limitPrice}
@@ -502,104 +490,73 @@ export function CreateExecutor() {
               positions={mainPositions}
             />
           </div>
-          <TradingRulesInfo rule={selectedRule} />
-          <TradeBottomPane
-            executors={mainExecutors}
-            positions={mainPositions}
-            isLoadingPositions={isLoadingPositions}
-          />
+          <div className="hidden md:block">
+            <TradeBottomPane
+              executors={mainExecutors}
+              positions={mainPositions}
+              isLoadingPositions={isLoadingPositions}
+            />
+          </div>
         </div>
 
         {/* Right Panel */}
-        <div className="flex w-72 shrink-0 flex-col bg-[var(--color-surface)] xl:w-80">
-          {/* Panel Mode Toggle */}
-          <div className="flex border-b border-[var(--color-border)]">
-            <button
-              onClick={() => setRightPanel("config")}
-              className={`flex flex-1 items-center justify-center gap-1.5 px-2 py-2 text-[11px] font-medium transition-colors ${
-                rightPanel === "config"
-                  ? "border-b-2 border-[var(--color-primary)] text-[var(--color-primary)]"
-                  : "text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
-              }`}
-            >
-              <Settings2 className="h-3.5 w-3.5" />
-              Execute
-            </button>
-            <button
-              onClick={() => setRightPanel("depth")}
-              className={`flex flex-1 items-center justify-center gap-1.5 px-2 py-2 text-[11px] font-medium transition-colors ${
-                rightPanel === "depth"
-                  ? "border-b-2 border-[var(--color-primary)] text-[var(--color-primary)]"
-                  : "text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
-              }`}
-            >
-              <BarChart3 className="h-3.5 w-3.5" />
-              Data
-            </button>
+        <div className="flex w-full md:w-72 shrink-0 flex-col bg-[var(--color-surface)] xl:w-80">
+          {/* Type Tabs */}
+          <div className="border-b border-[var(--color-border)] shrink-0">
+            <div className="flex overflow-x-auto no-scrollbar">
+              {TYPE_TABS.map((tab) => (
+                <button
+                  key={tab.value}
+                  onClick={() => handleTypeChange(tab.value)}
+                  className={`flex flex-1 items-center justify-center gap-1.5 px-2 py-2.5 text-[11px] font-medium transition-colors whitespace-nowrap ${
+                    executorType === tab.value
+                      ? "border-b-2 border-[var(--color-primary)] text-[var(--color-primary)]"
+                      : "text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+                  }`}
+                >
+                  {tab.icon}
+                  {tab.label}
+                </button>
+              ))}
+            </div>
           </div>
 
-          {rightPanel === "config" ? (
-            <>
-              {/* Type Tabs */}
-              <div className="border-b border-[var(--color-border)]">
-                <div className="flex">
-                  {TYPE_TABS.map((tab) => (
-                    <button
-                      key={tab.value}
-                      onClick={() => handleTypeChange(tab.value)}
-                      className={`flex flex-1 items-center justify-center gap-1.5 px-2 py-2.5 text-[11px] font-medium transition-colors ${
-                        executorType === tab.value
-                          ? "border-b-2 border-[var(--color-primary)] text-[var(--color-primary)]"
-                          : "text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
-                      }`}
-                    >
-                      {tab.icon}
-                      {tab.label}
-                    </button>
-                  ))}
-                </div>
-              </div>
+          {/* Config Panel */}
+          <div className="flex-1 overflow-y-auto">
+            {executorType === "grid" && (
+              <GridConfigPanel state={gridState} dispatch={gridDispatch} currentPrice={currentPrice} isSpot={isSpot} />
+            )}
+            {executorType === "position" && (
+              <PositionConfigPanel state={positionConfig.state} dispatch={positionConfig.dispatch} currentPrice={currentPrice} isSpot={isSpot} pair={pair} />
+            )}
+            {executorType === "order" && (
+              <OrderConfigPanel state={orderConfig.state} dispatch={orderConfig.dispatch} currentPrice={currentPrice} isSpot={isSpot} pair={pair} />
+            )}
+            {executorType === "dca" && (
+              <DCAConfigPanel state={dcaConfig.state} dispatch={dcaConfig.dispatch} currentPrice={currentPrice} isSpot={isSpot} pair={pair} />
+            )}
+          </div>
 
-              {/* Config Panel */}
-              <div className="flex-1 overflow-y-auto">
-                {executorType === "grid" && (
-                  <GridConfigPanel state={gridState} dispatch={gridDispatch} currentPrice={currentPrice} isSpot={isSpot} />
-                )}
-                {executorType === "position" && (
-                  <PositionConfigPanel state={positionConfig.state} dispatch={positionConfig.dispatch} currentPrice={currentPrice} isSpot={isSpot} pair={pair} />
-                )}
-                {executorType === "order" && (
-                  <OrderConfigPanel state={orderConfig.state} dispatch={orderConfig.dispatch} currentPrice={currentPrice} isSpot={isSpot} pair={pair} />
-                )}
-                {executorType === "dca" && (
-                  <DCAConfigPanel state={dcaConfig.state} dispatch={dcaConfig.dispatch} currentPrice={currentPrice} isSpot={isSpot} pair={pair} />
-                )}
-              </div>
-
-              {/* Sticky Create Footer */}
-              <div className="border-t border-[var(--color-border)] p-3">
-                {!activeValidation.valid && (
-                  <p className="mb-2 text-[11px] text-[var(--color-red)]">
-                    {activeValidation.errors[0]}
-                  </p>
-                )}
-                <button
-                  onClick={() => createMutation.mutate()}
-                  disabled={!activeValidation.valid || createMutation.isPending}
-                  className="flex w-full items-center justify-center gap-2 rounded-lg bg-[var(--color-primary)] px-4 py-2.5 text-sm font-bold text-white transition-colors hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  {createMutation.isPending ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Rocket className="h-4 w-4" />
-                  )}
-                  Create {TYPE_LABELS[executorType]}
-                </button>
-              </div>
-            </>
-          ) : (
-            <MarketDepthPanel server={server} connector={connector} pair={pair} />
-          )}
+          {/* Sticky Create Footer */}
+          <div className="border-t border-[var(--color-border)] p-3">
+            {!activeValidation.valid && (
+              <p className="mb-2 text-[11px] text-[var(--color-red)]">
+                {activeValidation.errors[0]}
+              </p>
+            )}
+            <button
+              onClick={() => createMutation.mutate()}
+              disabled={!activeValidation.valid || createMutation.isPending}
+              className="flex w-full items-center justify-center gap-2 rounded-lg bg-[var(--color-primary)] px-4 py-2.5 text-sm font-bold text-white transition-colors hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {createMutation.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Rocket className="h-4 w-4" />
+              )}
+              Create {TYPE_LABELS[executorType]}
+            </button>
+          </div>
         </div>
       </div>
 

--- a/frontend/src/pages/Executors.tsx
+++ b/frontend/src/pages/Executors.tsx
@@ -575,11 +575,11 @@ export function DetailPanel({
 
   return (
       <div
-        className="h-full bg-[var(--color-bg)] border-l border-[var(--color-border)] overflow-y-auto shadow-xl shrink-0 relative"
-        style={{ width: panelWidth }}
+        className="fixed inset-y-0 right-0 z-50 flex h-full flex-col bg-[var(--color-bg)] border-l border-[var(--color-border)] shadow-xl transition-all duration-300 md:relative md:shadow-none md:shrink-0"
+        style={{ width: window.innerWidth < 768 ? "100%" : panelWidth }}
       >
         <div
-          className="absolute top-0 left-0 w-1.5 h-full cursor-col-resize hover:bg-[var(--color-primary)]/30 transition-colors z-10"
+          className="absolute top-0 left-0 hidden w-1.5 h-full cursor-col-resize hover:bg-[var(--color-primary)]/30 transition-colors z-10 md:block"
           onMouseDown={onMouseDown}
         />
 
@@ -1226,9 +1226,9 @@ export function Executors() {
     return <p className="text-[var(--color-text-muted)]">Select a server</p>;
 
   return (
-    <div className="flex gap-0 -m-6 h-[calc(100vh)] overflow-hidden">
+    <div className="flex gap-0 -m-4 md:-m-6 h-[calc(100vh)] overflow-hidden">
       {/* Main content */}
-      <div className={`flex-1 overflow-auto p-6 transition-all duration-200 ${selectedExecutor ? "min-w-0" : ""}`}>
+      <div className={`flex-1 overflow-auto p-4 md:p-6 transition-all duration-200 ${selectedExecutor ? "min-w-0" : ""}`}>
       <div className="space-y-5">
       {/* Header */}
       <div className="flex items-center justify-between flex-wrap gap-3">
@@ -1240,7 +1240,8 @@ export function Executors() {
             className="flex items-center gap-1.5 rounded-md bg-[var(--color-primary)] px-3 py-1.5 text-xs font-medium text-white transition-colors hover:brightness-110"
           >
             <Plus className="h-3.5 w-3.5" />
-            New Executor
+            <span className="hidden sm:inline">New Executor</span>
+            <span className="sm:hidden">New</span>
           </button>
           {/* Export all */}
           <button
@@ -1255,16 +1256,18 @@ export function Executors() {
 
       {/* Filters */}
       <div className="flex gap-2 flex-wrap items-center">
-        <Filter className="h-4 w-4 text-[var(--color-text-muted)]" />
-        <input
-          type="text"
-          placeholder="Filter pair..."
-          value={filters.trading_pair}
-          onChange={(e) =>
-            setFilters((f) => ({ ...f, trading_pair: e.target.value }))
-          }
-          className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm transition-colors hover:border-[var(--color-primary)]/50 focus:border-[var(--color-primary)] focus:outline-none"
-        />
+        <Filter className="h-4 w-4 text-[var(--color-text-muted)] shrink-0" />
+        <div className="flex-1 min-w-[140px] md:flex-none">
+          <input
+            type="text"
+            placeholder="Filter pair..."
+            value={filters.trading_pair}
+            onChange={(e) =>
+              setFilters((f) => ({ ...f, trading_pair: e.target.value }))
+            }
+            className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm transition-colors hover:border-[var(--color-primary)]/50 focus:border-[var(--color-primary)] focus:outline-none"
+          />
+        </div>
         <MultiSelect
           options={executorTypes}
           selected={filters.executor_types}
@@ -1277,27 +1280,30 @@ export function Executors() {
           onChange={(v) => setFilters((f) => ({ ...f, controller_ids: v }))}
           placeholder="All controllers"
         />
-        <span className="text-xs text-[var(--color-text-muted)] tabular-nums">
-          {executors.length} loaded
-          {isFetchingNextPage && " · loading…"}
-          {!hasNextPage && !isFetchingNextPage && executors.length > 0 && " · done"}
-          {reachedCap && " · cap reached"}
-        </span>
-        {reachedCap && (
+        <div className="flex items-center gap-2 w-full sm:w-auto">
+          <span className="text-xs text-[var(--color-text-muted)] tabular-nums whitespace-nowrap">
+            {executors.length} loaded
+            {isFetchingNextPage && " · loading…"}
+            {!hasNextPage && !isFetchingNextPage && executors.length > 0 && " · done"}
+            {reachedCap && " · cap reached"}
+          </span>
+          <div className="flex-1" />
+          {reachedCap && (
+            <button
+              onClick={() => setMaxPages((p) => p + 40)}
+              className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-xs font-medium hover:bg-[var(--color-surface-hover)] transition-colors"
+            >
+              Load more
+            </button>
+          )}
           <button
-            onClick={() => setMaxPages((p) => p + 40)}
+            onClick={() => refetch()}
             className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-xs font-medium hover:bg-[var(--color-surface-hover)] transition-colors"
+            title="Refresh"
           >
-            Load more
+            Refresh
           </button>
-        )}
-        <button
-          onClick={() => refetch()}
-          className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-xs font-medium hover:bg-[var(--color-surface-hover)] transition-colors"
-          title="Refresh"
-        >
-          Refresh
-        </button>
+        </div>
       </div>
 
       {isLoading ? (

--- a/frontend/src/pages/MarketData.tsx
+++ b/frontend/src/pages/MarketData.tsx
@@ -1,0 +1,514 @@
+import { useQuery, useQueryClient, keepPreviousData } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { ExchangeSelector } from "@/components/market/ExchangeSelector";
+import { OrderBook } from "@/components/market/OrderBook";
+import { RecentTrades } from "@/components/market/RecentTrades";
+import { PairSelector, useTradingRules } from "@/components/market/PairSelector";
+import { PriceTicker } from "@/components/market/PriceTicker";
+import { TradingRulesInfo } from "@/components/market/TradingRulesInfo";
+import { useServer } from "@/hooks/useServer";
+import { useTheme } from "@/hooks/useTheme";
+import { useCondorWebSocket } from "@/hooks/useWebSocket";
+import { api, type CandleData } from "@/lib/api";
+import { createCondorDatafeed } from "@/lib/tradingview-datafeed";
+
+// Map our interval strings to TradingView resolution format
+const INTERVAL_TO_RESOLUTION: Record<string, string> = {
+  "1m": "1",
+  "5m": "5",
+  "15m": "15",
+  "1h": "60",
+  "4h": "240",
+  "1d": "1D",
+};
+
+const INTERVALS = ["1m", "5m", "15m", "1h", "4h", "1d"];
+
+// Lookback options: label -> seconds
+const LOOKBACK_OPTIONS: { label: string; seconds: number }[] = [
+  { label: "1h", seconds: 3600 },
+  { label: "6h", seconds: 6 * 3600 },
+  { label: "1d", seconds: 86400 },
+  { label: "3d", seconds: 3 * 86400 },
+  { label: "7d", seconds: 7 * 86400 },
+  { label: "14d", seconds: 14 * 86400 },
+  { label: "30d", seconds: 30 * 86400 },
+];
+
+// ─── TradingView Chart ──────────────────────────────────────────
+
+function getChartColors() {
+  const style = getComputedStyle(document.documentElement);
+  return {
+    bg: style.getPropertyValue("--chart-bg").trim() || "#0f1525",
+    grid: style.getPropertyValue("--chart-grid").trim() || "#1c2541",
+    text: style.getPropertyValue("--chart-text").trim() || "#6b7994",
+    up: style.getPropertyValue("--chart-up").trim() || "#22c55e",
+    down: style.getPropertyValue("--chart-down").trim() || "#ef4444",
+    accent: style.getPropertyValue("--color-accent").trim() || "#d4a845",
+  };
+}
+
+function TradingViewChart({
+  server,
+  connector,
+  pair,
+  interval,
+}: {
+  server: string;
+  connector: string;
+  pair: string;
+  interval: string;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const widgetRef = useRef<TradingViewWidget | null>(null);
+  const readyRef = useRef(false);
+  const { theme } = useTheme();
+
+  const channel = `candles:${server}:${connector}:${pair}:${interval}`;
+  const channels = useMemo(() => [channel], [channel]);
+  const { wsRef } = useCondorWebSocket(channels, server);
+
+  useEffect(() => {
+    if (!containerRef.current || !window.TradingView) return;
+
+    const colors = getChartColors();
+    const datafeed = createCondorDatafeed(server, connector, wsRef);
+    const resolution = INTERVAL_TO_RESOLUTION[interval] || "1";
+
+    const widget = new window.TradingView.widget({
+      container: containerRef.current,
+      datafeed,
+      symbol: pair,
+      interval: resolution,
+      library_path: "/charting_library/",
+      locale: "en",
+      fullscreen: false,
+      autosize: true,
+      theme: theme === "dark" ? "Dark" : "Light",
+      timezone: "Etc/UTC",
+      toolbar_bg: colors.bg,
+      loading_screen: {
+        backgroundColor: colors.bg,
+        foregroundColor: colors.accent,
+      },
+      overrides: {
+        "paneProperties.background": colors.bg,
+        "paneProperties.backgroundType": "solid",
+        "paneProperties.vertGridProperties.color": colors.grid,
+        "paneProperties.horzGridProperties.color": colors.grid,
+        "scalesProperties.textColor": colors.text,
+        "mainSeriesProperties.candleStyle.upColor": colors.up,
+        "mainSeriesProperties.candleStyle.downColor": colors.down,
+        "mainSeriesProperties.candleStyle.wickUpColor": colors.up,
+        "mainSeriesProperties.candleStyle.wickDownColor": colors.down,
+        "mainSeriesProperties.candleStyle.borderUpColor": colors.up,
+        "mainSeriesProperties.candleStyle.borderDownColor": colors.down,
+      },
+      disabled_features: ["header_symbol_search", "header_compare"],
+      enabled_features: ["study_templates", "drawing_templates"],
+      auto_save_delay: 5,
+    });
+
+    widgetRef.current = widget;
+    readyRef.current = false;
+
+    widget.onChartReady(() => {
+      readyRef.current = true;
+    });
+
+    return () => {
+      readyRef.current = false;
+      widgetRef.current = null;
+      widget.remove();
+    };
+  }, [server, connector, theme]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (!widgetRef.current || !readyRef.current) return;
+    widgetRef.current.activeChart().setSymbol(pair);
+  }, [pair]);
+
+  useEffect(() => {
+    if (!widgetRef.current || !readyRef.current) return;
+    const resolution = INTERVAL_TO_RESOLUTION[interval] || "1";
+    widgetRef.current.activeChart().setResolution(resolution);
+  }, [interval]);
+
+  return <div ref={containerRef} className="h-full w-full" />;
+}
+
+// ─── Fallback Chart (lightweight-charts) ────────────────────────
+
+function FallbackChart({
+  server,
+  connector,
+  pair,
+  interval,
+  lookbackSeconds,
+}: {
+  server: string;
+  connector: string;
+  pair: string;
+  interval: string;
+  lookbackSeconds: number;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const chartModuleRef = useRef<typeof import("lightweight-charts") | null>(
+    null,
+  );
+  const chartRef = useRef<import("lightweight-charts").IChartApi | null>(null);
+  const seriesRef =
+    useRef<import("lightweight-charts").ISeriesApi<"Candlestick"> | null>(null);
+  const initializedRef = useRef(false);
+
+  const channel = `candles:${server}:${connector}:${pair}:${interval}`;
+  const channels = useMemo(() => [channel], [channel]);
+  const { wsRef, wsVersion } = useCondorWebSocket(channels, server);
+
+  // Send duration to backend so it sizes its candle buffer appropriately
+  useEffect(() => {
+    const ws = wsRef.current;
+    if (!ws) return;
+    ws.setCandleDuration(channel, lookbackSeconds);
+  }, [lookbackSeconds, channel]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const startTime = useMemo(
+    () => Math.floor(Date.now() / 1000) - lookbackSeconds,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [lookbackSeconds, pair, interval],
+  );
+
+  const queryClient = useQueryClient();
+
+  // Invalidate candle cache when lookbackSeconds changes so we refetch with new startTime
+  useEffect(() => {
+    queryClient.invalidateQueries({ queryKey: ["candles", server, connector, pair, interval] });
+  }, [lookbackSeconds]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const { data: candles } = useQuery({
+    queryKey: ["candles", server, connector, pair, interval],
+    queryFn: () =>
+      api.getCandles(server, connector, pair, interval, 5000, startTime),
+    placeholderData: keepPreviousData,
+  });
+
+  const candleStatusKey = ["candles-status", server, connector, pair, interval];
+
+  const { data: candleStatus } = useQuery<{
+    status: string;
+    message?: string;
+  }>({
+    queryKey: candleStatusKey,
+    enabled: false,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    import("lightweight-charts").then((mod) => {
+      if (cancelled || !containerRef.current) return;
+      chartModuleRef.current = mod;
+
+      const colors = getChartColors();
+      const chart = mod.createChart(containerRef.current, {
+        autoSize: true,
+        layout: {
+          background: { type: mod.ColorType.Solid, color: colors.bg },
+          textColor: colors.text,
+        },
+        grid: {
+          vertLines: { color: colors.grid },
+          horzLines: { color: colors.grid },
+        },
+        timeScale: { timeVisible: true, secondsVisible: false },
+      });
+      chartRef.current = chart;
+
+      const series = chart.addSeries(mod.CandlestickSeries, {
+        upColor: colors.up,
+        downColor: colors.down,
+        wickUpColor: colors.up,
+        wickDownColor: colors.down,
+        borderVisible: false,
+      });
+      seriesRef.current = series;
+    });
+    return () => {
+      cancelled = true;
+      if (chartRef.current) {
+        chartRef.current.remove();
+        chartRef.current = null;
+        seriesRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const currentWs = wsRef.current;
+    if (!currentWs) return;
+
+    const removeHandler = currentWs.onMessage((msgChannel, data) => {
+      if (msgChannel !== channel || !seriesRef.current) return;
+
+      const payload = data as {
+        type: string;
+        candle?: CandleData;
+        data?: CandleData[];
+      };
+
+      if (payload.type === "candle_update" && payload.candle) {
+        const c = payload.candle;
+        const ts = c.timestamp > 1e12 ? c.timestamp / 1000 : c.timestamp;
+        seriesRef.current.update({
+          time: ts as import("lightweight-charts").UTCTimestamp,
+          open: c.open,
+          high: c.high,
+          low: c.low,
+          close: c.close,
+        });
+      } else if (payload.type === "candles" && payload.data?.length) {
+        const c = payload.data[payload.data.length - 1];
+        const ts = c.timestamp > 1e12 ? c.timestamp / 1000 : c.timestamp;
+        seriesRef.current.update({
+          time: ts as import("lightweight-charts").UTCTimestamp,
+          open: c.open,
+          high: c.high,
+          low: c.low,
+          close: c.close,
+        });
+      }
+    });
+
+    return removeHandler;
+  }, [channel, wsVersion]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (!seriesRef.current || !candles?.length || !chartModuleRef.current)
+      return;
+
+    const mapped = candles.map((c) => {
+      const ts = c.timestamp > 1e12 ? c.timestamp / 1000 : c.timestamp;
+      return {
+        time: ts as import("lightweight-charts").UTCTimestamp,
+        open: c.open,
+        high: c.high,
+        low: c.low,
+        close: c.close,
+      };
+    });
+    seriesRef.current.setData(mapped);
+    if (!initializedRef.current) {
+      chartRef.current?.timeScale().fitContent();
+      initializedRef.current = true;
+    }
+  }, [candles]);
+
+  useEffect(() => {
+    initializedRef.current = false;
+  }, [pair, interval, lookbackSeconds]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-1.5">
+        <p className="text-[10px] text-[var(--color-text-muted)]">
+          Live Market Data
+        </p>
+        {candleStatus?.status === "error" && (
+          <button
+            onClick={() => queryClient.removeQueries({ queryKey: candleStatusKey })}
+            className="flex items-center gap-1 rounded bg-red-500/20 px-2 py-0.5 text-xs text-red-400 hover:bg-red-500/30"
+            title="Click to dismiss"
+          >
+            {candleStatus.message ?? "Stream error"}
+            <span className="ml-1 text-[10px] opacity-60">✕</span>
+          </button>
+        )}
+        {candleStatus?.status === "connected" && (
+          <span className="rounded bg-green-500/20 px-2 py-0.5 text-xs text-green-400">
+            Live
+          </span>
+        )}
+      </div>
+      <div ref={containerRef} className="flex-1" />
+    </div>
+  );
+}
+
+// ─── Main Page ──────────────────────────────────────────────────
+
+export function MarketData() {
+  const { server } = useServer();
+  const [connector, setConnector] = useState("binance");
+  const [pair, setPair] = useState("BTC-USDT");
+  const [interval, setInterval] = useState("1m");
+  const [lookbackSeconds, setLookbackSeconds] = useState(3 * 86400); // 3 days default
+  const [tvAvailable, setTvAvailable] = useState(false);
+  const [tvChecked, setTvChecked] = useState(false);
+
+  useEffect(() => {
+    if (window.TradingView) {
+      setTvAvailable(true);
+      setTvChecked(true);
+      return;
+    }
+    const timer = setTimeout(() => {
+      setTvAvailable(!!window.TradingView);
+      setTvChecked(true);
+    }, 1000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const { data: connectors } = useQuery({
+    queryKey: ["connectors", server],
+    queryFn: () => api.getConnectors(server!),
+    enabled: !!server,
+  });
+
+  // Trading rules for the selected connector (shared with PairSelector)
+  const rulesData = useTradingRules(server ?? "", connector);
+  const selectedRule = useMemo(
+    () => rulesData?.rules?.find((r) => r.trading_pair === pair),
+    [rulesData, pair],
+  );
+
+  useEffect(() => {
+    if (connectors?.length && !connectors.includes(connector)) {
+      setConnector(connectors[0]);
+    }
+  }, [connectors, connector]);
+
+  // Reset pair to first available when connector changes
+  useEffect(() => {
+    if (rulesData?.rules?.length) {
+      const pairs = rulesData.rules.map((r) => r.trading_pair);
+      if (!pairs.includes(pair)) {
+        // Default to BTC-USDT if available, otherwise first pair
+        const defaultPair = pairs.find((p) => p === "BTC-USDT") ?? pairs[0];
+        setPair(defaultPair);
+      }
+    }
+  }, [rulesData, connector]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!server)
+    return (
+      <p className="p-6 text-[var(--color-text-muted)]">Select a server</p>
+    );
+
+  return (
+    <div className="flex h-full flex-col -m-4 md:-m-0">
+      {/* ── Top Bar: Exchange-style header ── */}
+      <div className="flex flex-col md:flex-row md:items-center border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+        {/* Left: Pair selector + Exchange selector */}
+        <div className="flex items-center border-b md:border-b-0 md:border-r border-[var(--color-border)]">
+          <PairSelector
+            server={server}
+            connector={connector}
+            value={pair}
+            onChange={setPair}
+          />
+
+          {/* Exchange dropdown styled as a subtle badge */}
+          <div className="relative border-l border-[var(--color-border)]">
+            <ExchangeSelector
+              connectors={connectors ?? []}
+              value={connector}
+              onChange={setConnector}
+            />
+          </div>
+        </div>
+
+        {/* Center: Price ticker stats */}
+        <div className="flex items-center px-4 py-2 border-b md:border-b-0 md:border-r border-[var(--color-border)]">
+          <PriceTicker server={server} connector={connector} pair={pair} />
+        </div>
+
+        {/* Right: Interval + Range (lightweight fallback only) */}
+        {!tvAvailable && tvChecked && (
+          <div className="flex items-center gap-3 px-4 py-2 overflow-x-auto no-scrollbar flex-nowrap shrink-0 border-l border-[var(--color-border)]">
+            <div className="flex shrink-0 overflow-hidden rounded-md border border-[var(--color-border)] flex-nowrap">
+              {INTERVALS.map((iv) => (
+                <button
+                  key={iv}
+                  onClick={() => setInterval(iv)}
+                  className={`px-2 md:px-2.5 py-1 text-[10px] md:text-xs whitespace-nowrap ${
+                    interval === iv
+                      ? "bg-[var(--color-primary)] text-white"
+                      : "bg-[var(--color-bg)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]"
+                  }`}
+                >
+                  {iv}
+                </button>
+              ))}
+            </div>
+
+            <div className="flex shrink-0 items-center gap-1.5 flex-nowrap">
+              <span className="text-[10px] text-[var(--color-text-muted)] whitespace-nowrap">Range:</span>
+              <div className="flex overflow-hidden rounded-md border border-[var(--color-border)] flex-nowrap">
+                {LOOKBACK_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.label}
+                    onClick={() => setLookbackSeconds(opt.seconds)}
+                    className={`px-1.5 md:px-2 py-1 text-[10px] md:text-xs whitespace-nowrap ${
+                      lookbackSeconds === opt.seconds
+                        ? "bg-[var(--color-primary)] text-white"
+                        : "bg-[var(--color-bg)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]"
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* ── Main Area: Chart + Order Book ── */}
+      <div className="flex min-h-0 flex-1 flex-col md:flex-row overflow-y-auto md:overflow-hidden">
+        {/* Chart */}
+        <div className="min-w-0 flex-1 border-b md:border-b-0 md:border-r border-[var(--color-border)]">
+          <div className="h-[400px] md:h-full overflow-hidden rounded-none border-0 bg-[var(--color-surface)] shrink-0">
+            {tvAvailable ? (
+              <TradingViewChart
+                key={`${server}:${connector}`}
+                server={server}
+                connector={connector}
+                pair={pair}
+                interval={interval}
+              />
+            ) : tvChecked ? (
+              <FallbackChart
+                key={`${connector}:${pair}:${interval}`}
+                server={server}
+                connector={connector}
+                pair={pair}
+                interval={interval}
+                lookbackSeconds={lookbackSeconds}
+              />
+            ) : (
+              <div className="flex h-full items-center justify-center text-[var(--color-text-muted)]">
+                Loading chart...
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Order Book + Recent Trades */}
+        <div className="flex w-full md:w-72 shrink-0 flex-col bg-[var(--color-surface)] xl:w-80">
+          <div className="h-[400px] md:flex-[3] overflow-hidden">
+            <OrderBook server={server} connector={connector} pair={pair} />
+          </div>
+          <div className="h-[300px] md:flex-[2] overflow-hidden border-t border-[var(--color-border)]">
+            <RecentTrades server={server} connector={connector} pair={pair} />
+          </div>
+        </div>
+      </div>
+
+      {/* ── Bottom Bar: Trading Rules ── */}
+      <div className="hidden md:block">
+        <TradingRulesInfo rule={selectedRule} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -130,15 +130,15 @@ function TokenBarChart({
           const barPct = maxVal > 0 ? (t.usd_value / maxVal) * 100 : 0;
           const allocPct = totalPortfolioValue > 0 ? (t.usd_value / totalPortfolioValue) * 100 : 0;
           return (
-            <div key={`${t.connector}-${t.token}`} className="flex items-center gap-3">
-              <div className="flex items-center gap-1.5 w-20 justify-end">
+            <div key={`${t.connector}-${t.token}`} className="flex items-center gap-2 md:gap-3">
+              <div className="flex items-center gap-1.5 w-16 md:w-20 justify-end shrink-0">
                 <div
                   className="h-2.5 w-2.5 rounded-sm shrink-0"
                   style={{ backgroundColor: CHART_COLORS[i % CHART_COLORS.length] }}
                 />
-                <span className="text-xs font-medium truncate">{t.token}</span>
+                <span className="text-[10px] md:text-xs font-medium truncate">{t.token}</span>
               </div>
-              <div className="flex-1 h-5 rounded bg-[var(--color-bg)] overflow-hidden relative">
+              <div className="flex-1 h-4 md:h-5 rounded bg-[var(--color-bg)] overflow-hidden relative">
                 <div
                   className="h-full rounded transition-all duration-500"
                   style={{
@@ -148,7 +148,7 @@ function TokenBarChart({
                   }}
                 />
               </div>
-              <span className="text-xs tabular-nums text-[var(--color-text-muted)] w-32 text-right">
+              <span className="text-[10px] md:text-xs tabular-nums text-[var(--color-text-muted)] w-24 md:w-32 text-right shrink-0">
                 {formatUsd(t.usd_value)} ({allocPct.toFixed(1)}%)
               </span>
             </div>
@@ -765,8 +765,8 @@ export function Portfolio() {
           <p>No balances found</p>
         </div>
       ) : (
-        <div className="overflow-hidden rounded-lg border border-[var(--color-border)]">
-          <table className="w-full text-sm">
+        <div className="overflow-x-auto rounded-lg border border-[var(--color-border)]">
+          <table className="w-full text-sm min-w-[600px] md:min-w-0">
             <thead>
               <tr className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
                 <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">

--- a/frontend/src/pages/Routines.tsx
+++ b/frontend/src/pages/Routines.tsx
@@ -170,9 +170,9 @@ export function Routines() {
         </button>
       </div>
 
-      <div className="flex gap-4" style={{ minHeight: "calc(100vh - 160px)" }}>
+      <div className="flex flex-col md:flex-row gap-4" style={{ minHeight: "calc(100vh - 160px)" }}>
         {/* ── Left: Catalog ── */}
-        <div className="w-72 shrink-0 space-y-2">
+        <div className={`w-full md:w-72 shrink-0 space-y-2 ${selected ? "hidden md:block" : "block"}`}>
           {loadingRoutines ? (
             <div className="flex justify-center py-8">
               <Loader2 className="h-5 w-5 animate-spin text-[var(--color-text-muted)]" />
@@ -225,13 +225,21 @@ export function Routines() {
         </div>
 
         {/* ── Right: Detail ── */}
-        <div className="flex-1 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-5">
+        <div className={`flex-1 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-4 md:p-5 ${!selected ? "hidden md:block" : "block"}`}>
           {!selectedRoutine ? (
             <div className="flex h-full items-center justify-center text-sm text-[var(--color-text-muted)]">
               Select a routine from the catalog
             </div>
           ) : (
             <div className="space-y-5">
+              {/* Mobile Back Button */}
+              <button
+                onClick={() => setSelected(null)}
+                className="flex items-center gap-2 text-xs font-medium text-[var(--color-primary)] md:hidden mb-2"
+              >
+                <RefreshCw className="h-3 w-3 rotate-180" /> Back to Catalog
+              </button>
+
               {/* Title */}
               <div>
                 <h2 className="text-lg font-semibold text-[var(--color-text)]">
@@ -295,7 +303,7 @@ export function Routines() {
 
               {/* Result display — persists because activeInstanceId stays set */}
               {activeInstance && activeInstance.status !== "running" && (activeInstance.result_text || activeInstance.has_result) && (
-                <div>
+                <div className="overflow-x-auto">
                   <h3 className="mb-2 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
                     Last Result
                   </h3>
@@ -313,11 +321,11 @@ export function Routines() {
                     {selectedInstances.map((inst) => (
                       <div
                         key={inst.instance_id}
-                        className="flex items-center justify-between rounded-md border border-[var(--color-border)] bg-[var(--color-surface-hover)]/50 px-3 py-2"
+                        className="flex flex-col sm:flex-row sm:items-center justify-between rounded-md border border-[var(--color-border)] bg-[var(--color-surface-hover)]/50 px-3 py-2 gap-2"
                       >
-                        <div className="flex items-center gap-3">
+                        <div className="flex flex-wrap items-center gap-2 sm:gap-3">
                           <code className="text-xs font-mono text-[var(--color-primary)]">
-                            #{inst.instance_id}
+                            #{inst.instance_id.slice(0, 8)}
                           </code>
                           <span
                             className={`rounded px-1.5 py-0.5 text-[10px] font-bold uppercase ${
@@ -333,27 +341,29 @@ export function Routines() {
                           {inst.schedule?.type === "interval" && (
                             <span className="flex items-center gap-1 text-[10px] text-[var(--color-text-muted)]">
                               <Clock className="h-3 w-3" />
-                              every {(inst.schedule.interval_sec as number)}s
+                              {(inst.schedule.interval_sec as number)}s
                             </span>
                           )}
                           <span className="text-[10px] text-[var(--color-text-muted)]">
-                            #{inst.run_count} runs · {formatAgo(inst.last_run_at)}
+                            {inst.run_count} runs · {formatAgo(inst.last_run_at)}
                           </span>
+                        </div>
+                        <div className="flex items-center justify-end gap-3">
                           {inst.last_duration != null && (
                             <span className="text-[10px] text-[var(--color-text-muted)]">
                               {formatDuration(inst.last_duration)}
                             </span>
                           )}
+                          <button
+                            type="button"
+                            onClick={() => stopMutation.mutate(inst.instance_id)}
+                            disabled={stopMutation.isPending}
+                            className="rounded p-1 text-[var(--color-red)] hover:bg-[var(--color-red)]/10"
+                            title="Stop"
+                          >
+                            <Square className="h-3.5 w-3.5" />
+                          </button>
                         </div>
-                        <button
-                          type="button"
-                          onClick={() => stopMutation.mutate(inst.instance_id)}
-                          disabled={stopMutation.isPending}
-                          className="rounded p-1 text-[var(--color-red)] hover:bg-[var(--color-red)]/10"
-                          title="Stop"
-                        >
-                          <Square className="h-3.5 w-3.5" />
-                        </button>
                       </div>
                     ))}
                   </div>


### PR DESCRIPTION
Introduce a new MarketData page with TradingView integration and a lightweight-charts fallback, WebSocket candle handling, candle lookback controls and trading-view datafeed support. Refactor the app shell to add a responsive sidebar (desktop + mobile overlay), server selector placement, collapsed state, mobile header/menu and a no-scrollbar utility in CSS. Enhance AgentDetail with Strategy and Learnings tabs (markdown editors + save mutations), make the tab bar scrollable and constrain page width. Update Bots to add Controllers and Configs tabs (lazy-loaded) and preserve visited tabs; make tab bar scrollable. Revamp CreateExecutor layout for responsive behaviour, tweak WebSocket channel usage, unify chart keys, move execution config into type tabs, simplify footer create button, and adjust TradeBottomPane visibility. Make Executors detail panel responsive (full width on mobile), refine header/filters layout and add a refresh/load-more UI tweak. Various UI/ux improvements and small icon/route updates (Market nav item and icon swap).