### PR TITLE
fix(acp): use npx for Gemini and Copilot CLI commands

### DIFF
--- a/condor/acp/client.py
+++ b/condor/acp/client.py
@@ -20,8 +20,8 @@ log = logging.getLogger(__name__)
 
 ACP_COMMANDS: dict[str, str] = {
     "claude-code": "claude-agent-acp",
-    "gemini": "gemini --experimental-acp",
-    "copilot": "copilot --acp",
+    "gemini": "npx @google/gemini-cli --acp",
+    "copilot": "npx @github/copilot --acp --stdio",
     "codex": "npx @zed-industries/codex-acp"
 }
 


### PR DESCRIPTION
## Summary
- Use `npx` to invoke Gemini CLI and GitHub Copilot CLI instead of relying on direct binaries in PATH
- This ensures the commands work regardless of how Node.js is installed (nvm, system, etc.)
- Fixes deprecated `--experimental-acp` flag for Gemini (now `--acp`)

## Changes
| Agent | Before | After |
|-------|--------|-------|
| gemini | `gemini --experimental-acp` | `npx @google/gemini-cli --acp` |
| copilot | `copilot --acp` | `npx @github/copilot --acp --stdio` |

## Test plan
- [ ] Test Gemini agent in Telegram bot
- [ ] Test Copilot agent in Telegram bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)