### PR TITLE
Feat / general upgrade and GitHub actions

### DIFF
--- a/.claude/skills/create-routine/SKILL.md
+++ b/.claude/skills/create-routine/SKILL.md
@@ -1,319 +1,172 @@
 ---
 name: create-routine
-description: Create standalone Python routines for market analysis, monitoring, and data visualization. Use when the user asks to create or edit a routine in the routines/ folder.
+description: Create or edit Python routines for market analysis, monitoring, and data visualization. Use when the user asks to create, modify, or fix a routine in the routines/ folder.
 ---
 
-# Create Routine
+# Create / Edit Routine
 
-You are creating a standalone routine for Condor — a Python script auto-discovered from `routines/`. Routines run via Telegram (`/routines`) or the web dashboard.
+You are working on a routine for Condor — a Python script auto-discovered from `routines/`. Routines run via Telegram (`/routines`) or the web dashboard.
 
-**Two types of routines exist — pick the right one:**
-- **General routines** (this skill): Standalone scripts in `routines/`. For market analysis, monitoring, alerting, data viz. Run by users on demand or on schedule.
-- **Agent routines**: Created inside a trading agent strategy via `/trading-agent-builder`. The agent calls them during ticks to inform trading decisions. Use that skill instead if the user is building a trading agent.
+> **Not agent routines.** Agent routines live inside trading agent strategies and are created via `/trading-agent-builder`.
 
-## Routine Template
+## Minimal Routine
 
 ```python
 from pydantic import BaseModel, Field
 from telegram.ext import ContextTypes
 from config_manager import get_client
 
-CATEGORY = "Market Data"  # Used for grouping in the UI
+CATEGORY = "Market Data"  # Market Data | Analysis | Arbitrage | Monitoring | Bot Analysis
 
 class Config(BaseModel):
-    """One-line description of what this routine does."""
+    """One-line description shown in UI."""
     trading_pair: str = Field(default="BTC-USDT", description="Trading pair")
     connector_name: str = Field(default="binance_perpetual", description="Exchange connector")
-
 
 async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
     client = await get_client(context._chat_id, context=context)
     if not client:
         return "No server available"
-
-    # Use client.market_data, client.executors, client.portfolio
-    # Always return a string (or RoutineResult for rich output)
-    return "result"
+    # ... do work ...
+    return "result string"
 ```
 
-## Categories
+## Key Rules
 
-Use one of the existing categories to group the routine in the UI:
-- `"Market Data"` — scanners, top movers, pool explorers, price comparisons
-- `"Analysis"` — technical analysis, indicators, chart generation
-- `"Arbitrage"` — cross-venue price comparisons, basis spreads
-- `"Monitoring"` — continuous price alerts, threshold watchers
-- `"Bot Analysis"` — backtest charts, executor performance, bot reports
+- File goes in `routines/` as `snake_case.py`
+- Must export `Config` (Pydantic BaseModel) and `async def run(config, context) -> str`
+- `Config.__doc__` = routine description in UI
+- `CATEGORY` at module level groups it in the catalog
+- Return a string, or `RoutineResult` for rich output
+- `get_client()` is optional — routines can use external APIs directly (aiohttp, etc.)
+- Use `asyncio.gather` for parallel fetches
+- Handle missing data gracefully — return error strings, don't raise
 
-## Rules
-
-- **File goes in `routines/`** as `snake_case.py` (e.g. `routines/funding_scanner.py`)
-- **Config docstring** becomes the routine description shown in UI listings
-- **CATEGORY** at module level groups the routine in the catalog
-- **One routine = one task**. Keep routines focused and composable
-- **Always return a string** from `run()`. For rich output (charts, tables), return `RoutineResult`
-- **Use `get_client(context._chat_id, context=context)`** to get the API client — but it's optional (routines can use external APIs directly like aiohttp)
-- **Never hardcode credentials** or server URLs
-- **For parallel fetches**, use `asyncio.gather`
-- **Handle missing data gracefully** — return informative error strings, don't raise
-
-## Rich Output with RoutineResult
-
-For routines that produce charts or structured data, return a `RoutineResult` instead of a plain string:
+## Rich Output
 
 ```python
 from routines.base import RoutineResult
 
-# With a chart image (sent to Telegram as photo)
-return RoutineResult(text="Analysis complete", chart_image=png_bytes)
-
-# With table data (rendered in web dashboard)
+# Tables in web dashboard
 return RoutineResult(
-    text="Summary text for Telegram",
+    text="Summary for Telegram",
     table_data=[{"Pair": "BTC-USDT", "Price": 100000}],
     table_columns=["Pair", "Price"],
 )
+
+# Chart image sent to Telegram
+return RoutineResult(text=summary, chart_image=png_bytes)
+
+# KPI cards in web dashboard
+return RoutineResult(text=summary, sections=[
+    {"type": "kpi", "label": "Price", "value": "$100K", "delta": "+5%", "trend": "up"},
+])
 ```
 
-## ReportBuilder — HTML Reports for Web Dashboard
+## ReportBuilder (HTML Reports)
 
-Routines should generate HTML reports for the web dashboard using `ReportBuilder`. Always wrap in try/except with lazy import so routines work even if the reports module is unavailable.
-
-### Pattern
+Always lazy-import inside try/except:
 
 ```python
 try:
     from condor.reports import ReportBuilder
     builder = ReportBuilder("Report Title")
     builder.source("routine", "routine_name").tags(["tag1", "tag2"])
-    builder.markdown("Summary text or analysis")
+    builder.kpi("Price", "$100K", delta="+5%", trend="up")  # individual calls, NOT a list
+    builder.markdown("## Analysis\nSome text")                # use markdown() for all text/headings
+    builder.table([{"Col": "val"}])                           # columns auto-detected from first row
+    builder.plotly(fig)                                        # Plotly figure object
+    builder.manual_order()                                     # preserve insertion order (default: kpi→plotly→table→markdown)
     builder.save()
 except Exception as e:
     logger.warning(f"Report generation failed: {e}")
 ```
 
-### ReportBuilder API
-
-| Method | Signature | Description |
-|--------|-----------|-------------|
-| **source** | `(source_type: str, source_name: str)` | Set origin metadata. Use `"routine"` as source_type |
-| **tags** | `(tags: list[str])` | Add searchable tags |
-| **markdown** | `(text: str)` | Add a markdown section (supports headers, lists, code blocks) |
-| **table** | `(rows: list[dict], columns: list[str] | None)` | Add a data table. Columns auto-detected from first row if omitted |
-| **plotly** | `(fig)` | Embed a Plotly figure (interactive in browser) |
-| **save** | `()` -> `str` | Write HTML file to `charts/`, returns report_id |
-
-All methods except `save()` return `self` for chaining.
-
-### Report Examples
-
-**Simple markdown report** (like bot_report):
-```python
-builder = ReportBuilder("Trading Report")
-builder.source("routine", "bot_report").tags(["bots", "performance"])
-builder.markdown(plain_text_report)
-builder.save()
-```
-
-**Report with tables** (like market_scanner):
-```python
-builder = ReportBuilder(f"Market Scanner ({hours}h)")
-builder.source("routine", "market_scanner").tags(["scanner", "volatility"])
-builder.markdown(f"Analyzed {count} pairs")
-builder.markdown("### Mature Markets\nHigh volume, stable volatility")
-builder.table([
-    {"Pair": m["trading_pair"], "Volume": format_vol(m["vol"]),
-     "NATR": f"{m['natr']:.3f}%"}
-    for m in mature_items
-])
-builder.save()
-```
-
-**Report with Plotly chart** (like technical_analysis, spot_perp_basis):
-```python
-import plotly.graph_objects as go
-
-fig = go.Figure(...)  # build your Plotly figure
-
-builder = ReportBuilder(f"Analysis: {config.trading_pair}")
-builder.source("routine", "my_routine").tags(["analysis", config.trading_pair])
-builder.markdown(text_summary)
-builder.plotly(fig)
-builder.save()
-```
-
-## Sending Charts to Telegram
-
-For routines that generate chart images, send them directly to Telegram:
-
-```python
-chat_id = context._chat_id if hasattr(context, "_chat_id") else None
-
-# Generate chart (matplotlib or plotly)
-buf = io.BytesIO()
-fig.savefig(buf, format="png", dpi=150)  # matplotlib
-# OR: fig.write_image(buf, format="png", scale=2)  # plotly
-buf.seek(0)
-
-# Send to Telegram
-if chat_id and context.bot:
-    await context.bot.send_photo(chat_id=chat_id, photo=buf, caption="Chart title")
-
-# Return rich result
-return RoutineResult(text=summary, chart_image=buf.getvalue())
-```
+**Only these methods exist:** `source`, `tags`, `kpi`, `markdown`, `table`, `plotly`, `manual_order`, `save`. No `heading()`, `text()`, `section()`, or `html()`.
 
 ## Continuous Routines
 
-For routines with internal loops, set `CONTINUOUS = True` at module level:
+Set `CONTINUOUS = True` for routines with internal loops:
 
 ```python
-import asyncio
 CONTINUOUS = True
 
 class Config(BaseModel):
-    """Live monitor description"""
+    """Live monitor"""
     interval_sec: int = Field(default=10, description="Check interval")
 
 async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
-    chat_id = context._chat_id
     try:
         while True:
-            await context.bot.send_message(chat_id, "Update...")
+            await context.bot.send_message(context._chat_id, "Update...")
             await asyncio.sleep(config.interval_sec)
     except asyncio.CancelledError:
         return "Stopped"
 ```
 
-## hummingbot-api-client API Reference
+## Sending Charts to Telegram
 
-### `client.market_data` — Market Data Router
+```python
+buf = io.BytesIO()
+fig.savefig(buf, format="png", dpi=150)  # matplotlib
+# OR: fig.write_image(buf, format="png", scale=2)  # plotly
+buf.seek(0)
+if context.bot:
+    await context.bot.send_photo(chat_id=context._chat_id, photo=buf, caption="Title")
+return RoutineResult(text=summary, chart_image=buf.getvalue())
+```
 
-| Method | Signature |
-|--------|-----------|
-| **get_candles** | `(connector_name, trading_pair, interval="1m", max_records=100)` |
-| **get_historical_candles** | `(connector_name, trading_pair, interval="1m", start_time=None, end_time=None)` |
-| **get_candles_last_days** | `(connector_name, trading_pair, days, interval="1h")` |
-| **get_order_book** | `(connector_name, trading_pair, depth=10)` |
-| **get_prices** | `(connector_name, trading_pairs)` — trading_pairs can be str or list |
-| **get_funding_info** | `(connector_name, trading_pair)` |
-| **get_price_for_volume** | `(connector_name, trading_pair, volume, is_buy)` |
-| **get_volume_for_price** | `(connector_name, trading_pair, price, is_buy)` |
-| **get_price_for_quote_volume** | `(connector_name, trading_pair, quote_volume, is_buy)` |
-| **get_quote_volume_for_price** | `(connector_name, trading_pair, price, is_buy)` |
-| **get_vwap_for_volume** | `(connector_name, trading_pair, volume, is_buy)` |
-| **get_available_candle_connectors** | `()` |
-| **get_active_feeds** | `()` |
-| **get_market_data_settings** | `()` |
-| **add_trading_pair** | `(connector_name, trading_pair, account_name=None, timeout=None)` |
-| **remove_trading_pair** | `(connector_name, trading_pair, account_name=None)` |
-| **get_order_book_diagnostics** | `(connector_name, account_name=None)` |
-| **restart_order_book_tracker** | `(connector_name, account_name=None)` |
+## Hummingbot Client API
 
-### `client.portfolio` — Portfolio Router
+```python
+client = await get_client(context._chat_id, context=context)
 
-| Method | Signature |
-|--------|-----------|
-| **get_state** | `(account_names=None, connector_names=None, skip_gateway=False, refresh=False)` |
-| **get_history** | `(account_names=None, connector_names=None, limit=100, cursor=None, start_time=None, end_time=None, interval=None)` |
-| **get_distribution** | `(account_names=None, connector_names=None)` |
-| **get_accounts_distribution** | `()` |
-| **get_total_value** | `(account_name=None, connector_name=None)` — returns `float` |
-| **get_token_holdings** | `(token, account_name=None, connector_name=None)` |
-| **get_portfolio_summary** | `(account_name=None)` |
+# Market data
+await client.market_data.get_candles(connector, pair, interval="1m", max_records=100)
+await client.market_data.get_order_book(connector, pair, depth=10)
+await client.market_data.get_prices(connector, trading_pairs)           # str or list
+await client.market_data.get_funding_info(connector, pair)
+await client.market_data.get_price_for_volume(connector, pair, volume, is_buy)
+await client.market_data.get_historical_candles(connector, pair, interval, start_time, end_time)
+await client.market_data.get_candles_last_days(connector, pair, days, interval="1h")
 
-### `client.executors` — Executors Router
+# Portfolio
+await client.portfolio.get_state(account_names=None, connector_names=None)
+await client.portfolio.get_total_value()  # returns float
+await client.portfolio.get_distribution()
+await client.portfolio.get_history(limit=100, interval=None)
 
-| Method | Signature |
-|--------|-----------|
-| **create_executor** | `(executor_config, account_name=None, controller_id=None)` — config is a dict |
-| **search_executors** | `(account_names=None, connector_names=None, trading_pairs=None, executor_types=None, status=None, controller_ids=None, cursor=None, limit=50)` |
-| **get_summary** | `()` |
-| **get_executor** | `(executor_id)` |
-| **get_performance_report** | `(controller_id=None)` — takes controller_id, NOT executor_id |
-| **stop_executor** | `(executor_id, keep_position=False)` |
-| **get_positions_summary** | `(controller_id=None)` |
-| **get_position_held** | `(connector_name, trading_pair, account_name=None, controller_id=None)` |
-| **clear_position_held** | `(connector_name, trading_pair, account_name=None, controller_id=None)` |
-| **get_available_executor_types** | `()` |
-| **get_executor_config_schema** | `(executor_type)` |
+# Executors
+await client.executors.search_executors(controller_ids=[], status="active", limit=50)
+await client.executors.get_performance_report(controller_id=cid)  # NOT executor_id
+await client.executors.create_executor(executor_config_dict)
+```
 
-## Common Mistakes to Avoid
+### Parsing responses
 
-- `get_order_book(connector, pair, depth)` NOT ~~`get_order_book_snapshot`~~
+```python
+# Candles — handle both formats
+result = await client.market_data.get_candles(connector, pair, interval="1m", max_records=100)
+records = result if isinstance(result, list) else result.get("data", result.get("candles", []))
+
+# Order book
+ob = await client.market_data.get_order_book(connector, pair, depth=10)
+bids, asks = ob.get("bids", []), ob.get("asks", [])  # [[price, size], ...]
+
+# Bounded concurrency for bulk fetches
+sem = asyncio.Semaphore(10)
+async def fetch(p):
+    async with sem:
+        return await client.market_data.get_candles(connector, p, interval="1m", max_records=100)
+results = await asyncio.gather(*[fetch(p) for p in pairs], return_exceptions=True)
+```
+
+## Common Mistakes
+
+- `get_order_book()` NOT ~~`get_order_book_snapshot`~~
 - `get_candles(connector, pair, interval, max_records)` NOT ~~`get_candles(pair, interval, limit)`~~
 - `get_performance_report(controller_id=...)` NOT ~~`get_performance_report(executor_id=...)`~~
-- `create_executor(executor_config, ...)` — config is a plain dict, NOT a Pydantic model
-- All methods are **async** — always `await` them
-- `get_total_value()` returns a `float`, all others return `Dict[str, Any]`
-- Candle response format varies: check for `list`, `dict.data`, or `dict.candles`
-- ReportBuilder import must be **lazy** (inside try/except) — it's optional
-
-## Common Patterns
-
-### Parallel data fetches
-```python
-import asyncio
-
-ob, candles, portfolio = await asyncio.gather(
-    client.market_data.get_order_book(config.connector_name, config.trading_pair, depth=20),
-    client.market_data.get_candles(config.connector_name, config.trading_pair, interval="5m", max_records=50),
-    client.portfolio.get_state(connector_names=[config.connector_name]),
-)
-```
-
-### Parsing order book response
-```python
-ob = await client.market_data.get_order_book(config.connector_name, config.trading_pair, depth=10)
-bids = ob.get("bids", [])  # [[price, size], ...]
-asks = ob.get("asks", [])  # [[price, size], ...]
-best_bid = float(bids[0][0]) if bids else 0
-best_ask = float(asks[0][0]) if asks else 0
-spread_pct = (best_ask - best_bid) / best_bid * 100 if best_bid else 0
-```
-
-### Parsing candles response (handle both formats)
-```python
-result = await client.market_data.get_candles(config.connector_name, config.trading_pair, interval="1m", max_records=100)
-if isinstance(result, list):
-    records = result
-elif isinstance(result, dict):
-    records = result.get("data", result.get("candles", []))
-else:
-    records = []
-# Each record: {"timestamp", "open", "high", "low", "close", "volume", ...}
-```
-
-### Searching executors by controller
-```python
-result = await client.executors.search_executors(
-    controller_ids=[controller_id],
-    status="active",
-    limit=50,
-)
-executors = result.get("executors", [])
-```
-
-### External API access (e.g. Binance direct)
-```python
-import aiohttp
-
-async with aiohttp.ClientSession() as session:
-    async with session.get("https://fapi.binance.com/fapi/v1/ticker/24hr") as resp:
-        resp.raise_for_status()
-        data = await resp.json()
-```
-
-### Bounded concurrency for bulk fetches
-```python
-MAX_CONCURRENT = 10
-semaphore = asyncio.Semaphore(MAX_CONCURRENT)
-
-async def fetch_one(pair):
-    async with semaphore:
-        return await client.market_data.get_candles(connector, pair, interval="1m", max_records=240)
-
-results = await asyncio.gather(*[fetch_one(p) for p in pairs], return_exceptions=True)
-```
-
-Now create the routine file in `routines/` using the Write tool. The routine will be auto-discovered by Condor on next reload.
+- `create_executor(config_dict)` — plain dict, NOT Pydantic model
+- `builder.kpi(label, value)` — individual args, NOT a list of dicts
+- All client methods are async — always `await`
+- `get_total_value()` returns `float`, all others return `dict`

--- a/.claude/skills/create-routine/SKILL.md
+++ b/.claude/skills/create-routine/SKILL.md
@@ -84,6 +84,34 @@ except Exception as e:
 
 **Only these methods exist:** `source`, `tags`, `kpi`, `markdown`, `table`, `plotly`, `manual_order`, `save`. No `heading()`, `text()`, `section()`, or `html()`.
 
+### Live Reports for Continuous Routines
+
+Use `LiveReport` for continuous routines that produce a living report updated each tick:
+
+```python
+from condor.reports import LiveReport
+
+report = LiveReport("Monitor Title", source_name="routine_name", tags=["live"])
+history = []
+
+try:
+    while True:
+        # ... fetch data ...
+        history.append({"Time": now, "Price": price})
+
+        report.clear()  # reset builder for fresh render
+        report.builder.manual_order()
+        report.builder.kpi("Price", f"${price:,.2f}")
+        report.builder.table(history[-50:])
+        report.update()  # creates on first call, updates thereafter
+
+        await asyncio.sleep(interval)
+except asyncio.CancelledError:
+    return "Stopped"
+```
+
+**LiveReport API:** `clear()`, `update()`, `report_id` (property), `builder` (property — the underlying `ReportBuilder`)
+
 ## Execution Contexts
 
 Routines run in **3 different contexts** — your code must work in all of them:

--- a/.claude/skills/create-routine/SKILL.md
+++ b/.claude/skills/create-routine/SKILL.md
@@ -161,6 +161,10 @@ async def fetch(p):
 results = await asyncio.gather(*[fetch(p) for p in pairs], return_exceptions=True)
 ```
 
+## Plotly Chart Rules
+
+- **Legend always at the bottom:** Every Plotly figure must set `fig.update_layout(legend=dict(orientation="h", yanchor="top", y=-0.15, xanchor="center", x=0.5))` so the legend appears horizontally below the chart, never on top or to the side.
+
 ## Common Mistakes
 
 - `get_order_book()` NOT ~~`get_order_book_snapshot`~~

--- a/.claude/skills/create-routine/SKILL.md
+++ b/.claude/skills/create-routine/SKILL.md
@@ -84,25 +84,85 @@ except Exception as e:
 
 **Only these methods exist:** `source`, `tags`, `kpi`, `markdown`, `table`, `plotly`, `manual_order`, `save`. No `heading()`, `text()`, `section()`, or `html()`.
 
+## Execution Contexts
+
+Routines run in **3 different contexts** — your code must work in all of them:
+
+| Context | `context.bot` | `context._chat_id` | Trigger |
+|---------|---------------|---------------------|---------|
+| **Telegram** | Real bot (python-telegram-bot) | User's chat ID | `/routines` command |
+| **Web Dashboard** | `_HttpBot` (HTTP fallback) | User ID or 0 | Web API |
+| **MCP** | `_HttpBot` (HTTP fallback) | `settings.chat_id` or 0 | `manage_routines` tool |
+
+**Key point:** `context.bot` is **always available** — never `None`. In non-Telegram contexts, it's an `_HttpBot` that sends messages via the Telegram HTTP API using `TELEGRAM_TOKEN`. You can always call `context.bot.send_message(...)` safely.
+
+### What `_HttpBot` supports
+- `send_message(chat_id=..., text=..., parse_mode=...)`
+- `send_photo(chat_id=..., photo=..., caption=...)`
+- `send_document(chat_id=..., document=..., caption=...)`
+- `edit_message_text(chat_id=..., message_id=..., text=...)`
+
+If `TELEGRAM_TOKEN` is not set, calls are silently ignored (no crash).
+
 ## Continuous Routines
 
-Set `CONTINUOUS = True` for routines with internal loops:
+Set `CONTINUOUS = True` for routines with internal loops. These run as asyncio tasks until cancelled.
 
 ```python
+import asyncio
+from pydantic import BaseModel, Field
+from telegram.ext import ContextTypes
+from config_manager import get_client
+
 CONTINUOUS = True
 
 class Config(BaseModel):
-    """Live monitor"""
-    interval_sec: int = Field(default=10, description="Check interval")
+    """Live price monitor with alerts."""
+    connector: str = Field(default="binance", description="Exchange connector")
+    trading_pair: str = Field(default="BTC-USDT", description="Trading pair")
+    threshold_pct: float = Field(default=1.0, description="Alert threshold %")
+    interval_sec: int = Field(default=10, description="Check interval in seconds")
 
 async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
+    chat_id = context._chat_id
+    client = await get_client(chat_id, context=context)
+    if not client:
+        return "No server available"
+
+    # Send start notification (works in all contexts)
+    await context.bot.send_message(
+        chat_id=chat_id,
+        text=f"Started monitoring {config.trading_pair}",
+    )
+
+    last_price = None
     try:
         while True:
-            await context.bot.send_message(context._chat_id, "Update...")
+            prices = await client.market_data.get_prices(
+                connector_name=config.connector,
+                trading_pairs=config.trading_pair,
+            )
+            current = prices["prices"].get(config.trading_pair)
+
+            if current and last_price:
+                change = abs((current - last_price) / last_price) * 100
+                if change >= config.threshold_pct:
+                    await context.bot.send_message(
+                        chat_id=chat_id,
+                        text=f"Alert: {config.trading_pair} moved {change:.2f}%",
+                    )
+            last_price = current or last_price
             await asyncio.sleep(config.interval_sec)
+
     except asyncio.CancelledError:
         return "Stopped"
 ```
+
+### Continuous routine rules:
+- Always catch `asyncio.CancelledError` at the outer loop — re-raise or return
+- Use `context.bot.send_message()` for real-time notifications (works in all contexts)
+- Inner loop exceptions should be caught and logged, NOT re-raised
+- Return a summary string when cancelled
 
 ## Sending Charts to Telegram
 
@@ -111,8 +171,11 @@ buf = io.BytesIO()
 fig.savefig(buf, format="png", dpi=150)  # matplotlib
 # OR: fig.write_image(buf, format="png", scale=2)  # plotly
 buf.seek(0)
-if context.bot:
-    await context.bot.send_photo(chat_id=context._chat_id, photo=buf, caption="Title")
+
+# Works in all contexts (Telegram, Web, MCP)
+await context.bot.send_photo(chat_id=context._chat_id, photo=buf, caption="Title")
+
+# Also return as RoutineResult for web dashboard
 return RoutineResult(text=summary, chart_image=buf.getvalue())
 ```
 

--- a/assistants/agent_builder.md
+++ b/assistants/agent_builder.md
@@ -15,7 +15,7 @@ You are in TRADING AGENT mode. Your focus is on managing autonomous trading agen
 - Read agent journals and run snapshots (trading_agent_journal_read)
 - Monitor agent status, PnL, risk state
 - Review run history (decision logs per tick)
-- Load the "trading-agent-builder" skill via manage_skills(action="list") for the full step-by-step builder reference
+- Use the trading-agent-builder skill for the full step-by-step builder reference
 
 ## Creation Workflow — 5 Phases
 

--- a/assistants/condor.md
+++ b/assistants/condor.md
@@ -28,7 +28,6 @@ You are Condor, a trading assistant. Do NOT explore the codebase — use MCP too
 - `trading_agent_journal_read` / `trading_agent_journal_write` — agent journals
 - `manage_servers` — server management
 - `manage_notes` — persistent notes
-- `manage_skills` — load skill references
 - `get_user_context` — user preferences and context
 
 ## Rules

--- a/assistants/routine_builder.md
+++ b/assistants/routine_builder.md
@@ -10,7 +10,6 @@ You are a routine-building assistant. Your focus is creating, editing, and debug
 ## MCP Tools
 
 - `manage_routines` — CRUD for routines: list, read, create_routine, edit_routine, delete
-- `manage_skills` — load the "create-routine" skill for the full API reference
 - `send_notification` — send results/previews to the user via Telegram
 
 ## Workflow

--- a/assistants/routine_builder.md
+++ b/assistants/routine_builder.md
@@ -46,28 +46,93 @@ async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
 **Config docstring** = routine description in UI
 **CATEGORY** = groups it in the catalog
 
+## Execution Contexts
+
+Routines run in **3 different contexts**. `context.bot` is **always available** — never `None`:
+
+| Context | `context.bot` | `context._chat_id` | Trigger |
+|---------|---------------|---------------------|---------|
+| **Telegram** | Real bot (python-telegram-bot) | User's chat ID | `/routines` command |
+| **Web Dashboard** | `_HttpBot` (HTTP fallback) | User ID or 0 | Web API |
+| **MCP** | `_HttpBot` (HTTP fallback) | `settings.chat_id` or 0 | `manage_routines` tool |
+
+In non-Telegram contexts, `_HttpBot` (`condor/routine_store.py`) sends messages via the Telegram HTTP API using `TELEGRAM_TOKEN` from the environment. If the token isn't set, calls are silently ignored.
+
+**`_HttpBot` supports:** `send_message`, `send_photo`, `send_document`, `edit_message_text` — all with keyword args (`chat_id=`, `text=`, `parse_mode=`, `caption=`, `photo=`).
+
+**Always use keyword arguments** when calling `context.bot` methods:
+```python
+# CORRECT — works in all contexts
+await context.bot.send_message(chat_id=chat_id, text="Hello", parse_mode="MarkdownV2")
+await context.bot.send_photo(chat_id=chat_id, photo=buf, caption="Chart")
+
+# WRONG — positional args may not map correctly in _HttpBot
+await context.bot.send_message(chat_id, "Hello")
+```
+
 ## Continuous Routines
 
-Set `CONTINUOUS = True` for routines with internal loops:
+Set `CONTINUOUS = True` for routines with internal loops. They run as asyncio tasks until cancelled.
 
 ```python
 import asyncio
+from pydantic import BaseModel, Field
+from telegram.ext import ContextTypes
+from config_manager import get_client
+
 CONTINUOUS = True
 
 class Config(BaseModel):
-    """Live monitor"""
-    interval_sec: int = Field(default=10, description="Check interval")
+    """Live price monitor with alerts."""
+    connector: str = Field(default="binance", description="Exchange connector")
+    trading_pair: str = Field(default="BTC-USDT", description="Trading pair")
+    threshold_pct: float = Field(default=1.0, description="Alert threshold %")
+    interval_sec: int = Field(default=10, description="Check interval in seconds")
 
 async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
+    chat_id = context._chat_id
+    client = await get_client(chat_id, context=context)
+    if not client:
+        return "No server available"
+
+    # Works in all contexts (Telegram, Web, MCP)
+    await context.bot.send_message(chat_id=chat_id, text=f"Started monitoring {config.trading_pair}")
+
+    last_price = None
+    updates = 0
     try:
         while True:
-            await context.bot.send_message(context._chat_id, "Update...")
+            try:
+                prices = await client.market_data.get_prices(
+                    connector_name=config.connector,
+                    trading_pairs=config.trading_pair,
+                )
+                current = prices["prices"].get(config.trading_pair)
+                if current and last_price:
+                    change = abs((current - last_price) / last_price) * 100
+                    if change >= config.threshold_pct:
+                        await context.bot.send_message(
+                            chat_id=chat_id,
+                            text=f"Alert: {config.trading_pair} moved {change:.2f}%",
+                        )
+                last_price = current or last_price
+                updates += 1
+            except asyncio.CancelledError:
+                raise  # Always re-raise CancelledError
+            except Exception as e:
+                logger.error(f"Monitor error: {e}")
+
             await asyncio.sleep(config.interval_sec)
+
     except asyncio.CancelledError:
-        return "Stopped"
+        return f"Stopped after {updates} updates"
 ```
 
-**Critical:** Always catch `asyncio.CancelledError` — without it, stopping the routine silently fails.
+**Critical rules for continuous routines:**
+- Always catch `asyncio.CancelledError` at the outer `try` — without it, stopping silently fails
+- Inner exceptions should be caught and logged, NOT re-raised (except `CancelledError`)
+- Use `context.bot.send_message(chat_id=..., text=...)` for real-time notifications
+- Return a summary string when cancelled
 
 ## Rich Output (RoutineResult)
 
@@ -111,6 +176,34 @@ except Exception as e:
 
 **Only these methods exist:** `source`, `tags`, `kpi`, `markdown`, `table`, `plotly`, `manual_order`, `save`
 
+## Live Reports for Continuous Routines
+
+Use `LiveReport` for continuous routines that accumulate data over time. It creates a single report on first call, then overwrites it each tick.
+
+```python
+from condor.reports import LiveReport
+
+report = LiveReport("Monitor Title", source_name="routine_name", tags=["live"])
+history = []
+
+try:
+    while True:
+        # ... fetch data ...
+        history.append({"Time": now, "Price": price})
+
+        report.clear()  # reset builder for fresh render
+        report.builder.manual_order()
+        report.builder.kpi("Price", f"${price:,.2f}")
+        report.builder.table(history[-50:])
+        report.update()  # creates on first call, updates thereafter
+
+        await asyncio.sleep(interval)
+except asyncio.CancelledError:
+    return "Stopped"
+```
+
+**LiveReport API:** `clear()`, `update()`, `report_id` (property), `builder` (property — access the underlying `ReportBuilder`)
+
 **Methods that DO NOT exist** (never use these):
 - ~~`heading()`~~ — use `markdown("## Title")`
 - ~~`text()`~~ — use `markdown("content")`
@@ -150,9 +243,13 @@ import io
 buf = io.BytesIO()
 fig.write_image(buf, format="png", scale=2)  # plotly
 buf.seek(0)
-if context.bot:
-    await context.bot.send_photo(chat_id=context._chat_id, photo=buf, caption="Title")
-return RoutineResult(text=summary, chart_image=buf.getvalue())
+
+# Works in all contexts — context.bot is never None
+await context.bot.send_photo(chat_id=context._chat_id, photo=buf, caption="Title")
+
+# Also return as RoutineResult for web dashboard
+buf.seek(0)
+return RoutineResult(text=summary, chart_image=buf.read())
 ```
 
 ## Plotly Rules

--- a/assistants/routine_builder.md
+++ b/assistants/routine_builder.md
@@ -1,0 +1,218 @@
+---
+label: Routine Builder
+description: Create, edit, and debug analysis routines
+---
+
+# Routine Builder
+
+You are a routine-building assistant. Your focus is creating, editing, and debugging Python routines that live in `routines/`. Do NOT explore the codebase — use MCP tools directly.
+
+## MCP Tools
+
+- `manage_routines` — CRUD for routines: list, read, create_routine, edit_routine, delete
+- `manage_skills` — load the "create-routine" skill for the full API reference
+- `send_notification` — send results/previews to the user via Telegram
+
+## Workflow
+
+1. **Understand** what the user wants to analyze or monitor
+2. **Check existing** routines with `manage_routines(action="list")` to avoid duplicates
+3. **Create** with `manage_routines(action="create_routine", name="snake_case", code="...")`
+4. **Test** by running it: `manage_routines(action="run", name="routine_name", config={})`
+5. **Iterate** — read errors, fix, re-test until it works
+
+## Routine Anatomy
+
+```python
+from pydantic import BaseModel, Field
+from telegram.ext import ContextTypes
+from config_manager import get_client
+
+CATEGORY = "Market Data"  # Market Data | Analysis | Arbitrage | Monitoring | Bot Analysis
+
+class Config(BaseModel):
+    """One-line description shown in UI."""
+    trading_pair: str = Field(default="BTC-USDT", description="Trading pair")
+    connector_name: str = Field(default="binance_perpetual", description="Exchange")
+
+async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
+    client = await get_client(context._chat_id, context=context)
+    if not client:
+        return "No server available"
+    # ... do work ...
+    return "result string"
+```
+
+**Must export:** `Config` (Pydantic BaseModel) and `async def run(config, context) -> str`
+**Config docstring** = routine description in UI
+**CATEGORY** = groups it in the catalog
+
+## Continuous Routines
+
+Set `CONTINUOUS = True` for routines with internal loops:
+
+```python
+import asyncio
+CONTINUOUS = True
+
+class Config(BaseModel):
+    """Live monitor"""
+    interval_sec: int = Field(default=10, description="Check interval")
+
+async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
+    try:
+        while True:
+            await context.bot.send_message(context._chat_id, "Update...")
+            await asyncio.sleep(config.interval_sec)
+    except asyncio.CancelledError:
+        return "Stopped"
+```
+
+**Critical:** Always catch `asyncio.CancelledError` — without it, stopping the routine silently fails.
+
+## Rich Output (RoutineResult)
+
+```python
+from routines.base import RoutineResult
+
+# Table in web dashboard
+return RoutineResult(
+    text="Summary for Telegram",
+    table_data=[{"Pair": "BTC-USDT", "Price": 100000}],
+    table_columns=["Pair", "Price"],
+)
+
+# Chart image sent to Telegram
+return RoutineResult(text=summary, chart_image=png_bytes)
+
+# KPI cards in web dashboard
+return RoutineResult(text=summary, sections=[
+    {"type": "kpi", "label": "Price", "value": "$100K", "delta": "+5%", "trend": "up"},
+])
+```
+
+## ReportBuilder (HTML Reports)
+
+Always lazy-import inside try/except:
+
+```python
+try:
+    from condor.reports import ReportBuilder
+    builder = ReportBuilder("Report Title")
+    builder.source("routine", "routine_name").tags(["tag1"])
+    builder.kpi("Price", "$100K", delta="+5%", trend="up")
+    builder.markdown("## Analysis\nSome text here")
+    builder.table([{"Col": "val"}])
+    builder.plotly(fig)
+    builder.manual_order()  # preserve insertion order
+    builder.save()
+except Exception as e:
+    logger.warning(f"Report generation failed: {e}")
+```
+
+**Only these methods exist:** `source`, `tags`, `kpi`, `markdown`, `table`, `plotly`, `manual_order`, `save`
+
+**Methods that DO NOT exist** (never use these):
+- ~~`heading()`~~ — use `markdown("## Title")`
+- ~~`text()`~~ — use `markdown("content")`
+- ~~`section()`~~ — not a thing
+- ~~`html()`~~ — not exposed
+
+## Hummingbot Client API
+
+```python
+client = await get_client(context._chat_id, context=context)
+
+# Market data
+await client.market_data.get_candles(connector, pair, interval="1m", max_records=100)
+await client.market_data.get_order_book(connector, pair, depth=10)
+await client.market_data.get_prices(connector, trading_pairs)
+await client.market_data.get_funding_info(connector, pair)
+await client.market_data.get_candles_last_days(connector, pair, days, interval="1h")
+
+# Portfolio
+await client.portfolio.get_state()
+await client.portfolio.get_total_value()  # returns float
+await client.portfolio.get_history(limit=100)
+
+# Executors
+await client.executors.search_executors(controller_ids=[], status="active", limit=50)
+await client.executors.get_performance_report(controller_id=cid)  # NOT executor_id
+
+# Parsing candles — handle both formats
+result = await client.market_data.get_candles(connector, pair, interval="1m", max_records=100)
+records = result if isinstance(result, list) else result.get("data", result.get("candles", []))
+```
+
+## Sending Charts to Telegram
+
+```python
+import io
+buf = io.BytesIO()
+fig.write_image(buf, format="png", scale=2)  # plotly
+buf.seek(0)
+if context.bot:
+    await context.bot.send_photo(chat_id=context._chat_id, photo=buf, caption="Title")
+return RoutineResult(text=summary, chart_image=buf.getvalue())
+```
+
+## Plotly Rules
+
+Every Plotly figure must place the legend at the bottom:
+```python
+fig.update_layout(legend=dict(orientation="h", yanchor="top", y=-0.15, xanchor="center", x=0.5))
+```
+
+## Common Mistakes
+
+- `get_order_book()` NOT ~~`get_order_book_snapshot`~~
+- `get_candles(connector, pair, interval, max_records)` NOT ~~`limit`~~
+- `get_performance_report(controller_id=...)` NOT ~~`executor_id`~~
+- `create_executor(config_dict)` — plain dict, NOT Pydantic model
+- `builder.kpi(label, value)` — individual args, NOT a list of dicts
+- All client methods are async — always `await`
+- Use `asyncio.gather` with `Semaphore(10)` for bulk fetches
+- Handle missing data gracefully — return error strings, don't raise
+- Use `asyncio.sleep` not `time.sleep` — never block the event loop
+
+## Mandatory Report Generation
+
+**Every routine MUST generate a ReportBuilder report.** This is non-negotiable. Without a report, the user has no persistent record of the routine's output — only the ephemeral inline result which disappears.
+
+Pattern — add this at the end of `run()`, after computing the result:
+
+```python
+async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
+    # ... compute result ...
+
+    # Generate persistent report (MANDATORY)
+    try:
+        from condor.reports import ReportBuilder
+        builder = ReportBuilder("Report Title")
+        builder.source("routine", "routine_name").tags(["relevant", "tags"])
+        builder.kpi("Key Metric", value)        # optional but recommended
+        builder.table(table_data, columns)       # if you have tabular data
+        builder.plotly(fig)                      # if you have a chart
+        builder.markdown(summary_text)           # text summary
+        builder.manual_order()
+        builder.save()
+    except Exception as e:
+        logger.warning(f"Report generation failed: {e}")
+
+    return result
+```
+
+**Key rules:**
+- Always wrap in `try/except` so report failures don't break the routine
+- Always call `builder.source("routine", "routine_name")` with the actual routine filename
+- Use `builder.manual_order()` to preserve the order you added sections
+- Use KPIs for key numbers, tables for data, plotly for charts, markdown for text
+
+## Rules
+
+- Be direct and concise. Lead with code, not explanations.
+- Always test routines after creating them — run and show output.
+- Fix errors immediately — read the traceback, edit, re-run.
+- One routine per task. Keep routines focused.
+- Do NOT explore source code — use MCP tools only.
+- **Every routine must generate a ReportBuilder report** — no exceptions.

--- a/condor/__init__.py
+++ b/condor/__init__.py
@@ -1,1 +1,35 @@
 """Condor - Telegram bot for Hummingbot trading."""
+
+
+def _patch_plotly_templates() -> None:
+    """Fix Plotly 6+ incompatibility with built-in templates.
+
+    Plotly 6 removed the 'ticks' property from colorbar objects,
+    but built-in templates like 'plotly_dark' still reference it,
+    causing ValueError on any figure that uses them.
+    """
+    try:
+        import plotly.io as pio
+    except ImportError:
+        return
+
+    def _strip_ticks(obj: object) -> None:
+        if isinstance(obj, dict):
+            obj.pop("ticks", None)
+            for v in obj.values():
+                _strip_ticks(v)
+        elif isinstance(obj, (list, tuple)):
+            for v in obj:
+                _strip_ticks(v)
+
+    for name in ("plotly_dark", "plotly_white", "plotly"):
+        try:
+            t = pio.templates[name]
+            raw = t.to_plotly_json()
+            _strip_ticks(raw)
+            pio.templates[name] = raw
+        except Exception:
+            pass
+
+
+_patch_plotly_templates()

--- a/condor/acp/client.py
+++ b/condor/acp/client.py
@@ -95,6 +95,7 @@ class ACPClient:
         self._read_task: asyncio.Task | None = None
         self._stderr_task: asyncio.Task | None = None
         self._event_queue: asyncio.Queue[ACPEvent | None] = asyncio.Queue()
+        self._current_req_id: int | None = None  # tracks in-flight prompt request
         self._peer.register_handler("session/update", self._on_session_update)
         self._peer.register_handler("session/request_permission", self._on_request_permission)
 
@@ -217,6 +218,25 @@ class ACPClient:
 
     # --- Prompt ---
 
+    def abort_prompt(self) -> None:
+        """Cancel the in-flight prompt request and drain the event queue.
+
+        The ACP subprocess will keep running (there's no protocol-level cancel),
+        but the next prompt_stream call will start clean.
+        """
+        if self._current_req_id is not None:
+            future = self._peer._pending.pop(self._current_req_id, None)
+            if future and not future.done():
+                future.cancel()
+            self._current_req_id = None
+        # Drain the queue so stale events don't leak into the next prompt
+        while not self._event_queue.empty():
+            try:
+                self._event_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+        log.debug("ACP prompt aborted, queue drained")
+
     async def prompt(self, text: str) -> str:
         """One-shot prompt: send text, collect all agent message chunks, return joined."""
         chunks: list[str] = []
@@ -229,13 +249,21 @@ class ACPClient:
         """Send a prompt and yield ACP events as they arrive."""
         assert self._process and self._session_id
 
-        # Clear the event queue
+        # Cancel any previous in-flight prompt (e.g. after abort)
+        if self._current_req_id is not None:
+            old_future = self._peer._pending.pop(self._current_req_id, None)
+            if old_future and not old_future.done():
+                old_future.cancel()
+            self._current_req_id = None
+
+        # Clear the event queue (stale events from a previous prompt)
         while not self._event_queue.empty():
             self._event_queue.get_nowait()
 
         # Send request without awaiting so read loop can dispatch notifications
         req_id = self._peer._next_id
         self._peer._next_id += 1
+        self._current_req_id = req_id
         msg = {
             "jsonrpc": "2.0",
             "method": "session/prompt",
@@ -252,6 +280,9 @@ class ACPClient:
         self._peer._pending[req_id] = future
 
         def _on_response(fut: asyncio.Future) -> None:
+            # Only enqueue PromptDone if this is still the current prompt
+            if self._current_req_id != req_id:
+                return  # stale response from an aborted prompt — ignore
             if fut.cancelled():
                 self._event_queue.put_nowait(PromptDone(stop_reason="cancelled"))
             elif fut.exception():
@@ -290,6 +321,10 @@ class ACPClient:
             yield event
             if isinstance(event, PromptDone):
                 break
+
+        # Clear current request tracking when prompt completes normally
+        if self._current_req_id == req_id:
+            self._current_req_id = None
 
     # --- Reverse-RPC handlers ---
 

--- a/condor/acp/client.py
+++ b/condor/acp/client.py
@@ -230,7 +230,7 @@ class ACPClient:
                 future.cancel()
             self._current_req_id = None
         # Drain the queue so stale events don't leak into the next prompt
-        while not self._event_queue.empty():
+        while True:
             try:
                 self._event_queue.get_nowait()
             except asyncio.QueueEmpty:

--- a/condor/fetchers/market_data.py
+++ b/condor/fetchers/market_data.py
@@ -16,7 +16,7 @@ async def fetch_current_price(
         )
         return prices.get("prices", {}).get(trading_pair)
     except Exception as e:
-        logger.error("Error fetching price for %s: %s", trading_pair, e, exc_info=True)
+        logger.warning("Error fetching price for %s: %s", trading_pair, e)
         return None
 
 

--- a/condor/fetchers/portfolio.py
+++ b/condor/fetchers/portfolio.py
@@ -11,6 +11,11 @@ async def fetch_portfolio(client, **_kw) -> Any:
     return await client.portfolio.get_state()
 
 
+async def fetch_portfolio_refreshed(client, **_kw) -> Any:
+    """Fetch portfolio state with refresh=True to force exchange re-fetch."""
+    return await client.portfolio.get_state(refresh=True)
+
+
 async def fetch_cex_balances(
     client, account_name: str, refresh: bool = False
 ) -> Dict[str, List[Dict[str, Any]]]:

--- a/condor/fetchers/prices.py
+++ b/condor/fetchers/prices.py
@@ -19,5 +19,5 @@ async def fetch_prices(
         )
         return prices.get("prices", {}).get(trading_pair)
     except Exception as e:
-        logger.error("Error fetching price for %s: %s", trading_pair, e, exc_info=True)
+        logger.warning("Error fetching price for %s: %s", trading_pair, e)
         return None

--- a/condor/reports.py
+++ b/condor/reports.py
@@ -307,13 +307,15 @@ class ReportBuilder:
         self._sections.append({"type": "table", "columns": columns or [], "rows": rows})
         return self
 
-    def save(self) -> str:
+    def save(self, report_id: str | None = None) -> str:
+        """Save the report as an HTML file.
+
+        Args:
+            report_id: If provided, update an existing report in place.
+                       If None (default), create a new report.
+        """
         CHARTS_DIR.mkdir(exist_ok=True)
-        report_id = uuid.uuid4().hex[:6]
         now = datetime.now(timezone.utc)
-        ts_str = now.strftime("%Y%m%d_%H%M%S")
-        slug = _slugify(self._title)
-        filename = f"{ts_str}_{slug}_{report_id}.html"
 
         sections_html = self._render_sections()
         meta_badges = ""
@@ -321,6 +323,37 @@ class ReportBuilder:
             meta_badges += f"<span>{self._source_type}: {self._source_name}</span>"
         for tag in self._tags:
             meta_badges += f"<span>#{tag}</span>"
+
+        if report_id is not None:
+            # Update existing report
+            entries = _read_index()
+            entry = next((e for e in entries if e["id"] == report_id), None)
+            if entry is None:
+                raise ValueError(f"Report '{report_id}' not found in index")
+
+            html = _HTML_TEMPLATE.format(
+                title=self._title,
+                created_at=now.strftime("%Y-%m-%d %H:%M UTC"),
+                meta_badges=meta_badges,
+                sections_html=sections_html,
+            )
+            (CHARTS_DIR / entry["filename"]).write_text(html)
+
+            entry["updated_at"] = now.isoformat()
+            entry["title"] = self._title
+            entry["tags"] = self._tags
+            _write_index(entries)
+
+            global _last_report_id
+            _last_report_id = report_id
+            logger.info(f"Report updated: {entry['filename']}")
+            return report_id
+
+        # New report
+        new_id = uuid.uuid4().hex[:6]
+        ts_str = now.strftime("%Y%m%d_%H%M%S")
+        slug = _slugify(self._title)
+        filename = f"{ts_str}_{slug}_{new_id}.html"
 
         html = _HTML_TEMPLATE.format(
             title=self._title,
@@ -332,7 +365,7 @@ class ReportBuilder:
         (CHARTS_DIR / filename).write_text(html)
 
         entry = {
-            "id": report_id,
+            "id": new_id,
             "title": self._title,
             "filename": filename,
             "created_at": now.isoformat(),
@@ -346,11 +379,9 @@ class ReportBuilder:
         _write_index(entries)
         _cleanup()
 
-        global _last_report_id
-        _last_report_id = report_id
-
+        _last_report_id = new_id
         logger.info(f"Report saved: {filename}")
-        return report_id
+        return new_id
 
     def _render_sections(self) -> str:
         sections = list(self._sections)
@@ -403,3 +434,41 @@ class ReportBuilder:
             body_rows.append(f"<tr>{cells}</tr>")
         body = "\n".join(body_rows)
         return f'<div class="section section-table"><table><thead><tr>{header}</tr></thead><tbody>{body}</tbody></table></div>'
+
+
+# ── LiveReport ──
+
+
+class LiveReport:
+    """Updatable report for continuous routines.
+
+    Creates a single report on first update, then overwrites it on each
+    subsequent call. Ideal for continuous routines that accumulate data.
+    """
+
+    def __init__(self, title: str, source_name: str = "", tags: list[str] | None = None):
+        self._title = title
+        self._source_name = source_name
+        self._tags = tags or []
+        self._report_id: str | None = None
+        self._builder: ReportBuilder | None = None
+        self.clear()
+
+    @property
+    def report_id(self) -> str | None:
+        return self._report_id
+
+    @property
+    def builder(self) -> ReportBuilder:
+        return self._builder
+
+    def clear(self) -> None:
+        """Reset builder for a fresh render cycle."""
+        self._builder = ReportBuilder(self._title)
+        self._builder.source("routine", self._source_name)
+        self._builder.tags(self._tags)
+
+    def update(self) -> str:
+        """Save or update the report. Returns report_id."""
+        self._report_id = self._builder.save(report_id=self._report_id)
+        return self._report_id

--- a/condor/reports.py
+++ b/condor/reports.py
@@ -14,6 +14,10 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Module-level variable to capture the last saved report ID.
+# Safe in asyncio (single-threaded); reset before each routine execution.
+_last_report_id: str | None = None
+
 CHARTS_DIR = Path(__file__).resolve().parent.parent / "reports"
 INDEX_FILE = CHARTS_DIR / "reports_index.json"
 MAX_REPORTS = int(os.environ.get("CONDOR_MAX_REPORTS", "100"))
@@ -341,6 +345,9 @@ class ReportBuilder:
         entries.append(entry)
         _write_index(entries)
         _cleanup()
+
+        global _last_report_id
+        _last_report_id = report_id
 
         logger.info(f"Report saved: {filename}")
         return report_id

--- a/condor/reports.py
+++ b/condor/reports.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -21,6 +22,7 @@ _last_report_id: str | None = None
 CHARTS_DIR = Path(__file__).resolve().parent.parent / "reports"
 INDEX_FILE = CHARTS_DIR / "reports_index.json"
 MAX_REPORTS = int(os.environ.get("CONDOR_MAX_REPORTS", "100"))
+_index_lock = asyncio.Lock()
 
 # ── HTML Template ──
 
@@ -229,24 +231,26 @@ def get_report(report_id: str) -> dict | None:
     return None
 
 
-def delete_report(report_id: str) -> bool:
-    entries = _read_index()
-    new_entries = []
-    deleted = False
-    for e in entries:
-        if e["id"] == report_id:
-            fpath = CHARTS_DIR / e["filename"]
-            if fpath.exists():
-                fpath.unlink()
-            deleted = True
-        else:
-            new_entries.append(e)
-    if deleted:
-        _write_index(new_entries)
+async def delete_report(report_id: str) -> bool:
+    async with _index_lock:
+        entries = _read_index()
+        new_entries = []
+        deleted = False
+        for e in entries:
+            if e["id"] == report_id:
+                fpath = CHARTS_DIR / e["filename"]
+                if fpath.exists():
+                    fpath.unlink()
+                deleted = True
+            else:
+                new_entries.append(e)
+        if deleted:
+            _write_index(new_entries)
     return deleted
 
 
-def _cleanup(max_reports: int = MAX_REPORTS) -> None:
+def _cleanup_locked(max_reports: int = MAX_REPORTS) -> None:
+    """Run cleanup while caller already holds _index_lock."""
     entries = _read_index()
     if len(entries) <= max_reports:
         return
@@ -307,7 +311,7 @@ class ReportBuilder:
         self._sections.append({"type": "table", "columns": columns or [], "rows": rows})
         return self
 
-    def save(self, report_id: str | None = None) -> str:
+    async def save(self, report_id: str | None = None) -> str:
         """Save the report as an HTML file.
 
         Args:
@@ -324,60 +328,56 @@ class ReportBuilder:
         for tag in self._tags:
             meta_badges += f"<span>#{tag}</span>"
 
-        if report_id is not None:
-            # Update existing report
-            entries = _read_index()
-            entry = next((e for e in entries if e["id"] == report_id), None)
-            if entry is None:
-                raise ValueError(f"Report '{report_id}' not found in index")
-
-            html = _HTML_TEMPLATE.format(
-                title=self._title,
-                created_at=now.strftime("%Y-%m-%d %H:%M UTC"),
-                meta_badges=meta_badges,
-                sections_html=sections_html,
-            )
-            (CHARTS_DIR / entry["filename"]).write_text(html)
-
-            entry["updated_at"] = now.isoformat()
-            entry["title"] = self._title
-            entry["tags"] = self._tags
-            _write_index(entries)
-
-            global _last_report_id
-            _last_report_id = report_id
-            logger.info(f"Report updated: {entry['filename']}")
-            return report_id
-
-        # New report
-        new_id = uuid.uuid4().hex[:6]
-        ts_str = now.strftime("%Y%m%d_%H%M%S")
-        slug = _slugify(self._title)
-        filename = f"{ts_str}_{slug}_{new_id}.html"
-
-        html = _HTML_TEMPLATE.format(
+        html_content = _HTML_TEMPLATE.format(
             title=self._title,
             created_at=now.strftime("%Y-%m-%d %H:%M UTC"),
             meta_badges=meta_badges,
             sections_html=sections_html,
         )
 
-        (CHARTS_DIR / filename).write_text(html)
+        global _last_report_id
 
-        entry = {
-            "id": new_id,
-            "title": self._title,
-            "filename": filename,
-            "created_at": now.isoformat(),
-            "source_type": self._source_type,
-            "source_name": self._source_name,
-            "tags": self._tags,
-        }
+        async with _index_lock:
+            if report_id is not None:
+                # Update existing report
+                entries = _read_index()
+                entry = next((e for e in entries if e["id"] == report_id), None)
+                if entry is None:
+                    raise ValueError(f"Report '{report_id}' not found in index")
 
-        entries = _read_index()
-        entries.append(entry)
-        _write_index(entries)
-        _cleanup()
+                (CHARTS_DIR / entry["filename"]).write_text(html_content)
+
+                entry["updated_at"] = now.isoformat()
+                entry["title"] = self._title
+                entry["tags"] = self._tags
+                _write_index(entries)
+
+                _last_report_id = report_id
+                logger.info(f"Report updated: {entry['filename']}")
+                return report_id
+
+            # New report
+            new_id = uuid.uuid4().hex[:6]
+            ts_str = now.strftime("%Y%m%d_%H%M%S")
+            slug = _slugify(self._title)
+            filename = f"{ts_str}_{slug}_{new_id}.html"
+
+            (CHARTS_DIR / filename).write_text(html_content)
+
+            entry = {
+                "id": new_id,
+                "title": self._title,
+                "filename": filename,
+                "created_at": now.isoformat(),
+                "source_type": self._source_type,
+                "source_name": self._source_name,
+                "tags": self._tags,
+            }
+
+            entries = _read_index()
+            entries.append(entry)
+            _write_index(entries)
+            _cleanup_locked()
 
         _last_report_id = new_id
         logger.info(f"Report saved: {filename}")
@@ -468,7 +468,7 @@ class LiveReport:
         self._builder.source("routine", self._source_name)
         self._builder.tags(self._tags)
 
-    def update(self) -> str:
+    async def update(self) -> str:
         """Save or update the report. Returns report_id."""
-        self._report_id = self._builder.save(report_id=self._report_id)
+        self._report_id = await self._builder.save(report_id=self._report_id)
         return self._report_id

--- a/condor/routine_store.py
+++ b/condor/routine_store.py
@@ -123,6 +123,8 @@ class RoutineStore:
             entry["table_data"] = result.table_data
             entry["table_columns"] = result.table_columns
             entry["sections"] = result.sections
+        # Ensure error is always present in response
+        entry.setdefault("error", None)
         return entry
 
     def add_instance(self, instance_id: str, metadata: dict) -> None:
@@ -202,17 +204,21 @@ class RoutineStore:
         except Exception as e:
             logger.error(f"Web routine {routine.name}[{instance_id}] failed: {e}")
             result = RoutineResult(text=f"Error: {e}")
+            failed = True
+        else:
+            failed = False
 
         duration = time.time() - start
         self._results[instance_id] = result
 
         if instance_id in self._instances:
             self._instances[instance_id].update({
-                "status": "completed",
+                "status": "failed" if failed else "completed",
                 "last_run_at": time.time(),
                 "last_result": result.text[:500],
                 "last_duration": duration,
                 "run_count": self._instances[instance_id].get("run_count", 0) + 1,
+                "error": str(e) if failed else None,
             })
 
     async def schedule(
@@ -264,6 +270,9 @@ class RoutineStore:
                 except Exception as e:
                     logger.error(f"Scheduled routine {routine.name}[{instance_id}] error: {e}")
                     result = RoutineResult(text=f"Error: {e}")
+                    run_failed = True
+                else:
+                    run_failed = False
 
                 duration = time.time() - start
                 self._results[instance_id] = result
@@ -275,6 +284,7 @@ class RoutineStore:
                         "last_result": result.text[:500],
                         "last_duration": duration,
                         "run_count": self._instances[instance_id].get("run_count", 0) + 1,
+                        "error": str(e) if run_failed else None,
                     })
 
                 await asyncio.sleep(interval_sec)

--- a/condor/routine_store.py
+++ b/condor/routine_store.py
@@ -20,12 +20,67 @@ from routines.base import RoutineResult, discover_routines, discover_routines_fr
 logger = logging.getLogger(__name__)
 
 
+class _HttpBot:
+    """Fallback bot that sends Telegram messages via HTTP when no real bot is available."""
+
+    def __init__(self):
+        import os
+        self._token = os.environ.get("TELEGRAM_BOT_TOKEN") or os.environ.get("TELEGRAM_TOKEN", "")
+
+    async def _post(self, method: str, data: dict, files: dict | None = None):
+        if not self._token:
+            return None
+        import httpx
+        url = f"https://api.telegram.org/bot{self._token}/{method}"
+        async with httpx.AsyncClient(timeout=30) as client:
+            if files:
+                resp = await client.post(url, data=data, files=files)
+            else:
+                resp = await client.post(url, json=data)
+            result = resp.json()
+            if not result.get("ok"):
+                logger.warning(f"Telegram {method} failed: {resp.text}")
+            return result
+
+    async def send_message(self, *a, **kw):
+        chat_id = kw.get("chat_id") or (a[0] if a else None)
+        text = kw.get("text") or (a[1] if len(a) > 1 else "")
+        data = {"chat_id": chat_id, "text": text}
+        if kw.get("parse_mode"):
+            data["parse_mode"] = kw["parse_mode"]
+        return await self._post("sendMessage", data)
+
+    async def send_photo(self, *a, **kw):
+        chat_id = kw.get("chat_id") or (a[0] if a else None)
+        photo = kw.get("photo") or (a[1] if len(a) > 1 else None)
+        data = {"chat_id": chat_id}
+        if kw.get("caption"):
+            data["caption"] = kw["caption"]
+        files = {"photo": ("chart.png", photo, "image/png")} if photo else None
+        return await self._post("sendPhoto", data, files=files)
+
+    async def send_document(self, *a, **kw):
+        chat_id = kw.get("chat_id") or (a[0] if a else None)
+        document = kw.get("document") or (a[1] if len(a) > 1 else None)
+        data = {"chat_id": chat_id}
+        if kw.get("caption"):
+            data["caption"] = kw["caption"]
+        files = {"document": ("file", document, "application/octet-stream")} if document else None
+        return await self._post("sendDocument", data, files=files)
+
+    async def edit_message_text(self, *a, **kw):
+        data = {k: v for k, v in kw.items() if v is not None}
+        return await self._post("editMessageText", data)
+
+_http_bot = _HttpBot()
+
+
 class WebRoutineContext:
     """Lightweight context so routines can run without Telegram."""
 
     def __init__(self, server_name: str, bot=None, chat_id: int = 0):
         self._chat_id = chat_id
-        self.bot = bot
+        self.bot = bot if bot is not None else _http_bot
         self._user_data: dict[str, Any] = {
             "preferences": {"general": {"active_server": server_name}},
         }

--- a/condor/routine_store.py
+++ b/condor/routine_store.py
@@ -52,7 +52,7 @@ class RoutineStore:
 
     def _discover_all(self) -> dict[str, "RoutineInfo"]:
         """Discover global routines + agent routines, merged into one dict."""
-        all_routines = dict(discover_routines())
+        all_routines = dict(discover_routines(force_reload=True))
 
         # Scan trading_agents/*/routines/
         agents_dir = Path(__file__).resolve().parent.parent / "trading_agents"
@@ -223,6 +223,67 @@ class RoutineStore:
                 "last_duration": duration,
                 "run_count": self._instances[instance_id].get("run_count", 0) + 1,
                 "error": error_msg,
+            })
+
+    async def start_continuous(
+        self,
+        routine_name: str,
+        config: dict,
+        server_name: str,
+        user_id: int = 0,
+    ) -> str:
+        """Start a continuous routine as a background task. Returns instance_id."""
+        routine = self._resolve_routine(routine_name)
+        if not routine:
+            raise ValueError(f"Routine '{routine_name}' not found")
+        if not routine.is_continuous:
+            raise ValueError(f"Routine '{routine_name}' is not continuous — use execute() instead")
+
+        instance_id = self._gen_id()
+        self._instances[instance_id] = {
+            "routine_name": routine_name,
+            "config": config,
+            "status": "running",
+            "source": "mcp",
+            "server_name": server_name,
+            "user_id": user_id,
+            "created_at": time.time(),
+            "last_run_at": None,
+            "last_result": None,
+            "last_duration": None,
+            "run_count": 0,
+        }
+
+        task = asyncio.create_task(
+            self._run_continuous(instance_id, routine, config, server_name, user_id)
+        )
+        self._tasks[instance_id] = task
+        return instance_id
+
+    async def _run_continuous(self, instance_id: str, routine, config: dict, server_name: str, user_id: int = 0) -> None:
+        ctx = WebRoutineContext(server_name, bot=self._bot, chat_id=user_id)
+        start = time.time()
+        try:
+            cfg = routine.config_class(**config)
+            raw = await routine.run_fn(cfg, ctx)
+            result = normalize_result(raw)
+        except asyncio.CancelledError:
+            result = RoutineResult(text="Stopped by user")
+        except Exception as e:
+            tb = traceback.format_exc()
+            logger.error(f"Continuous routine {routine.name}[{instance_id}] failed: {type(e).__name__}: {e}\n{tb}")
+            result = RoutineResult(text=f"Error: {type(e).__name__}: {e}\n\n{tb}")
+
+        duration = time.time() - start
+        self._results[instance_id] = result
+
+        if instance_id in self._instances:
+            self._instances[instance_id].update({
+                "status": "stopped",
+                "last_run_at": time.time(),
+                "last_result": result.text[:500],
+                "last_duration": duration,
+                "run_count": self._instances[instance_id].get("run_count", 0) + 1,
             })
 
     async def schedule(

--- a/condor/routine_store.py
+++ b/condor/routine_store.py
@@ -10,6 +10,7 @@ import asyncio
 import hashlib
 import logging
 import time
+import traceback
 from typing import Any
 
 from pathlib import Path
@@ -202,10 +203,13 @@ class RoutineStore:
             raw = await routine.run_fn(cfg, ctx)
             result = normalize_result(raw)
         except Exception as e:
-            logger.error(f"Web routine {routine.name}[{instance_id}] failed: {e}")
-            result = RoutineResult(text=f"Error: {e}")
+            tb = traceback.format_exc()
+            logger.error(f"Web routine {routine.name}[{instance_id}] failed: {type(e).__name__}: {e}\n{tb}")
+            error_msg = f"{type(e).__name__}: {e}"
+            result = RoutineResult(text=f"Error: {error_msg}\n\n{tb}")
             failed = True
         else:
+            error_msg = None
             failed = False
 
         duration = time.time() - start
@@ -218,7 +222,7 @@ class RoutineStore:
                 "last_result": result.text[:500],
                 "last_duration": duration,
                 "run_count": self._instances[instance_id].get("run_count", 0) + 1,
-                "error": str(e) if failed else None,
+                "error": error_msg,
             })
 
     async def schedule(
@@ -268,10 +272,13 @@ class RoutineStore:
                     raw = await routine.run_fn(cfg, ctx)
                     result = normalize_result(raw)
                 except Exception as e:
-                    logger.error(f"Scheduled routine {routine.name}[{instance_id}] error: {e}")
-                    result = RoutineResult(text=f"Error: {e}")
+                    tb = traceback.format_exc()
+                    logger.error(f"Scheduled routine {routine.name}[{instance_id}] error: {type(e).__name__}: {e}\n{tb}")
+                    error_msg = f"{type(e).__name__}: {e}"
+                    result = RoutineResult(text=f"Error: {error_msg}\n\n{tb}")
                     run_failed = True
                 else:
+                    error_msg = None
                     run_failed = False
 
                 duration = time.time() - start
@@ -284,7 +291,7 @@ class RoutineStore:
                         "last_result": result.text[:500],
                         "last_duration": duration,
                         "run_count": self._instances[instance_id].get("run_count", 0) + 1,
-                        "error": str(e) if run_failed else None,
+                        "error": error_msg,
                     })
 
                 await asyncio.sleep(interval_sec)

--- a/condor/trading_agent/performance.py
+++ b/condor/trading_agent/performance.py
@@ -55,23 +55,16 @@ def _executor_row(ex: dict) -> dict[str, Any]:
     if not isinstance(custom_info, dict):
         custom_info = {}
 
-    # entry_price: prefer custom_info (position executors store it there)
-    entry_price = (
-        float(cfg.get("entry_price") or 0)
-        or float(ex.get("entry_price") or 0)
-        or float(custom_info.get("current_position_average_price") or 0)
-    )
-    # current_price / close_price
-    current_price = (
-        float(ex.get("current_price") or 0)
-        or float(custom_info.get("close_price") or 0)
-    )
+    # entry_price: config > top-level > custom_info (position executors store it there)
+    _cfg_entry = float(cfg.get("entry_price") or 0)
+    _top_entry = float(ex.get("entry_price") or 0)
+    _ci_entry = float(custom_info.get("current_position_average_price") or 0)
+    entry_price = _cfg_entry if _cfg_entry > 0 else (_top_entry if _top_entry > 0 else (_ci_entry if _ci_entry > 0 else 0.0))
 
-    ex_id = ex.get("id") or ex.get("executor_id") or "unknown"
-    if entry_price == 0.0:
-        log.warning("Executor %s: entry_price fell back to 0.0 — PnL may be misleading", ex_id)
-    if current_price == 0.0:
-        log.warning("Executor %s: current_price fell back to 0.0 — PnL may be misleading", ex_id)
+    # current_price / close_price: top-level > custom_info
+    _top_cur = float(ex.get("current_price") or 0)
+    _ci_close = float(custom_info.get("close_price") or 0)
+    current_price = _top_cur if _top_cur > 0 else (_ci_close if _ci_close > 0 else 0.0)
 
     return {
         "id": str(ex.get("id") or ex.get("executor_id") or ""),

--- a/condor/trading_agent/performance.py
+++ b/condor/trading_agent/performance.py
@@ -60,6 +60,9 @@ def _executor_row(ex: dict) -> dict[str, Any]:
     _top_entry = float(ex.get("entry_price") or 0)
     _ci_entry = float(custom_info.get("current_position_average_price") or 0)
     entry_price = _cfg_entry if _cfg_entry > 0 else (_top_entry if _top_entry > 0 else (_ci_entry if _ci_entry > 0 else 0.0))
+    if entry_price == 0.0:
+        log.warning("entry_price fell back to 0.0 for executor %s — PnL may be wrong",
+                     ex.get("id") or ex.get("executor_id") or "?")
 
     # current_price / close_price: top-level > custom_info
     _top_cur = float(ex.get("current_price") or 0)

--- a/condor/trading_agent/prompts.py
+++ b/condor/trading_agent/prompts.py
@@ -195,7 +195,10 @@ def build_tick_prompt(
         "trading_context", "risk_limits",  # shown in dedicated sections
         "agent_key", "server_name", "frequency_sec", "execution_mode",  # noise / internal
     }
-    config_lines = ["[CURRENT CONFIG]"]
+    config_lines = [
+        "[CURRENT CONFIG]",
+        "These are the ACTIVE values for this session. If the strategy instructions mention different defaults, IGNORE them and use these values instead.",
+    ]
     for k, v in config.items():
         if k in _CONFIG_EXCLUDE:
             continue

--- a/condor/web/app.py
+++ b/condor/web/app.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
-from condor.web.routes import agents, archived, auth, backtesting, bots, chat_ws, executors, market, portfolio, positions, reports, routines, servers, settings, transcribe, ws
+from condor.web.routes import agents, archived, auth, backtesting, bots, chat_ws, controller_performance, executors, market, portfolio, positions, reports, routines, servers, settings, transcribe, ws
 
 
 def create_app() -> FastAPI:
@@ -31,6 +31,7 @@ def create_app() -> FastAPI:
     app.include_router(servers.router, prefix="/api/v1")
     app.include_router(portfolio.router, prefix="/api/v1")
     app.include_router(bots.router, prefix="/api/v1")
+    app.include_router(controller_performance.router, prefix="/api/v1")
     app.include_router(archived.router, prefix="/api/v1")
     app.include_router(executors.router, prefix="/api/v1")
     app.include_router(positions.router, prefix="/api/v1")

--- a/condor/web/models.py
+++ b/condor/web/models.py
@@ -133,6 +133,64 @@ class BotsPageResponse(BaseModel):
     error_hint: Optional[str] = None
 
 
+# ── Bot Runs ──
+
+
+class BotRunInfo(BaseModel):
+    bot_name: str
+    account_name: str = ""
+    strategy_type: str = ""
+    strategy_name: str = ""
+    run_status: str = ""
+    deployment_status: str = ""
+    created_at: Optional[str] = None
+    stopped_at: Optional[str] = None
+    realized_pnl_quote: float = 0.0
+    unrealized_pnl_quote: float = 0.0
+    global_pnl_quote: float = 0.0
+    volume_traded: float = 0.0
+    num_controllers: int = 0
+
+
+class BotRunsResponse(BaseModel):
+    runs: list[BotRunInfo] = []
+    total: int = 0
+
+
+# ── Controller Performance ──
+
+
+class ControllerPerformanceSnapshot(BaseModel):
+    timestamp: str = ""
+    bot_name: str = ""
+    controller_id: str = ""
+    controller_name: str = ""
+    connector: str = ""
+    trading_pair: str = ""
+    realized_pnl_quote: float = 0.0
+    unrealized_pnl_quote: float = 0.0
+    global_pnl_quote: float = 0.0
+    global_pnl_pct: float = 0.0
+    volume_traded: float = 0.0
+    close_type_counts: dict[str, int] = {}
+    positions_summary: list[dict[str, Any]] = []
+    custom_info: dict[str, Any] = {}
+
+
+class ControllerPerformanceLatestResponse(BaseModel):
+    snapshots: list[ControllerPerformanceSnapshot] = []
+    server_online: bool = True
+    error_hint: Optional[str] = None
+
+
+class ControllerPerformanceHistoryResponse(BaseModel):
+    snapshots: list[ControllerPerformanceSnapshot] = []
+    next_cursor: Optional[str] = None
+    interval: str = "5m"
+    server_online: bool = True
+    error_hint: Optional[str] = None
+
+
 # ── Executors ──
 
 

--- a/condor/web/models.py
+++ b/condor/web/models.py
@@ -138,6 +138,7 @@ class BotsPageResponse(BaseModel):
 
 class BotRunInfo(BaseModel):
     bot_name: str
+    bot_run_id: Optional[int] = None
     account_name: str = ""
     strategy_type: str = ""
     strategy_name: str = ""

--- a/condor/web/routes/bots.py
+++ b/condor/web/routes/bots.py
@@ -920,6 +920,8 @@ async def update_bot_controller_config_endpoint(
 
         merged = {**existing, **body}
         merged["id"] = config_id
+        # Strip internal fields like _config_name that cause Pydantic validation errors
+        merged = {k: v for k, v in merged.items() if not k.startswith("_")}
 
         result = await client.controllers.update_bot_controller_config(
             bot_name, config_id, merged

--- a/condor/web/routes/bots.py
+++ b/condor/web/routes/bots.py
@@ -76,6 +76,29 @@ def _extract_bots_list(result: Any) -> list[dict]:
     return []
 
 
+def _extract_perf_snapshots(result: Any) -> list[dict]:
+    """Normalize controller performance API response into a list of snapshot dicts."""
+    if isinstance(result, list):
+        return [s for s in result if isinstance(s, dict)]
+    if isinstance(result, dict):
+        data = result.get("data", result.get("snapshots", result.get("records", [])))
+        if isinstance(data, list):
+            return [s for s in data if isinstance(s, dict)]
+        if isinstance(data, dict):
+            out = []
+            for key, val in data.items():
+                if isinstance(val, dict):
+                    val.setdefault("controller_id", key)
+                    out.append(val)
+                elif isinstance(val, list):
+                    for item in val:
+                        if isinstance(item, dict):
+                            item.setdefault("controller_id", key)
+                            out.append(item)
+            return out
+    return []
+
+
 @router.get("/servers/{name}/bots", response_model=BotsPageResponse)
 async def list_bots(name: str, user: WebUser = Depends(get_current_user)):
     cm = get_config_manager()
@@ -99,7 +122,7 @@ async def list_bots(name: str, user: WebUser = Depends(get_current_user)):
             error_hint="Unable to reach server",
         )
 
-    # Still need a client for bot_runs (not cached)
+    # Get client for enrichment calls
     try:
         client = await cm.get_client(name)
     except Exception:
@@ -108,14 +131,14 @@ async def list_bots(name: str, user: WebUser = Depends(get_current_user)):
     bots_list = _extract_bots_list(result)
     logger.info("Server '%s': found %d bot(s)", name, len(bots_list))
 
-    # Pre-fetch controller configs AND bot runs concurrently
+    # Pre-fetch controller configs, bot runs, AND latest controller performance concurrently
     ctrl_configs: dict[str, dict] = {}
     bot_runs: dict[str, str] = {}
+    latest_perf: dict[str, dict] = {}  # keyed by controller_id
 
     if client is not None:
         import asyncio
 
-        # Fetch all bot controller configs concurrently
         async def _fetch_ctrl_configs() -> dict[str, dict]:
             configs_map: dict[str, dict] = {}
             bot_names = [b.get("bot_name", "") for b in bots_list if b.get("bot_name")]
@@ -164,8 +187,22 @@ async def list_bots(name: str, user: WebUser = Depends(get_current_user)):
                 pass
             return runs
 
-        ctrl_configs, bot_runs = await asyncio.gather(
-            _fetch_ctrl_configs(), _fetch_bot_runs()
+        async def _fetch_latest_perf() -> dict[str, dict]:
+            """Fetch latest controller performance snapshots from DB."""
+            perf_map: dict[str, dict] = {}
+            try:
+                perf_result = await client.bot_orchestration.get_latest_controller_performance()
+                snapshots = _extract_perf_snapshots(perf_result)
+                for snap in snapshots:
+                    cid = snap.get("controller_id", "")
+                    if cid:
+                        perf_map[cid] = snap
+            except Exception:
+                logger.debug("Latest controller performance not available for '%s'", name)
+            return perf_map
+
+        ctrl_configs, bot_runs, latest_perf = await asyncio.gather(
+            _fetch_ctrl_configs(), _fetch_bot_runs(), _fetch_latest_perf()
         )
 
     controllers: list[ControllerInfo] = []
@@ -193,37 +230,52 @@ async def list_bots(name: str, user: WebUser = Depends(get_current_user)):
 
                 num_controllers += 1
                 ctrl_status = ctrl_info.get("status", "running")
-                ctrl_perf = ctrl_info.get("performance", {})
-
-                if not isinstance(ctrl_perf, dict):
-                    ctrl_perf = {}
-
-                realized = float(ctrl_perf.get("realized_pnl_quote", 0) or 0)
-                unrealized = float(ctrl_perf.get("unrealized_pnl_quote", 0) or 0)
-                global_pnl = realized + unrealized
-                global_pnl_pct = float(ctrl_perf.get("global_pnl_pct", 0) or 0)
-                volume = float(ctrl_perf.get("volume_traded", 0) or 0)
-                close_types = ctrl_perf.get("close_type_counts", {})
-                if not isinstance(close_types, dict):
-                    close_types = {}
-                positions = ctrl_perf.get("positions_summary", [])
-                if not isinstance(positions, list):
-                    positions = []
 
                 # Get config from pre-fetched configs
                 ctrl_config = ctrl_configs.get(ctrl_name, {})
+                config_id = ctrl_config.get("id") or ctrl_config.get("controller_id", ctrl_name)
+
+                # Use latest DB performance if available, fallback to live bot status
+                db_snap = latest_perf.get(config_id) or latest_perf.get(ctrl_name)
+                if db_snap:
+                    db_perf = db_snap.get("performance", db_snap)
+                    if not isinstance(db_perf, dict):
+                        db_perf = {}
+                else:
+                    db_perf = {}
+
+                # Live performance from bot status (always available)
+                live_perf = ctrl_info.get("performance", {})
+                if not isinstance(live_perf, dict):
+                    live_perf = {}
+
+                # Merge: prefer live data for real-time fields, DB for historical consistency
+                realized = float(live_perf.get("realized_pnl_quote", 0) or db_perf.get("realized_pnl_quote", 0) or 0)
+                unrealized = float(live_perf.get("unrealized_pnl_quote", 0) or db_perf.get("unrealized_pnl_quote", 0) or 0)
+                global_pnl = realized + unrealized
+                global_pnl_pct = float(live_perf.get("global_pnl_pct", 0) or db_perf.get("global_pnl_pct", 0) or 0)
+                volume = float(live_perf.get("volume_traded", 0) or db_perf.get("volume_traded", 0) or 0)
+                close_types = live_perf.get("close_type_counts") or db_perf.get("close_type_counts", {})
+                if not isinstance(close_types, dict):
+                    close_types = {}
+                positions = live_perf.get("positions_summary") or db_perf.get("positions_summary", [])
+                if not isinstance(positions, list):
+                    positions = []
 
                 # Primary: config dict (correct keys)
                 connector = ctrl_config.get("connector_name", "")
                 trading_pair = ctrl_config.get("trading_pair", "")
 
-                # Fallback: try to parse connector/pair from controller name
-                # e.g. "binance_perpetual_SOL-USDT_pmm_simple"
+                # Fallback: try DB snapshot, then parse from controller name
+                if not connector:
+                    connector = db_perf.get("connector", db_perf.get("connector_name", ""))
+                if not trading_pair:
+                    trading_pair = db_perf.get("trading_pair", "")
+
                 if not connector or not trading_pair:
                     parts = ctrl_name.split("_")
                     for i, part in enumerate(parts):
                         if "-" in part and part[0].isupper():
-                            # Looks like a trading pair (e.g. SOL-USDT)
                             if not trading_pair:
                                 trading_pair = part
                             if not connector and i > 0:
@@ -233,9 +285,7 @@ async def list_bots(name: str, user: WebUser = Depends(get_current_user)):
                 total_pnl += global_pnl
                 total_volume += volume
 
-                # Use human-readable controller_name from config if available
                 config_cname = ctrl_config.get("controller_name", "")
-                config_id = ctrl_config.get("id") or ctrl_config.get("controller_id", "")
                 display_name = config_cname or ctrl_name
                 display_id = config_id or ctrl_name
 
@@ -289,36 +339,44 @@ async def get_bot(name: str, bot_id: str, user: WebUser = Depends(get_current_us
 
     client = await cm.get_client(name)
 
-    # Fetch status, config, and performance concurrently
-    async def _get_status():
-        return await client.bot_orchestration.get_bot_status(bot_id)
-
-    async def _get_config():
-        try:
-            r = await client.bot_orchestration.get_bot_config(bot_id)
-            return r if isinstance(r, dict) else {}
-        except Exception:
-            return {}
-
-    async def _get_perf():
-        try:
-            r = await client.bot_orchestration.get_bot_performance(bot_id)
-            return r if isinstance(r, dict) else {}
-        except Exception:
-            return {}
-
     try:
-        result, config, performance = await asyncio.gather(
-            _get_status(), _get_config(), _get_perf()
-        )
+        result = await client.bot_orchestration.get_bot_status(bot_id)
     except Exception as e:
         raise HTTPException(status_code=502, detail=str(e))
 
     if not isinstance(result, dict):
         raise HTTPException(status_code=404, detail="Bot not found")
 
-    bot = _parse_bot(result)
-    return BotDetailResponse(bot=bot, config=config, performance=performance)
+    # Extract nested data from the status response
+    data = result.get("data", result)
+    if not isinstance(data, dict):
+        data = result
+
+    # Extract performance from status response (keyed by controller_id)
+    performance = data.get("performance", {})
+    if not isinstance(performance, dict):
+        performance = {}
+
+    # Flatten controller performance into a single merged dict for display
+    flat_perf: dict = {}
+    for ctrl_name, ctrl_info in performance.items():
+        if isinstance(ctrl_info, dict):
+            perf = ctrl_info.get("performance", {})
+            if isinstance(perf, dict):
+                flat_perf = perf
+                break  # Single-controller bot: use first controller's performance
+
+    # Fetch controller config concurrently
+    config: dict = {}
+    try:
+        configs = await client.controllers.get_bot_controller_configs(bot_id)
+        if isinstance(configs, list) and configs:
+            config = configs[0] if isinstance(configs[0], dict) else {}
+    except Exception:
+        pass
+
+    bot = _parse_bot(data)
+    return BotDetailResponse(bot=bot, config=config, performance=flat_perf)
 
 
 @router.get(

--- a/condor/web/routes/bots.py
+++ b/condor/web/routes/bots.py
@@ -890,3 +890,39 @@ async def start_controllers_endpoint(
         raise HTTPException(status_code=502, detail=str(e))
 
     return result
+
+
+@router.put("/servers/{name}/bots/{bot_name}/controllers/{config_id}/config")
+async def update_bot_controller_config_endpoint(
+    name: str,
+    bot_name: str,
+    config_id: str,
+    body: dict[str, Any],
+    user: WebUser = Depends(get_current_user),
+):
+    """Update a controller config inside a running bot in real-time."""
+    cm = get_config_manager()
+    if not cm.has_server_access(user.id, name):
+        raise HTTPException(status_code=403, detail="No access")
+
+    client = await cm.get_client(name)
+
+    try:
+        # Fetch current bot controller config to merge partial updates
+        current_configs = await client.controllers.get_bot_controller_configs(bot_name)
+        existing = next((c for c in current_configs if c.get("id") == config_id), None)
+        if not existing:
+            raise HTTPException(status_code=404, detail=f"Controller '{config_id}' not found in bot '{bot_name}'")
+
+        merged = {**existing, **body}
+        merged["id"] = config_id
+
+        result = await client.controllers.update_bot_controller_config(
+            bot_name, config_id, merged
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=str(e))
+
+    return {"updated": True, "config_id": config_id, "bot_name": bot_name, "result": result}

--- a/condor/web/routes/bots.py
+++ b/condor/web/routes/bots.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -27,6 +28,65 @@ from condor.web.models import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["bots"])
+
+# ── Transitional state store ──
+# Tracks bots/controllers that have been sent a stop command but haven't
+# finished shutting down yet. Auto-expires after TTL seconds.
+
+_TRANSITIONAL_TTL = 300  # 5 minutes max
+
+# { "server:bot_name" -> timestamp }
+_stopping_bots: dict[str, float] = {}
+# { "server:bot_name:controller_id" -> timestamp }
+_stopping_controllers: dict[str, float] = {}
+
+
+def mark_bot_stopping(server: str, bot_name: str) -> None:
+    _stopping_bots[f"{server}:{bot_name}"] = time.monotonic()
+
+
+def mark_controllers_stopping(server: str, bot_name: str, controller_ids: list[str]) -> None:
+    now = time.monotonic()
+    for cid in controller_ids:
+        _stopping_controllers[f"{server}:{bot_name}:{cid}"] = now
+
+
+def clear_bot_stopping(server: str, bot_name: str) -> None:
+    _stopping_bots.pop(f"{server}:{bot_name}", None)
+
+
+def get_stopping_bots(server: str) -> set[str]:
+    """Return bot names currently in stopping state for a server."""
+    now = time.monotonic()
+    result = set()
+    expired = []
+    for key, ts in _stopping_bots.items():
+        if now - ts > _TRANSITIONAL_TTL:
+            expired.append(key)
+            continue
+        srv, bot = key.split(":", 1)
+        if srv == server:
+            result.add(bot)
+    for key in expired:
+        _stopping_bots.pop(key, None)
+    return result
+
+
+def get_stopping_controllers(server: str) -> set[str]:
+    """Return 'bot_name:controller_id' keys currently in stopping state."""
+    now = time.monotonic()
+    result = set()
+    expired = []
+    for key, ts in _stopping_controllers.items():
+        if now - ts > _TRANSITIONAL_TTL:
+            expired.append(key)
+            continue
+        parts = key.split(":", 2)
+        if len(parts) == 3 and parts[0] == server:
+            result.add(f"{parts[1]}:{parts[2]}")
+    for key in expired:
+        _stopping_controllers.pop(key, None)
+    return result
 
 
 def _parse_bot(bot: dict) -> BotInfo:
@@ -320,6 +380,33 @@ async def list_bots(name: str, user: WebUser = Depends(get_current_user)):
                 general_logs=general_logs[-100:],
             )
         )
+
+    # Overlay transitional "stopping" state
+    stopping_bot_names = get_stopping_bots(name)
+    stopping_ctrl_keys = get_stopping_controllers(name)
+
+    for bot in bots:
+        if bot.bot_name in stopping_bot_names:
+            # Bot is no longer in the active list from API → it actually stopped
+            if bot.status not in ("running",):
+                clear_bot_stopping(name, bot.bot_name)
+            else:
+                bot.status = "stopping"
+
+    # Clear stopping bots that are no longer in the response at all
+    active_bot_names = {b.bot_name for b in bots}
+    for sbn in list(stopping_bot_names):
+        if sbn not in active_bot_names:
+            clear_bot_stopping(name, sbn)
+
+    for ctrl in controllers:
+        key = f"{ctrl.bot_name}:{ctrl.controller_id}"
+        if key in stopping_ctrl_keys:
+            # If kill switch is already on, the stop landed → clear
+            if ctrl.config.get("manual_kill_switch") is True:
+                _stopping_controllers.pop(f"{name}:{key}", None)
+            else:
+                ctrl.status = "stopping"
 
     return BotsPageResponse(
         controllers=controllers,
@@ -732,6 +819,9 @@ async def stop_bot_endpoint(
     if not cm.has_server_access(user.id, name):
         raise HTTPException(status_code=403, detail="No access")
 
+    # Mark as stopping immediately so UI reflects it
+    mark_bot_stopping(name, bot_name)
+
     client = await cm.get_client(name)
 
     from mcp_servers.hummingbot_api.tools.bot_management import manage_bot_execution
@@ -743,6 +833,7 @@ async def stop_bot_endpoint(
             action="stop_bot",
         )
     except Exception as e:
+        clear_bot_stopping(name, bot_name)
         raise HTTPException(status_code=502, detail=str(e))
 
     return result
@@ -755,6 +846,9 @@ async def stop_controllers_endpoint(
     cm = get_config_manager()
     if not cm.has_server_access(user.id, name):
         raise HTTPException(status_code=403, detail="No access")
+
+    # Mark controllers as stopping immediately
+    mark_controllers_stopping(name, bot_name, body.controller_names)
 
     client = await cm.get_client(name)
 

--- a/condor/web/routes/bots.py
+++ b/condor/web/routes/bots.py
@@ -594,6 +594,8 @@ async def update_controller_config(
             merged = {**existing, **body}
 
         merged["id"] = config_id  # ensure id stays consistent
+        # Strip internal fields like _config_name that cause Pydantic validation errors
+        merged = {k: v for k, v in merged.items() if not k.startswith("_")}
 
         result = await client.controllers.create_or_update_controller_config(
             config_id, merged
@@ -733,8 +735,10 @@ async def create_controller_config(
 
     client = await cm.get_client(name)
     try:
+        # Strip internal fields like _config_name that cause Pydantic validation errors
+        clean_body = {k: v for k, v in body.items() if not k.startswith("_")}
         result = await client.controllers.create_or_update_controller_config(
-            config_id, body
+            config_id, clean_body
         )
     except Exception as e:
         raise HTTPException(status_code=502, detail=str(e))

--- a/condor/web/routes/chat_ws.py
+++ b/condor/web/routes/chat_ws.py
@@ -259,7 +259,13 @@ async def _handle_send_message(
     session = get_session(session_key)
 
     if not session or not session.client.alive:
-        await _send(ws, {"event": "error", "message": "Session not found. Create a new one."})
+        # Session died — clean up and notify frontend
+        await destroy_session(session_key)
+        slots = _user_slots.get(user_id, [])
+        if slot_id in slots:
+            slots.remove(slot_id)
+        await _send(ws, {"event": "error", "slot_id": slot_id, "message": "Session ended. Start a new one."})
+        await _send(ws, {"event": "session_destroyed", "slot_id": slot_id, "had_session": True})
         return
 
     if session.is_busy:
@@ -301,9 +307,11 @@ async def _handle_send_message(
                 })
     except RuntimeError as e:
         await _send(ws, {"event": "error", "slot_id": slot_id, "message": str(e)})
+        await _send(ws, {"event": "prompt_done", "slot_id": slot_id, "stop_reason": "error"})
     except Exception:
         log.exception("Error streaming prompt for user %d", user_id)
         await _send(ws, {"event": "error", "slot_id": slot_id, "message": "Stream error"})
+        await _send(ws, {"event": "prompt_done", "slot_id": slot_id, "stop_reason": "error"})
 
 
 async def _handle_destroy_session(ws: WebSocket, user_id: int, msg: dict) -> None:

--- a/condor/web/routes/chat_ws.py
+++ b/condor/web/routes/chat_ws.py
@@ -338,13 +338,20 @@ async def _handle_abort_prompt(ws: WebSocket, user_id: int, msg: dict) -> None:
         await _send(ws, {"event": "error", "message": "No slot_id"})
         return
 
+    # Abort the ACP-level prompt so stale events don't leak into the next message
+    session_key = _session_key(user_id, slot_id)
+    session = get_session(session_key)
+    if session:
+        session.abort()
+
     task_key = f"{user_id}:{slot_id}"
     task = _active_prompt_tasks.get(task_key)
     if task and not task.done():
         task.cancel()
-    else:
-        # No active task — send prompt_done anyway so frontend resets
-        await _send(ws, {"event": "prompt_done", "slot_id": slot_id, "stop_reason": "cancelled"})
+
+    # Always send prompt_done so the frontend resets (the task's CancelledError
+    # handler also sends one, but this guarantees it even if the send fails)
+    await _send(ws, {"event": "prompt_done", "slot_id": slot_id, "stop_reason": "cancelled"})
 
 
 async def _handle_destroy_session(ws: WebSocket, user_id: int, msg: dict) -> None:

--- a/condor/web/routes/chat_ws.py
+++ b/condor/web/routes/chat_ws.py
@@ -348,10 +348,11 @@ async def _handle_abort_prompt(ws: WebSocket, user_id: int, msg: dict) -> None:
     task = _active_prompt_tasks.get(task_key)
     if task and not task.done():
         task.cancel()
-
-    # Always send prompt_done so the frontend resets (the task's CancelledError
-    # handler also sends one, but this guarantees it even if the send fails)
-    await _send(ws, {"event": "prompt_done", "slot_id": slot_id, "stop_reason": "cancelled"})
+        # Don't send prompt_done here — the CancelledError handler in
+        # _handle_send_message already sends it when the task is cancelled.
+    else:
+        # No active task to cancel — send prompt_done directly so the frontend resets
+        await _send(ws, {"event": "prompt_done", "slot_id": slot_id, "stop_reason": "cancelled"})
 
 
 async def _handle_destroy_session(ws: WebSocket, user_id: int, msg: dict) -> None:
@@ -362,6 +363,10 @@ async def _handle_destroy_session(ws: WebSocket, user_id: int, msg: dict) -> Non
 
     session_key = _session_key(user_id, slot_id)
     destroyed = await destroy_session(session_key)
+
+    # Clean up active prompt task to prevent memory leaks
+    task_key = f"{user_id}:{slot_id}"
+    _active_prompt_tasks.pop(task_key, None)
 
     # Remove from user slots
     slots = _user_slots.get(user_id, [])

--- a/condor/web/routes/chat_ws.py
+++ b/condor/web/routes/chat_ws.py
@@ -49,6 +49,9 @@ _pending_permissions: dict[str, asyncio.Future] = {}
 # Track which session slots exist per user: user_id -> [slot_id, ...]
 _user_slots: dict[int, list[str]] = {}
 
+# Track active prompt tasks per slot: "user_id:slot_id" -> asyncio.Task
+_active_prompt_tasks: dict[str, asyncio.Task] = {}
+
 PERMISSION_TIMEOUT = 120  # seconds
 MAX_SESSIONS_PER_USER = 5
 
@@ -71,6 +74,7 @@ def _get_user_sessions(user_id: int) -> list[dict]:
                 "agent_key": session.agent_key,
                 "mode": session.mode,
                 "is_busy": session.is_busy,
+                "server_name": session.server_name,
             })
     return result
 
@@ -172,6 +176,8 @@ async def chat_websocket(ws: WebSocket, token: str = Query(...)):
                 await _send(ws, {"event": "sessions_list", "sessions": sessions})
             elif action == "resolve_permission":
                 _handle_resolve_permission(msg)
+            elif action == "abort_prompt":
+                _spawn(_handle_abort_prompt(ws, user_id, msg))
             else:
                 await _send(ws, {"event": "error", "message": f"Unknown action: {action}"})
 
@@ -192,6 +198,7 @@ async def _handle_start_session(
 ) -> None:
     agent_key = msg.get("agent_key", DEFAULT_AGENT)
     mode = msg.get("mode", DEFAULT_MODE)
+    server_name = msg.get("server_name")  # From frontend's selected server
 
     # Check slot limit
     slots = _user_slots.get(user_id, [])
@@ -222,6 +229,7 @@ async def _handle_start_session(
             mode=mode,
             platform="web",
             lazy_context=True,  # Don't block — inject context on first message
+            server_name=server_name,
         )
 
         # Append mode-specific assistant context (e.g. agent_builder instructions)
@@ -237,6 +245,7 @@ async def _handle_start_session(
             "slot_id": slot_id,
             "agent_key": agent_key,
             "mode": mode,
+            "server_name": session.server_name,
         })
     except Exception as e:
         log.exception("Failed to start chat session for user %d", user_id)
@@ -272,6 +281,11 @@ async def _handle_send_message(
         await _send(ws, {"event": "error", "message": "Agent is busy"})
         return
 
+    task_key = f"{user_id}:{slot_id}"
+    task = asyncio.current_task()
+    if task:
+        _active_prompt_tasks[task_key] = task
+
     try:
         async for event in session.prompt_stream(text):
             if isinstance(event, TextChunk):
@@ -305,6 +319,8 @@ async def _handle_send_message(
                     "slot_id": slot_id,
                     "stop_reason": event.stop_reason,
                 })
+    except asyncio.CancelledError:
+        await _send(ws, {"event": "prompt_done", "slot_id": slot_id, "stop_reason": "cancelled"})
     except RuntimeError as e:
         await _send(ws, {"event": "error", "slot_id": slot_id, "message": str(e)})
         await _send(ws, {"event": "prompt_done", "slot_id": slot_id, "stop_reason": "error"})
@@ -312,6 +328,23 @@ async def _handle_send_message(
         log.exception("Error streaming prompt for user %d", user_id)
         await _send(ws, {"event": "error", "slot_id": slot_id, "message": "Stream error"})
         await _send(ws, {"event": "prompt_done", "slot_id": slot_id, "stop_reason": "error"})
+    finally:
+        _active_prompt_tasks.pop(task_key, None)
+
+
+async def _handle_abort_prompt(ws: WebSocket, user_id: int, msg: dict) -> None:
+    slot_id = msg.get("slot_id", "")
+    if not slot_id:
+        await _send(ws, {"event": "error", "message": "No slot_id"})
+        return
+
+    task_key = f"{user_id}:{slot_id}"
+    task = _active_prompt_tasks.get(task_key)
+    if task and not task.done():
+        task.cancel()
+    else:
+        # No active task — send prompt_done anyway so frontend resets
+        await _send(ws, {"event": "prompt_done", "slot_id": slot_id, "stop_reason": "cancelled"})
 
 
 async def _handle_destroy_session(ws: WebSocket, user_id: int, msg: dict) -> None:

--- a/condor/web/routes/chat_ws.py
+++ b/condor/web/routes/chat_ws.py
@@ -338,7 +338,9 @@ async def _handle_abort_prompt(ws: WebSocket, user_id: int, msg: dict) -> None:
         await _send(ws, {"event": "error", "message": "No slot_id"})
         return
 
-    # Abort the ACP-level prompt so stale events don't leak into the next message
+    # Abort the ACP-level prompt so stale events don't leak into the next message.
+    # session.abort() sets an event flag that makes prompt_stream break out on the
+    # next iteration, triggering its finally block to release the lock properly.
     session_key = _session_key(user_id, slot_id)
     session = get_session(session_key)
     if session:
@@ -348,8 +350,12 @@ async def _handle_abort_prompt(ws: WebSocket, user_id: int, msg: dict) -> None:
     task = _active_prompt_tasks.get(task_key)
     if task and not task.done():
         task.cancel()
-        # Don't send prompt_done here — the CancelledError handler in
-        # _handle_send_message already sends it when the task is cancelled.
+        # Wait briefly for the task to finish so the lock is released
+        # before the next message can acquire it.
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout=3)
+        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+            pass
     else:
         # No active task to cancel — send prompt_done directly so the frontend resets
         await _send(ws, {"event": "prompt_done", "slot_id": slot_id, "stop_reason": "cancelled"})

--- a/condor/web/routes/controller_performance.py
+++ b/condor/web/routes/controller_performance.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from config_manager import get_config_manager
+from condor.web.auth import get_current_user
+from condor.web.models import (
+    BotRunInfo,
+    BotRunsResponse,
+    ControllerPerformanceHistoryResponse,
+    ControllerPerformanceLatestResponse,
+    ControllerPerformanceSnapshot,
+    WebUser,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["controller-performance"])
+
+
+# ── Helpers ──
+
+
+def _parse_snapshot(raw: dict) -> ControllerPerformanceSnapshot:
+    """Normalize a raw performance snapshot dict into our model."""
+    perf = raw.get("performance", raw)
+    if not isinstance(perf, dict):
+        perf = {}
+
+    return ControllerPerformanceSnapshot(
+        timestamp=str(raw.get("timestamp", "")),
+        bot_name=raw.get("bot_name", ""),
+        controller_id=raw.get("controller_id", ""),
+        controller_name=raw.get("controller_name", ""),
+        connector=raw.get("connector", raw.get("connector_name", "")),
+        trading_pair=raw.get("trading_pair", ""),
+        realized_pnl_quote=float(perf.get("realized_pnl_quote", 0) or 0),
+        unrealized_pnl_quote=float(perf.get("unrealized_pnl_quote", 0) or 0),
+        global_pnl_quote=float(perf.get("global_pnl_quote", 0) or 0),
+        global_pnl_pct=float(perf.get("global_pnl_pct", 0) or 0),
+        volume_traded=float(perf.get("volume_traded", 0) or 0),
+        close_type_counts=perf.get("close_type_counts", {}),
+        positions_summary=perf.get("positions_summary", []),
+        custom_info=perf.get("custom_info", raw.get("custom_info", {})),
+    )
+
+
+def _parse_bot_run(raw: dict, perf_by_bot: dict[str, dict] | None = None) -> BotRunInfo:
+    """Normalize a raw bot run dict into our model."""
+    bot_name = raw.get("bot_name", "")
+    realized = 0.0
+    unrealized = 0.0
+    volume = 0.0
+    num_controllers = 0
+
+    if perf_by_bot and bot_name in perf_by_bot:
+        agg = perf_by_bot[bot_name]
+        realized = agg.get("realized_pnl_quote", 0.0)
+        unrealized = agg.get("unrealized_pnl_quote", 0.0)
+        volume = agg.get("volume_traded", 0.0)
+        num_controllers = agg.get("num_controllers", 0)
+
+    return BotRunInfo(
+        bot_name=bot_name,
+        account_name=raw.get("account_name", ""),
+        strategy_type=raw.get("strategy_type", ""),
+        strategy_name=raw.get("strategy_name", ""),
+        run_status=raw.get("run_status", raw.get("status", "")),
+        deployment_status=raw.get("deployment_status", ""),
+        created_at=str(raw["created_at"]) if raw.get("created_at") else None,
+        stopped_at=str(raw["stopped_at"]) if raw.get("stopped_at") else None,
+        realized_pnl_quote=realized,
+        unrealized_pnl_quote=unrealized,
+        global_pnl_quote=realized + unrealized,
+        volume_traded=volume,
+        num_controllers=num_controllers,
+    )
+
+
+# ── Bot Runs ──
+
+
+@router.get(
+    "/servers/{name}/bot-runs",
+    response_model=BotRunsResponse,
+)
+async def get_bot_runs(
+    name: str,
+    bot_name: Optional[str] = Query(None),
+    account_name: Optional[str] = Query(None),
+    strategy_type: Optional[str] = Query(None),
+    strategy_name: Optional[str] = Query(None),
+    run_status: Optional[str] = Query(None),
+    deployment_status: Optional[str] = Query(None),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    user: WebUser = Depends(get_current_user),
+):
+    """Get bot runs with optional filtering."""
+    import asyncio
+
+    cm = get_config_manager()
+    if not cm.has_server_access(user.id, name):
+        raise HTTPException(status_code=403, detail="No access")
+
+    client = await cm.get_client(name)
+
+    async def _fetch_runs():
+        return await client.bot_orchestration.get_bot_runs(
+            bot_name=bot_name,
+            account_name=account_name,
+            strategy_type=strategy_type,
+            strategy_name=strategy_name,
+            run_status=run_status,
+            deployment_status=deployment_status,
+            limit=limit,
+            offset=offset,
+        )
+
+    async def _fetch_perf() -> dict[str, dict]:
+        """Fetch latest controller performance and aggregate by bot_name."""
+        try:
+            result = await client.bot_orchestration.get_latest_controller_performance()
+            snapshots = _extract_snapshots(result)
+            agg: dict[str, dict] = {}
+            for snap in snapshots:
+                bn = snap.get("bot_name", "")
+                if not bn:
+                    continue
+                perf = snap.get("performance", snap)
+                if not isinstance(perf, dict):
+                    perf = {}
+                if bn not in agg:
+                    agg[bn] = {"realized_pnl_quote": 0.0, "unrealized_pnl_quote": 0.0, "volume_traded": 0.0, "num_controllers": 0}
+                agg[bn]["realized_pnl_quote"] += float(perf.get("realized_pnl_quote", 0) or 0)
+                agg[bn]["unrealized_pnl_quote"] += float(perf.get("unrealized_pnl_quote", 0) or 0)
+                agg[bn]["volume_traded"] += float(perf.get("volume_traded", 0) or 0)
+                agg[bn]["num_controllers"] += 1
+            return agg
+        except Exception:
+            logger.debug("Could not fetch controller performance for bot runs enrichment")
+            return {}
+
+    try:
+        result, perf_by_bot = await asyncio.gather(_fetch_runs(), _fetch_perf())
+    except Exception as e:
+        logger.warning("Failed to fetch bot runs from '%s': %s", name, e)
+        raise HTTPException(status_code=502, detail=str(e))
+
+    runs_list = _extract_runs_list(result)
+
+    return BotRunsResponse(
+        runs=[_parse_bot_run(r, perf_by_bot) for r in runs_list],
+        total=len(runs_list),
+    )
+
+
+@router.delete(
+    "/servers/{name}/bot-runs/{bot_name}",
+)
+async def delete_bot_run(
+    name: str,
+    bot_name: str,
+    user: WebUser = Depends(get_current_user),
+):
+    """Delete an archived bot run."""
+    cm = get_config_manager()
+    if not cm.has_server_access(user.id, name):
+        raise HTTPException(status_code=403, detail="No access")
+
+    client = await cm.get_client(name)
+
+    try:
+        result = await client.bot_orchestration._delete(
+            f"/bot-orchestration/bot-runs/{bot_name}"
+        )
+    except Exception as e:
+        logger.warning("Failed to delete bot run '%s' from '%s': %s", bot_name, name, e)
+        raise HTTPException(status_code=502, detail=str(e))
+
+    return {"deleted": True, "bot_name": bot_name, "result": result}
+
+
+def _extract_runs_list(result) -> list[dict]:
+    """Normalize bot runs API response into a list of dicts."""
+    if isinstance(result, list):
+        return [r for r in result if isinstance(r, dict)]
+    if isinstance(result, dict):
+        data = result.get("data", result.get("runs", result))
+        if isinstance(data, list):
+            return [r for r in data if isinstance(r, dict)]
+        if isinstance(data, dict):
+            # Dict keyed by bot_name
+            return [
+                {"bot_name": k, **v} for k, v in data.items() if isinstance(v, dict)
+            ]
+    return []
+
+
+# ── Controller Performance: Latest ──
+
+
+@router.get(
+    "/servers/{name}/controller-performance/latest",
+    response_model=ControllerPerformanceLatestResponse,
+)
+async def get_latest_controller_performance(
+    name: str,
+    bot_name: Optional[str] = Query(None),
+    user: WebUser = Depends(get_current_user),
+):
+    """Get the most recent performance snapshot for each bot/controller."""
+    cm = get_config_manager()
+    if not cm.has_server_access(user.id, name):
+        raise HTTPException(status_code=403, detail="No access")
+
+    client = await cm.get_client(name)
+
+    try:
+        result = await client.bot_orchestration.get_latest_controller_performance(
+            bot_name=bot_name,
+        )
+    except Exception as e:
+        logger.warning("Failed to fetch latest controller performance from '%s': %s", name, e)
+        return ControllerPerformanceLatestResponse(
+            server_online=False,
+            error_hint=f"Connection error: {e}",
+        )
+
+    snapshots = _extract_snapshots(result)
+
+    return ControllerPerformanceLatestResponse(
+        snapshots=[_parse_snapshot(s) for s in snapshots],
+    )
+
+
+# ── Controller Performance: History ──
+
+
+@router.get(
+    "/servers/{name}/controller-performance/history",
+    response_model=ControllerPerformanceHistoryResponse,
+)
+async def get_controller_performance_history(
+    name: str,
+    bot_name: Optional[str] = Query(None),
+    controller_id: Optional[str] = Query(None),
+    start_time: Optional[str] = Query(None),
+    end_time: Optional[str] = Query(None),
+    interval: str = Query("5m"),
+    limit: Optional[int] = Query(None, ge=1, le=5000),
+    cursor: Optional[str] = Query(None),
+    user: WebUser = Depends(get_current_user),
+):
+    """Get historical controller performance with pagination and interval sampling."""
+    cm = get_config_manager()
+    if not cm.has_server_access(user.id, name):
+        raise HTTPException(status_code=403, detail="No access")
+
+    client = await cm.get_client(name)
+
+    try:
+        result = await client.bot_orchestration.get_controller_performance_history(
+            bot_name=bot_name,
+            controller_id=controller_id,
+            start_time=start_time,
+            end_time=end_time,
+            interval=interval,
+            limit=limit,
+            cursor=cursor,
+        )
+    except Exception as e:
+        logger.warning("Failed to fetch controller performance history from '%s': %s", name, e)
+        return ControllerPerformanceHistoryResponse(
+            server_online=False,
+            error_hint=f"Connection error: {e}",
+        )
+
+    snapshots = _extract_snapshots(result)
+    next_cursor = None
+    if isinstance(result, dict):
+        next_cursor = result.get("next_cursor") or result.get("cursor")
+
+    return ControllerPerformanceHistoryResponse(
+        snapshots=[_parse_snapshot(s) for s in snapshots],
+        next_cursor=next_cursor,
+        interval=interval,
+    )
+
+
+def _extract_snapshots(result) -> list[dict]:
+    """Normalize performance API response into a list of snapshot dicts."""
+    if isinstance(result, list):
+        return [s for s in result if isinstance(s, dict)]
+    if isinstance(result, dict):
+        data = result.get("data", result.get("snapshots", result.get("records", [])))
+        if isinstance(data, list):
+            return [s for s in data if isinstance(s, dict)]
+        if isinstance(data, dict):
+            # Could be keyed by controller_id
+            out = []
+            for key, val in data.items():
+                if isinstance(val, dict):
+                    val.setdefault("controller_id", key)
+                    out.append(val)
+                elif isinstance(val, list):
+                    for item in val:
+                        if isinstance(item, dict):
+                            item.setdefault("controller_id", key)
+                            out.append(item)
+            return out
+    return []

--- a/condor/web/routes/controller_performance.py
+++ b/condor/web/routes/controller_performance.py
@@ -65,12 +65,13 @@ def _parse_bot_run(raw: dict, perf_by_bot: dict[str, dict] | None = None) -> Bot
 
     return BotRunInfo(
         bot_name=bot_name,
+        bot_run_id=raw.get("id"),
         account_name=raw.get("account_name", ""),
         strategy_type=raw.get("strategy_type", ""),
         strategy_name=raw.get("strategy_name", ""),
         run_status=raw.get("run_status", raw.get("status", "")),
         deployment_status=raw.get("deployment_status", ""),
-        created_at=str(raw["created_at"]) if raw.get("created_at") else None,
+        created_at=str(raw["deployed_at"]) if raw.get("deployed_at") else None,
         stopped_at=str(raw["stopped_at"]) if raw.get("stopped_at") else None,
         realized_pnl_quote=realized,
         unrealized_pnl_quote=unrealized,
@@ -159,14 +160,14 @@ async def get_bot_runs(
 
 
 @router.delete(
-    "/servers/{name}/bot-runs/{bot_name}",
+    "/servers/{name}/bot-runs/{bot_run_id}",
 )
 async def delete_bot_run(
     name: str,
-    bot_name: str,
+    bot_run_id: int,
     user: WebUser = Depends(get_current_user),
 ):
-    """Delete an archived bot run."""
+    """Delete an archived bot run by its numeric ID."""
     cm = get_config_manager()
     if not cm.has_server_access(user.id, name):
         raise HTTPException(status_code=403, detail="No access")
@@ -174,14 +175,12 @@ async def delete_bot_run(
     client = await cm.get_client(name)
 
     try:
-        result = await client.bot_orchestration._delete(
-            f"/bot-orchestration/bot-runs/{bot_name}"
-        )
+        result = await client.bot_orchestration.delete_bot_run(bot_run_id)
     except Exception as e:
-        logger.warning("Failed to delete bot run '%s' from '%s': %s", bot_name, name, e)
+        logger.warning("Failed to delete bot run %d from '%s': %s", bot_run_id, name, e)
         raise HTTPException(status_code=502, detail=str(e))
 
-    return {"deleted": True, "bot_name": bot_name, "result": result}
+    return {"deleted": True, "bot_run_id": bot_run_id, "result": result}
 
 
 def _extract_runs_list(result) -> list[dict]:

--- a/condor/web/routes/market.py
+++ b/condor/web/routes/market.py
@@ -93,6 +93,29 @@ async def get_price(
     raise HTTPException(status_code=502, detail="Unexpected response format")
 
 
+@router.post("/servers/{name}/rate-oracle/rates")
+async def get_rate_oracle_rates(
+    name: str,
+    body: dict,
+    user: WebUser = Depends(get_current_user),
+):
+    cm = get_config_manager()
+    if not cm.has_server_access(user.id, name):
+        raise HTTPException(status_code=403, detail="No access")
+
+    trading_pairs = body.get("trading_pairs", [])
+    if not trading_pairs:
+        return {"rates": {}}
+
+    client = await cm.get_client(name)
+    try:
+        result = await client.rate_oracle.get_rates(trading_pairs=trading_pairs)
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=str(e))
+
+    return result
+
+
 @router.get("/servers/{name}/market/trading-rules", response_model=TradingRulesResponse)
 async def get_trading_rules(
     name: str,

--- a/condor/web/routes/market.py
+++ b/condor/web/routes/market.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 # Simple TTL cache for candle data
 _candle_cache: dict[tuple, tuple[float, list]] = {}  # key -> (timestamp, data)
-_CANDLE_CACHE_TTL = 5.0  # seconds
+_CANDLE_CACHE_TTL = 30.0  # seconds
 from condor.web.auth import get_current_user
 from condor.web.models import (
     CandleData,
@@ -205,7 +205,10 @@ async def get_candles(
     if not cm.has_server_access(user.id, name):
         raise HTTPException(status_code=403, detail="No access")
 
-    cache_key = (name, connector, trading_pair, interval, limit, start_time, end_time)
+    # Bucket start_time to 60s intervals so near-identical requests share cache
+    bucketed_start = int(start_time // 60) * 60 if start_time is not None else None
+    bucketed_end = int(end_time // 60) * 60 if end_time is not None else None
+    cache_key = (name, connector, trading_pair, interval, limit, bucketed_start, bucketed_end)
     now = time.monotonic()
     cached = _candle_cache.get(cache_key)
     if cached and (now - cached[0]) < _CANDLE_CACHE_TTL:

--- a/condor/web/routes/portfolio.py
+++ b/condor/web/routes/portfolio.py
@@ -53,7 +53,11 @@ _last_request_time: dict[str, float] = {}  # server -> last request ts
 
 
 @router.get("/servers/{name}/portfolio", response_model=PortfolioResponse)
-async def get_portfolio(name: str, user: WebUser = Depends(get_current_user)):
+async def get_portfolio(
+    name: str,
+    refresh: bool = Query(False),
+    user: WebUser = Depends(get_current_user),
+):
     cm = get_config_manager()
     if not cm.has_server_access(user.id, name):
         raise HTTPException(status_code=403, detail="No access to this server")
@@ -61,7 +65,16 @@ async def get_portfolio(name: str, user: WebUser = Depends(get_current_user)):
     from condor.server_data_service import ServerDataType, get_server_data_service
 
     try:
-        state = await get_server_data_service().get_or_fetch(name, ServerDataType.PORTFOLIO)
+        if refresh:
+            # Bypass SDS cache — force exchange re-fetch via Hummingbot
+            from condor.fetchers.portfolio import fetch_portfolio_refreshed
+
+            client = await cm.get_client(name)
+            state = await fetch_portfolio_refreshed(client)
+            # Update SDS cache so subsequent non-refresh reads get fresh data
+            get_server_data_service().put(name, ServerDataType.PORTFOLIO, state)
+        else:
+            state = await get_server_data_service().get_or_fetch(name, ServerDataType.PORTFOLIO)
     except Exception as e:
         logger.warning("Portfolio fetch exception for %s: %s", name, e)
         raise HTTPException(status_code=502, detail=f"Failed to get portfolio: {e}")

--- a/condor/web/routes/positions.py
+++ b/condor/web/routes/positions.py
@@ -125,6 +125,37 @@ async def get_consolidated_positions(
         for pos, source_name in bot_raw
     ]
 
+    # Enrich positions missing current_price (the positions_summary endpoint doesn't provide it)
+    all_positions = executor_positions + bot_positions
+    pairs_needing_price = {}
+    for pos in all_positions:
+        if pos["current_price"] == 0 and pos["connector_name"] and pos["trading_pair"]:
+            key = (pos["connector_name"], pos["trading_pair"])
+            pairs_needing_price[key] = None
+
+    if pairs_needing_price:
+        try:
+            client = await cm.get_client(name)
+            price_tasks = [
+                client.market_data.get_prices(connector_name=conn, trading_pairs=pair)
+                for conn, pair in pairs_needing_price
+            ]
+            results = await asyncio.gather(*price_tasks, return_exceptions=True)
+            for (conn, pair), result in zip(pairs_needing_price, results):
+                if isinstance(result, dict):
+                    price = result.get("prices", {}).get(pair)
+                    if price:
+                        pairs_needing_price[(conn, pair)] = float(price)
+
+            for pos in all_positions:
+                if pos["current_price"] == 0:
+                    key = (pos["connector_name"], pos["trading_pair"])
+                    price = pairs_needing_price.get(key)
+                    if price:
+                        pos["current_price"] = price
+        except Exception as e:
+            logger.warning("Failed to enrich positions with current prices: %s", e)
+
     return {
         "executor_positions": executor_positions,
         "bot_positions": bot_positions,

--- a/condor/web/routes/reports.py
+++ b/condor/web/routes/reports.py
@@ -42,6 +42,6 @@ async def get_report_detail(report_id: str, user: WebUser = Depends(get_current_
 
 @router.delete("/{report_id}")
 async def delete_report_endpoint(report_id: str, user: WebUser = Depends(get_current_user)):
-    if not delete_report(report_id):
+    if not await delete_report(report_id):
         raise HTTPException(404, "Report not found")
     return {"deleted": True}

--- a/condor/web/routes/routines.py
+++ b/condor/web/routes/routines.py
@@ -208,8 +208,12 @@ async def get_routine_source(
         raise HTTPException(404, "Routine not found")
     try:
         source_file = inspect.getfile(routine.run_fn)
-        source = Path(source_file).read_text()
-        return {"filename": Path(source_file).name, "source": source}
+        source_path = Path(source_file).resolve()
+        routines_dir = Path("routines").resolve()
+        if not str(source_path).startswith(str(routines_dir)):
+            raise HTTPException(403, "Source not available")
+        source = source_path.read_text()
+        return {"filename": source_path.name, "source": source}
     except (TypeError, OSError) as e:
         raise HTTPException(404, f"Source not available: {e}")
 

--- a/condor/web/routes/routines.py
+++ b/condor/web/routes/routines.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
+from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
@@ -191,6 +193,25 @@ async def get_field_options(
             log.warning(f"Failed to fetch controller configs: {e}")
             return {"options": []}
     return {"options": []}
+
+
+@router.get("/{routine_name:path}/source")
+async def get_routine_source(
+    routine_name: str,
+    user: WebUser = Depends(get_current_user),
+):
+    """Return the source code of a routine."""
+    store = get_routine_store()
+    all_routines = store._discover_all()
+    routine = all_routines.get(routine_name)
+    if not routine:
+        raise HTTPException(404, "Routine not found")
+    try:
+        source_file = inspect.getfile(routine.run_fn)
+        source = Path(source_file).read_text()
+        return {"filename": Path(source_file).name, "source": source}
+    except (TypeError, OSError) as e:
+        raise HTTPException(404, f"Source not available: {e}")
 
 
 @router.get("/{routine_name:path}/reports")

--- a/condor/web/ws_manager.py
+++ b/condor/web/ws_manager.py
@@ -749,6 +749,17 @@ class WebSocketManager:
         if not has_subscribers:
             return
 
+        # Skip SDS-triggered broadcast for channels with active WS streams
+        # (the WS stream handler already broadcasts directly)
+        if dt_name == "BOTS_STATUS" and channel in self._bots_ws_tasks:
+            task = self._bots_ws_tasks.get(channel)
+            if task and not task.done():
+                return
+        if dt_name == "EXECUTORS" and channel in self._executor_ws_tasks:
+            task = self._executor_ws_tasks.get(channel)
+            if task and not task.done():
+                return
+
         # Transform raw data to match REST endpoint response shapes
         if dt_name == "BOTS_STATUS":
             try:

--- a/condor/web/ws_manager.py
+++ b/condor/web/ws_manager.py
@@ -131,6 +131,7 @@ class WebSocketManager:
         self._bots_ws_tasks: dict[str, asyncio.Task] = {}
         self._positions_ws_tasks: dict[str, asyncio.Task] = {}
         self._performance_ws_tasks: dict[str, asyncio.Task] = {}
+        self._controller_perf_tasks: dict[str, asyncio.Task] = {}
         self._sds_listener_registered = False
         # Track SDS subscriptions: channel -> CacheKey
         self._sds_subscriptions: dict[str, Any] = {}
@@ -245,6 +246,11 @@ class WebSocketManager:
                 task.cancel()
         self._performance_ws_tasks.clear()
 
+        for task in self._controller_perf_tasks.values():
+            if not task.done():
+                task.cancel()
+        self._controller_perf_tasks.clear()
+
         if self._cleanup_task and not self._cleanup_task.done():
             self._cleanup_task.cancel()
             self._cleanup_task = None
@@ -299,6 +305,8 @@ class WebSocketManager:
                     self._maybe_stop_positions_ws_stream(channel)
                 elif channel.startswith("performance_ws:"):
                     self._maybe_stop_performance_ws_stream(channel)
+                elif channel.startswith("controller_perf:"):
+                    self._maybe_stop_controller_perf_stream(channel)
                 else:
                     self._maybe_unsub_sds(channel)
 
@@ -366,6 +374,10 @@ class WebSocketManager:
                 if channel in self._last_data:
                     await self._send(conn, channel, self._last_data[channel])
                 self._ensure_performance_ws_stream(channel)
+            elif channel.startswith("controller_perf:"):
+                if channel in self._last_data:
+                    await self._send(conn, channel, self._last_data[channel])
+                self._ensure_controller_perf_stream(channel)
             else:
                 if channel in self._last_data:
                     await self._send(conn, channel, self._last_data[channel])
@@ -387,6 +399,8 @@ class WebSocketManager:
                 self._maybe_stop_positions_ws_stream(channel)
             elif channel.startswith("performance_ws:"):
                 self._maybe_stop_performance_ws_stream(channel)
+            elif channel.startswith("controller_perf:"):
+                self._maybe_stop_controller_perf_stream(channel)
             else:
                 self._maybe_unsub_sds(channel)
 
@@ -1555,6 +1569,78 @@ class WebSocketManager:
                 logger.warning("Performance WS stream error for %s: %s, reconnecting in %ds...", channel, e, backoff)
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 60)
+
+
+    # -- Controller Performance polling stream --
+
+    def _ensure_controller_perf_stream(self, channel: str) -> None:
+        if channel in self._controller_perf_tasks and not self._controller_perf_tasks[channel].done():
+            return
+        self._controller_perf_tasks[channel] = asyncio.create_task(
+            self._controller_perf_stream(channel)
+        )
+        logger.info("Started controller performance stream for %s", channel)
+
+    def _maybe_stop_controller_perf_stream(self, channel: str) -> None:
+        for conn in self._connections:
+            if channel in conn.channels:
+                return
+        task = self._controller_perf_tasks.pop(channel, None)
+        if task and not task.done():
+            task.cancel()
+            logger.info("Stopped controller performance stream for %s", channel)
+
+    async def _controller_perf_stream(self, channel: str) -> None:
+        """Poll latest controller performance every 30s and broadcast snapshots."""
+        parts = channel.split(":")
+        if len(parts) < 2:
+            return
+        server_name = parts[1]
+
+        from config_manager import get_config_manager
+
+        cm = get_config_manager()
+        backoff = 5
+
+        while True:
+            try:
+                if not any(channel in c.channels for c in self._connections):
+                    logger.info("No subscribers for %s, stopping controller perf stream", channel)
+                    self._controller_perf_tasks.pop(channel, None)
+                    return
+
+                client = await cm.get_client(server_name)
+                result = await client.bot_orchestration.get_latest_controller_performance()
+
+                # Normalize to list of snapshots
+                snapshots = []
+                if isinstance(result, list):
+                    snapshots = result
+                elif isinstance(result, dict):
+                    data = result.get("data", result.get("snapshots", result.get("records", [])))
+                    if isinstance(data, list):
+                        snapshots = data
+                    elif isinstance(data, dict):
+                        for key, val in data.items():
+                            if isinstance(val, dict):
+                                val.setdefault("controller_id", key)
+                                snapshots.append(val)
+
+                if snapshots:
+                    await self._broadcast_update(channel, {"snapshots": snapshots})
+                    backoff = 5
+
+                await asyncio.sleep(30)
+
+            except asyncio.CancelledError:
+                return
+            except Exception as e:
+                logger.warning(
+                    "Controller perf stream error for %s: %s, retrying in %ds...",
+                    channel, e, backoff,
+                )
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 120)
 
 
 # -- Singleton --

--- a/condor/web/ws_manager.py
+++ b/condor/web/ws_manager.py
@@ -690,6 +690,44 @@ class WebSocketManager:
             "server_online": True,
         }
 
+    @staticmethod
+    def _overlay_stopping_state(server_name: str, data: dict) -> None:
+        """Apply transitional 'stopping' state to WS broadcast data."""
+        from condor.web.routes.bots import (
+            clear_bot_stopping,
+            get_stopping_bots,
+            get_stopping_controllers,
+            _stopping_controllers,
+        )
+
+        stopping_bot_names = get_stopping_bots(server_name)
+        stopping_ctrl_keys = get_stopping_controllers(server_name)
+
+        if not stopping_bot_names and not stopping_ctrl_keys:
+            return
+
+        active_bot_names = set()
+        for bot in data.get("bots", []):
+            active_bot_names.add(bot.get("bot_name", ""))
+            if bot.get("bot_name") in stopping_bot_names:
+                if bot.get("status") in ("running",):
+                    bot["status"] = "stopping"
+                else:
+                    clear_bot_stopping(server_name, bot["bot_name"])
+
+        # Clear stopping entries for bots that disappeared (fully stopped)
+        for sbn in list(stopping_bot_names):
+            if sbn not in active_bot_names:
+                clear_bot_stopping(server_name, sbn)
+
+        for ctrl in data.get("controllers", []):
+            key = f"{ctrl.get('bot_name')}:{ctrl.get('controller_id')}"
+            if key in stopping_ctrl_keys:
+                if ctrl.get("config", {}).get("manual_kill_switch") is True:
+                    _stopping_controllers.pop(f"{server_name}:{key}", None)
+                else:
+                    ctrl["status"] = "stopping"
+
     def _on_data_update(self, server_name: str, cache_key: str, data_type: Any, value: Any) -> None:
         """Called by SDS when cache is updated. Maps to WS channels and broadcasts."""
         dt_name = data_type.name if hasattr(data_type, "name") else str(data_type)
@@ -715,6 +753,8 @@ class WebSocketManager:
         if dt_name == "BOTS_STATUS":
             try:
                 value = self._transform_bots(value)
+                # Overlay transitional "stopping" state from Condor's in-memory store
+                self._overlay_stopping_state(server_name, value)
             except Exception as e:
                 logger.debug("Failed to transform bots data for WS: %s", e)
                 return
@@ -1416,6 +1456,7 @@ class WebSocketManager:
                             get_server_data_service().put(server_name, ServerDataType.BOTS_STATUS, raw_data)
                             try:
                                 data = self._transform_bots(raw_data)
+                                self._overlay_stopping_state(server_name, data)
                                 await self._broadcast_update(channel, data)
                             except Exception as e:
                                 logger.debug("Failed to transform bots WS data: %s", e)

--- a/condor/web/ws_manager.py
+++ b/condor/web/ws_manager.py
@@ -1199,10 +1199,10 @@ class WebSocketManager:
         cm = get_config_manager()
         backoff = 5
 
-        # Try SDS cache first (pre-warmed by auto_subscribe_servers on startup)
-        if channel not in self._last_data:
-            from condor.server_data_service import ServerDataType, get_server_data_service
+        # Try SDS cache first (pre-warmed by auto_subscribe_servers or REST prefetch)
+        from condor.server_data_service import ServerDataType, get_server_data_service
 
+        if channel not in self._last_data:
             sds = get_server_data_service()
             cached = sds.get(server_name, ServerDataType.EXECUTORS)
             if cached is not None:
@@ -1213,6 +1213,23 @@ class WebSocketManager:
                         "Executor SDS cache hit: %d executors for %s",
                         len(executors), channel,
                     )
+
+        # Wait briefly for SDS to be populated by a concurrent REST request
+        # (usePrefetchData fires getExecutors which calls get_or_fetch on SDS)
+        if channel not in self._last_data:
+            sds = get_server_data_service()
+            for _ in range(6):  # up to 3 seconds
+                await asyncio.sleep(0.5)
+                cached = sds.get(server_name, ServerDataType.EXECUTORS)
+                if cached is not None:
+                    executors = self._transform_executors(cached)
+                    if executors:
+                        await self.broadcast(channel, executors)
+                        logger.info(
+                            "Executor SDS cache populated during wait: %d executors for %s",
+                            len(executors), channel,
+                        )
+                    break
 
         # Progressive pre-fetch only if we still have no data
         if channel not in self._last_data:

--- a/condor/web/ws_manager.py
+++ b/condor/web/ws_manager.py
@@ -1272,12 +1272,13 @@ class WebSocketManager:
                 async with client.ws.executors() as ws:
                     await ws.subscribe_executors(update_interval=2.0)
                     logger.info("Executor WS subscribed: %s", channel)
-                    backoff = 5  # Reset on successful connection
+                    got_message = False
                     async for msg in ws:
                         if not any(channel in c.channels for c in self._connections):
                             logger.info("No subscribers for %s, closing executor stream", channel)
                             return
 
+                        got_message = True
                         msg_type = msg.get("type")
                         if msg_type == "executors":
                             raw_data = msg.get("data", [])
@@ -1289,6 +1290,14 @@ class WebSocketManager:
                             error_msg = msg.get("message", "unknown error")
                             logger.warning("Executor stream error for %s: %s", channel, error_msg)
                             break
+
+                    # Connection closed cleanly — apply backoff if it was short-lived
+                    if got_message:
+                        backoff = 5
+                    else:
+                        logger.warning("Executor stream closed immediately for %s, reconnecting in %ds...", channel, backoff)
+                        await asyncio.sleep(backoff)
+                        backoff = min(backoff * 2, 60)
 
             except asyncio.CancelledError:
                 return

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -868,9 +868,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -888,9 +885,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -908,9 +902,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -928,9 +919,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -948,9 +936,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -968,9 +953,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^19.2.4",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.13.2",
+        "recharts": "^3.8.1",
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
@@ -775,6 +776,42 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
@@ -1037,6 +1074,18 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
@@ -1348,6 +1397,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1442,6 +1554,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2006,6 +2124,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/codemirror": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
@@ -2105,6 +2232,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2121,6 +2369,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -2194,6 +2448,16 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2411,6 +2675,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -2659,6 +2929,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2691,6 +2971,15 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -4325,6 +4614,13 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-markdown": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
@@ -4350,6 +4646,29 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router": {
@@ -4388,6 +4707,51 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/remark-gfm": {
@@ -4455,6 +4819,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -4656,6 +5026,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -4901,6 +5277,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -4927,6 +5312,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.2",
+    "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {

--- a/frontend/src/components/agent/AgentControls.tsx
+++ b/frontend/src/components/agent/AgentControls.tsx
@@ -160,7 +160,7 @@ export function StartSessionDialog({
           <div className={`grid gap-4 ${executionMode === "loop" ? "grid-cols-2" : "grid-cols-1"}`}>
             <div>
               <label className={labelClass}>
-                Budget (USDT)
+                Total Amount Quote
               </label>
               <input
                 type="number"

--- a/frontend/src/components/agent/AgentRoutinesTab.tsx
+++ b/frontend/src/components/agent/AgentRoutinesTab.tsx
@@ -6,7 +6,7 @@ import {
   Minimize2,
   Play,
 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { type ReportSummary, type RoutineInfo, api } from "@/lib/api";
 import { useServer } from "@/hooks/useServer";
@@ -30,22 +30,57 @@ function formatAgo(iso: string): string {
 
 // ── Routine Card ──
 
+const STORAGE_KEY_PREFIX = "routine_config:";
+
+function loadSavedConfig(routineName: string): Record<string, unknown> | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY_PREFIX + routineName);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveConfig(routineName: string, values: Record<string, unknown>) {
+  try {
+    localStorage.setItem(STORAGE_KEY_PREFIX + routineName, JSON.stringify(values));
+  } catch { /* ignore */ }
+}
+
+function buildConfigValues(routine: RoutineInfo): Record<string, unknown> {
+  const saved = loadSavedConfig(routine.name);
+  const values: Record<string, unknown> = {};
+  for (const [key, field] of Object.entries(routine.fields)) {
+    values[key] = saved && key in saved ? saved[key] : field.default;
+  }
+  return values;
+}
+
 function RoutineCard({ routine }: { routine: RoutineInfo }) {
   const { server } = useServer();
   const qc = useQueryClient();
-  const [configValues, setConfigValues] = useState<Record<string, unknown>>({});
+  const [configValues, setConfigValues] = useState<Record<string, unknown>>(() =>
+    buildConfigValues(routine),
+  );
   const [expanded, setExpanded] = useState(false);
   const [activeInstanceId, setActiveInstanceId] = useState<string | null>(null);
   const isPolling = useRef(false);
 
-  // Reset config when routine changes
+  // Rebuild config when routine changes — merge saved values with current fields
   useEffect(() => {
-    const defaults: Record<string, unknown> = {};
-    for (const [key, field] of Object.entries(routine.fields)) {
-      defaults[key] = field.default;
-    }
-    setConfigValues(defaults);
+    setConfigValues(buildConfigValues(routine));
   }, [routine.name]);
+
+  const handleConfigChange = useCallback(
+    (key: string, value: unknown) => {
+      setConfigValues((prev) => {
+        const next = { ...prev, [key]: value };
+        saveConfig(routine.name, next);
+        return next;
+      });
+    },
+    [routine.name],
+  );
 
   // Poll active instance
   const { data: activeInstance } = useQuery({
@@ -118,9 +153,7 @@ function RoutineCard({ routine }: { routine: RoutineInfo }) {
           <RoutineConfigForm
             fields={routine.fields}
             values={configValues}
-            onChange={(key, value) =>
-              setConfigValues((prev) => ({ ...prev, [key]: value }))
-            }
+            onChange={handleConfigChange}
           />
         </div>
       )}

--- a/frontend/src/components/agent/AgentRoutinesTab.tsx
+++ b/frontend/src/components/agent/AgentRoutinesTab.tsx
@@ -9,52 +9,10 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { type ReportSummary, type RoutineInfo, api } from "@/lib/api";
+import { buildConfigValues, formatAgo, formatRoutineName, invalidateRoutineQueries, saveConfig } from "@/lib/routineUtils";
 import { useServer } from "@/hooks/useServer";
 import { RoutineConfigForm } from "@/components/routines/RoutineConfigForm";
 import { RoutineResultView } from "@/components/routines/RoutineResultView";
-
-// ── Helpers ──
-
-function formatName(name: string): string {
-  const display = name.includes("/") ? name.split("/").pop()! : name;
-  return display.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-}
-
-function formatAgo(iso: string): string {
-  const diff = (Date.now() - new Date(iso).getTime()) / 1000;
-  if (diff < 60) return `${Math.floor(diff)}s ago`;
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
-  return `${Math.floor(diff / 86400)}d ago`;
-}
-
-// ── Routine Card ──
-
-const STORAGE_KEY_PREFIX = "routine_config:";
-
-function loadSavedConfig(routineName: string): Record<string, unknown> | null {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY_PREFIX + routineName);
-    return raw ? JSON.parse(raw) : null;
-  } catch {
-    return null;
-  }
-}
-
-function saveConfig(routineName: string, values: Record<string, unknown>) {
-  try {
-    localStorage.setItem(STORAGE_KEY_PREFIX + routineName, JSON.stringify(values));
-  } catch { /* ignore */ }
-}
-
-function buildConfigValues(routine: RoutineInfo): Record<string, unknown> {
-  const saved = loadSavedConfig(routine.name);
-  const values: Record<string, unknown> = {};
-  for (const [key, field] of Object.entries(routine.fields)) {
-    values[key] = saved && key in saved ? saved[key] : field.default;
-  }
-  return values;
-}
 
 function RoutineCard({ routine }: { routine: RoutineInfo }) {
   const { server } = useServer();
@@ -99,8 +57,8 @@ function RoutineCard({ routine }: { routine: RoutineInfo }) {
     const status = activeInstance?.status;
     if (prevStatus.current === "running" && status && status !== "running") {
       isPolling.current = false;
-      // Invalidate agent reports so new report shows up
       qc.invalidateQueries({ queryKey: ["agent-reports"] });
+      invalidateRoutineQueries(qc, routine.name);
     }
     prevStatus.current = status;
   }, [activeInstance?.status, qc]);
@@ -126,7 +84,7 @@ function RoutineCard({ routine }: { routine: RoutineInfo }) {
           className="flex-1 text-left"
         >
           <h3 className="text-sm font-semibold text-[var(--color-text)]">
-            {formatName(routine.name)}
+            {formatRoutineName(routine.name)}
           </h3>
           <p className="mt-0.5 text-xs text-[var(--color-text-muted)]">
             {routine.description}

--- a/frontend/src/components/agent/AgentSessionContent.tsx
+++ b/frontend/src/components/agent/AgentSessionContent.tsx
@@ -11,6 +11,7 @@ import { AgentPnlChart, metricsToDataPoints } from "@/components/agent/AgentPnlC
 import { useAgentExecutors } from "@/hooks/useAgentExecutors";
 import { type AgentExecutorRow, type AgentPerformance, type ExecutorInfo, api } from "@/lib/api";
 import { type ParsedJournal, type ParsedSnapshot, parseSnapshot } from "@/lib/parse-agent";
+import { useRates } from "@/hooks/useRates";
 import { DetailPanel, ExecutorTable, type SortDir, type SortKey } from "@/pages/Executors";
 
 // ── Helper ──
@@ -149,6 +150,13 @@ export function SessionExecutors({
     }
     return merged;
   }, [restExecutors, wsExecutors]);
+
+  // Currency conversion
+  const quoteCurrencies = useMemo(
+    () => executorInfos.map((ex) => ex.trading_pair?.split("-")[1] || "USDT"),
+    [executorInfos],
+  );
+  const { formatPnlValue, formatValue, formatValueDetailed } = useRates(quoteCurrencies);
 
   // Fetch snapshots for bubble markers
   const { data: snapshotsData } = useQuery({
@@ -440,6 +448,9 @@ export function SessionExecutors({
           onClose={() => setSelectedExecutor(null)}
           onStop={() => {}}
           stopping={false}
+          rateFormatPnl={formatPnlValue}
+          rateFormatValue={formatValue}
+          rateFormatDetailed={formatValueDetailed}
         />
       )}
     </div>

--- a/frontend/src/components/agent/AgentSessionContent.tsx
+++ b/frontend/src/components/agent/AgentSessionContent.tsx
@@ -11,7 +11,7 @@ import { AgentPnlChart, metricsToDataPoints } from "@/components/agent/AgentPnlC
 import { useAgentExecutors } from "@/hooks/useAgentExecutors";
 import { type AgentExecutorRow, type AgentPerformance, type ExecutorInfo, api } from "@/lib/api";
 import { type ParsedJournal, type ParsedSnapshot, parseSnapshot } from "@/lib/parse-agent";
-import { ExecutorTable, type SortDir, type SortKey } from "@/pages/Executors";
+import { DetailPanel, ExecutorTable, type SortDir, type SortKey } from "@/pages/Executors";
 
 // ── Helper ──
 
@@ -40,148 +40,22 @@ function agentRowToExecutorInfo(row: AgentExecutorRow): ExecutorInfo {
 
 // ── Session Overview ──
 
-export function SessionOverview({
-  journal,
-  perf,
-}: {
+export function SessionOverview(props: {
   journal: ParsedJournal;
   perf?: AgentPerformance | null;
 }) {
-  const { summary, executors, metrics } = journal;
-  const pnl = perf ? perf.total_pnl : summary.pnl;
+  const { metrics } = props.journal;
 
   // PnL chart data from metrics timeline
   const pnlData = useMemo(() => metricsToDataPoints(metrics), [metrics]);
 
+  if (pnlData.length <= 1) {
+    return null;
+  }
+
   return (
     <div className="space-y-4">
-      {/* Summary Card */}
-      <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
-        <h3 className="mb-3 text-xs font-bold uppercase tracking-widest text-[var(--color-text-muted)]">Summary</h3>
-        <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm md:grid-cols-4">
-          <div>
-            <span className="block text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">Status</span>
-            <span className={`rounded-full border px-2 py-0.5 text-[10px] font-bold uppercase ${
-              summary.status === "ACTIVE" || summary.status === "running"
-                ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
-                : summary.status === "paused"
-                  ? "border-amber-500/30 bg-amber-500/10 text-amber-400"
-                  : "border-[var(--color-border)] bg-[var(--color-surface-hover)] text-[var(--color-text-muted)]"
-            }`}>
-              {summary.status || "idle"}
-            </span>
-          </div>
-          <div>
-            <span className="block text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">Last Tick</span>
-            <span className="font-mono text-sm text-[var(--color-text)]">#{summary.lastTick}</span>
-          </div>
-          <div>
-            <span className="block text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">PnL</span>
-            <span className={`font-mono text-sm ${pnl >= 0 ? "text-emerald-400" : "text-red-400"}`}>
-              ${pnl >= 0 ? "+" : ""}{pnl.toFixed(2)}
-            </span>
-          </div>
-          <div>
-            <span className="block text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">Last Action</span>
-            <span className="text-sm text-[var(--color-text)]">{summary.lastAction || "—"}</span>
-          </div>
-        </div>
-      </div>
-
-      {/* Executor Table */}
-      {executors.length > 0 && (
-        <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
-          <h3 className="mb-3 text-xs font-bold uppercase tracking-widest text-[var(--color-text-muted)]">Executors</h3>
-          <div className="overflow-x-auto">
-            <table className="w-full text-left text-xs">
-              <thead>
-                <tr className="border-b border-[var(--color-border)] text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-muted)]">
-                  <th className="pb-2 pr-3">ID</th>
-                  <th className="pb-2 pr-3">Type</th>
-                  <th className="pb-2 pr-3">Pair</th>
-                  <th className="pb-2 pr-3">Side</th>
-                  <th className="pb-2 pr-3 text-right">Amount</th>
-                  <th className="pb-2 pr-3">Status</th>
-                  <th className="pb-2 pr-3 text-right">PnL</th>
-                  <th className="pb-2 text-right">Volume</th>
-                </tr>
-              </thead>
-              <tbody>
-                {executors.map((ex, i) => (
-                  <tr key={`${ex.id}-${i}`} className="border-b border-[var(--color-border)]/30">
-                    <td className="py-2 pr-3 font-mono text-[var(--color-text)]">{ex.id.slice(0, 8)}</td>
-                    <td className="py-2 pr-3 text-[var(--color-text-muted)]">{ex.type}</td>
-                    <td className="py-2 pr-3 font-mono text-[var(--color-text)]">{ex.pair}</td>
-                    <td className="py-2 pr-3">
-                      <span className={ex.side.toLowerCase() === "buy" ? "text-emerald-400" : "text-red-400"}>
-                        {ex.side.toUpperCase()}
-                      </span>
-                    </td>
-                    <td className="py-2 pr-3 text-right font-mono text-[var(--color-text)]">${ex.amount.toFixed(2)}</td>
-                    <td className="py-2 pr-3">
-                      <span className={`rounded-full border px-2 py-0.5 text-[10px] font-bold uppercase ${
-                        ex.status === "open"
-                          ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
-                          : "border-[var(--color-border)] bg-[var(--color-surface-hover)] text-[var(--color-text-muted)]"
-                      }`}>
-                        {ex.status}
-                      </span>
-                    </td>
-                    <td className={`py-2 pr-3 text-right font-mono ${ex.pnl >= 0 ? "text-emerald-400" : "text-red-400"}`}>
-                      {ex.pnl >= 0 ? "+" : ""}{ex.pnl.toFixed(2)}
-                    </td>
-                    <td className="py-2 text-right font-mono text-[var(--color-text-muted)]">{ex.volume.toFixed(2)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      )}
-
-      {/* PnL Chart (replaces metrics timeline text) */}
-      {pnlData.length > 1 && (
-        <AgentPnlChart data={pnlData} height={400} title="Metrics Timeline" />
-      )}
-
-      {/* Metrics table (compact, below chart) */}
-      {metrics.length > 0 && (
-        <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
-          <h3 className="mb-3 text-xs font-bold uppercase tracking-widest text-[var(--color-text-muted)]">Metrics Detail</h3>
-          <div className="overflow-x-auto">
-            <table className="w-full text-xs">
-              <thead>
-                <tr className="text-left text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">
-                  <th className="px-2 py-1">Time</th>
-                  <th className="px-2 py-1 text-right">PnL</th>
-                  <th className="px-2 py-1 text-right">Volume</th>
-                  <th className="px-2 py-1 text-right">Open</th>
-                  <th className="px-2 py-1 text-right">Exposure</th>
-                </tr>
-              </thead>
-              <tbody>
-                {metrics.map((m, i) => (
-                  <tr key={i} className="border-t border-[var(--color-border)]/30 font-mono">
-                    <td className="px-2 py-1.5 text-[var(--color-text-muted)]">{m.timestamp}</td>
-                    <td className={`px-2 py-1.5 text-right ${m.pnl >= 0 ? "text-emerald-400" : "text-red-400"}`}>
-                      ${m.pnl >= 0 ? "+" : ""}{m.pnl.toFixed(2)}
-                    </td>
-                    <td className="px-2 py-1.5 text-right text-[var(--color-text-muted)]">
-                      ${m.volume.toLocaleString("en-US", { maximumFractionDigits: 0 })}
-                    </td>
-                    <td className="px-2 py-1.5 text-right text-[var(--color-text-muted)]">{m.open}</td>
-                    <td className="px-2 py-1.5 text-right text-[var(--color-text-muted)]">${m.exposure.toFixed(2)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      )}
-
-      {executors.length === 0 && metrics.length === 0 && (
-        <p className="py-8 text-center text-sm text-[var(--color-text-muted)]">No executors or metrics yet.</p>
-      )}
+      <AgentPnlChart data={pnlData} height={400} title="Metrics Timeline" />
     </div>
   );
 }
@@ -238,12 +112,14 @@ export function SessionExecutors({
   serverName,
   controllerIds,
   onSnapshotClick,
+  sessionSummary,
 }: {
   slug: string;
   sessionNum: number;
   serverName: string;
   controllerIds?: string[];
   onSnapshotClick?: (tick: number) => void;
+  sessionSummary?: { status: string; lastTick: number; lastAction: string };
 }) {
   // REST data (fallback + historical executors)
   const { data: sessionDetail } = useQuery({
@@ -350,6 +226,21 @@ export function SessionExecutors({
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const stoppingIds = useMemo(() => new Set<string>(), []);
+  const [selectedExecutor, setSelectedExecutor] = useState<ExecutorInfo | null>(null);
+
+  // Positions held (filtered by controller IDs)
+  const { data: positionsData } = useQuery({
+    queryKey: ["positions-held", serverName],
+    queryFn: () => api.getPositionsHeld(serverName),
+    enabled: !!serverName && (controllerIds?.length ?? 0) > 0,
+    refetchInterval: 10000,
+  });
+
+  const positions = useMemo(() => {
+    if (!positionsData?.positions || !controllerIds?.length) return [];
+    const cidSet = new Set(controllerIds);
+    return positionsData.positions.filter((p) => p.controller_id && cidSet.has(p.controller_id));
+  }, [positionsData, controllerIds]);
 
   const handleSort = useCallback((key: SortKey) => {
     setSortDir((prev) => (sortKey === key ? (prev === "asc" ? "desc" : "asc") : "desc"));
@@ -395,6 +286,20 @@ export function SessionExecutors({
     <div className="space-y-3">
       {/* Stats strip */}
       <div className="flex flex-wrap items-center gap-4 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2.5">
+        {sessionSummary && (
+          <div>
+            <span className="block text-[9px] uppercase tracking-wider text-[var(--color-text-muted)]">Status</span>
+            <span className={`rounded-full border px-2 py-0.5 text-[10px] font-bold uppercase ${
+              sessionSummary.status === "ACTIVE" || sessionSummary.status === "running"
+                ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+                : sessionSummary.status === "paused"
+                  ? "border-amber-500/30 bg-amber-500/10 text-amber-400"
+                  : "border-[var(--color-border)] bg-[var(--color-surface-hover)] text-[var(--color-text-muted)]"
+            }`}>
+              {sessionSummary.status || "idle"}
+            </span>
+          </div>
+        )}
         <div>
           <span className="block text-[9px] uppercase tracking-wider text-[var(--color-text-muted)]">Net PnL</span>
           <span className={`font-mono text-sm font-semibold ${stats.totalPnl >= 0 ? "text-emerald-400" : "text-red-400"}`}>
@@ -418,7 +323,69 @@ export function SessionExecutors({
             )}
           </span>
         </div>
+        {sessionSummary && sessionSummary.lastTick > 0 && (
+          <div>
+            <span className="block text-[9px] uppercase tracking-wider text-[var(--color-text-muted)]">Last Tick</span>
+            <span className="font-mono text-sm text-[var(--color-text)]">#{sessionSummary.lastTick}</span>
+          </div>
+        )}
+        {sessionSummary?.lastAction && (
+          <div>
+            <span className="block text-[9px] uppercase tracking-wider text-[var(--color-text-muted)]">Last Action</span>
+            <span className="text-sm text-[var(--color-text)]">{sessionSummary.lastAction}</span>
+          </div>
+        )}
       </div>
+
+      {/* Positions Held */}
+      {positions.length > 0 && (
+        <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
+          <h3 className="mb-3 text-xs font-bold uppercase tracking-widest text-[var(--color-text-muted)]">
+            Positions Held ({positions.length})
+          </h3>
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-xs">
+              <thead>
+                <tr className="border-b border-[var(--color-border)] text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-muted)]">
+                  <th className="pb-2 pr-3">Pair</th>
+                  <th className="pb-2 pr-3">Side</th>
+                  <th className="pb-2 pr-3 text-right">Amount</th>
+                  <th className="pb-2 pr-3 text-right">Entry</th>
+                  <th className="pb-2 pr-3 text-right">Current</th>
+                  <th className="pb-2 pr-3 text-right">Unreal. PnL</th>
+                  <th className="pb-2 text-right">Leverage</th>
+                </tr>
+              </thead>
+              <tbody>
+                {positions.map((p, i) => {
+                  const upnl = p.unrealized_pnl_quote ?? p.unrealized_pnl ?? 0;
+                  const side = p.position_side || p.side || "—";
+                  const amount = p.net_amount_base ?? p.amount ?? 0;
+                  const entry = p.buy_breakeven_price ?? p.entry_price ?? 0;
+                  const current = p.current_price ?? 0;
+                  return (
+                    <tr key={`${p.trading_pair}-${i}`} className="border-b border-[var(--color-border)]/30">
+                      <td className="py-2 pr-3 font-mono text-[var(--color-text)]">{p.trading_pair}</td>
+                      <td className="py-2 pr-3">
+                        <span className={side.toLowerCase().includes("long") || side.toLowerCase() === "buy" ? "text-emerald-400" : "text-red-400"}>
+                          {side.toUpperCase()}
+                        </span>
+                      </td>
+                      <td className="py-2 pr-3 text-right font-mono text-[var(--color-text)]">{Math.abs(amount).toFixed(4)}</td>
+                      <td className="py-2 pr-3 text-right font-mono text-[var(--color-text-muted)]">${entry.toFixed(2)}</td>
+                      <td className="py-2 pr-3 text-right font-mono text-[var(--color-text)]">${current.toFixed(2)}</td>
+                      <td className={`py-2 pr-3 text-right font-mono ${upnl >= 0 ? "text-emerald-400" : "text-red-400"}`}>
+                        {upnl >= 0 ? "+" : ""}${upnl.toFixed(2)}
+                      </td>
+                      <td className="py-2 text-right font-mono text-[var(--color-text-muted)]">{p.leverage ? `${p.leverage}x` : "—"}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
 
       {/* Chart-focused view — each trading pair gets a prominent chart */}
       {chartGroups.map(([key, group]) => {
@@ -459,11 +426,22 @@ export function SessionExecutors({
         onToggleSelect={toggleSelect}
         onSelectAll={selectAll}
         allSelected={allSelected}
-        onRowClick={() => {}}
-        selectedExecutorId={null}
+        onRowClick={(ex) => setSelectedExecutor(ex)}
+        selectedExecutorId={selectedExecutor?.id ?? null}
         onStop={() => {}}
         stoppingIds={stoppingIds}
       />
+
+      {/* Executor Detail Panel */}
+      {selectedExecutor && (
+        <DetailPanel
+          executor={selectedExecutor}
+          server={serverName}
+          onClose={() => setSelectedExecutor(null)}
+          onStop={() => {}}
+          stopping={false}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/agent/SessionReviewer.tsx
+++ b/frontend/src/components/agent/SessionReviewer.tsx
@@ -392,6 +392,7 @@ export function SessionReviewer({
                       serverName={serverName}
                       controllerIds={controllerIds}
                       onSnapshotClick={handleSnapshotClick}
+                      sessionSummary={parsedJournal.summary}
                     />
                     <SessionOverview journal={parsedJournal} perf={sessionPerf} />
                   </div>

--- a/frontend/src/components/bots/AggregatedPnlChart.tsx
+++ b/frontend/src/components/bots/AggregatedPnlChart.tsx
@@ -1,280 +1,246 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useMemo, useState } from "react";
+import {
+  Area,
+  CartesianGrid,
+  ComposedChart,
+  Legend,
+  Line,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 
-import type { ControllerPerformanceSnapshot } from "@/lib/api";
+import type { ControllerInfo, ControllerPerformanceSnapshot } from "@/lib/api";
 import { formatCurrencyVolume, pnlColor } from "@/lib/formatters";
 
-function getChartColors() {
-  const style = getComputedStyle(document.documentElement);
-  return {
-    bg: style.getPropertyValue("--chart-bg").trim() || "#0f1525",
-    grid: style.getPropertyValue("--chart-grid").trim() || "#1c2541",
-    text: style.getPropertyValue("--chart-text").trim() || "#6b7994",
-    green: style.getPropertyValue("--chart-up").trim() || "#22c55e",
-    red: style.getPropertyValue("--chart-down").trim() || "#ef4444",
-    blue: "#3b82f6",
-    orange: "#f59e0b",
-  };
-}
+// ── Helpers ──
 
-function toSeconds(ts: string | number): number {
-  if (typeof ts === "number") return ts > 1e12 ? Math.floor(ts / 1000) : ts;
+function toMs(ts: string | number): number {
+  if (typeof ts === "number") return ts > 1e12 ? ts : ts * 1000;
   const parsed = Date.parse(ts);
-  if (!isNaN(parsed)) return Math.floor(parsed / 1000);
-  return 0;
+  return isNaN(parsed) ? 0 : parsed;
 }
 
-interface AggregatedPoint {
+function formatTime(ms: number): string {
+  return new Date(ms).toLocaleTimeString("en-US", { hour12: false, hour: "2-digit", minute: "2-digit" });
+}
+
+function formatDateTime(ms: number): string {
+  const d = new Date(ms);
+  return `${d.toLocaleDateString("en-US", { month: "short", day: "numeric" })} ${d.toLocaleTimeString("en-US", { hour12: false, hour: "2-digit", minute: "2-digit" })}`;
+}
+
+/** Compute net position value in quote from positions_summary */
+function positionQuoteValue(positions: Record<string, unknown>[]): number {
+  let value = 0;
+  for (const pos of positions) {
+    const amt = Number(pos.amount || pos.net_amount_base || 0);
+    const price = Number(pos.breakeven_price || pos.entry_price || pos.current_price || 0);
+    const side = String(pos.side || pos.position_side || "");
+    const isSell = side.toLowerCase().includes("sell") || side.toLowerCase().includes("short");
+    const notional = amt * price;
+    value += isSell ? -notional : notional;
+  }
+  return value;
+}
+
+// ── Aggregation ──
+
+interface AggPoint {
   time: number;
   realized: number;
   unrealized: number;
   total: number;
   volume: number;
+  position: number; // net position in quote currency
 }
+
+function aggregate(
+  snapshots: ControllerPerformanceSnapshot[],
+  enabledIds: Set<string>,
+): AggPoint[] {
+  if (!snapshots || snapshots.length === 0) return [];
+
+  const byCtrl: Record<string, ControllerPerformanceSnapshot[]> = {};
+  for (const snap of snapshots) {
+    const key = snap.controller_id || snap.controller_name;
+    if (!key || !enabledIds.has(key)) continue;
+    (byCtrl[key] ??= []).push(snap);
+  }
+
+  for (const snaps of Object.values(byCtrl)) {
+    snaps.sort((a, b) => toMs(a.timestamp) - toMs(b.timestamp));
+  }
+
+  const timeSet = new Set<number>();
+  for (const snaps of Object.values(byCtrl))
+    for (const s of snaps) timeSet.add(toMs(s.timestamp));
+  const times = Array.from(timeSet).sort((a, b) => a - b);
+  if (times.length === 0) return [];
+
+  const cids = Object.keys(byCtrl);
+  const cursors: Record<string, number> = {};
+  for (const c of cids) cursors[c] = 0;
+
+  const points: AggPoint[] = [];
+  for (const t of times) {
+    let realized = 0, unrealized = 0, volume = 0, position = 0;
+    for (const cid of cids) {
+      const snaps = byCtrl[cid];
+      while (cursors[cid] < snaps.length - 1 && toMs(snaps[cursors[cid] + 1].timestamp) <= t)
+        cursors[cid]++;
+      if (toMs(snaps[cursors[cid]].timestamp) <= t) {
+        const s = snaps[cursors[cid]];
+        realized += s.realized_pnl_quote;
+        unrealized += s.unrealized_pnl_quote;
+        volume += s.volume_traded;
+        if (Array.isArray(s.positions_summary)) {
+          position += positionQuoteValue(s.positions_summary as Record<string, unknown>[]);
+        }
+      }
+    }
+    points.push({ time: t, realized, unrealized, total: realized + unrealized, volume, position });
+  }
+  return points;
+}
+
+// ── Custom tooltips ──
+
+function PnlTooltip({ active, payload, label, symbol }: {
+  active?: boolean;
+  payload?: Array<{ dataKey: string; value: number }>;
+  label?: number;
+  symbol: string;
+}) {
+  if (!active || !payload?.length || !label) return null;
+  const byKey: Record<string, number> = {};
+  for (const p of payload) byKey[p.dataKey] = p.value;
+  const total = byKey.total ?? (byKey.realized ?? 0) + (byKey.unrealized ?? 0);
+  const sign = (v: number) => (v >= 0 ? "+" : "");
+
+  return (
+    <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg)]/95 backdrop-blur-sm px-2.5 py-2 text-[11px] leading-relaxed shadow-lg min-w-[150px]">
+      <div className="text-[var(--color-text-muted)] text-[10px] mb-1">{formatDateTime(label)}</div>
+      <div className="flex justify-between gap-3">
+        <span className="text-[var(--color-text-muted)]">Total</span>
+        <span className="font-semibold" style={{ color: pnlColor(total) }}>
+          {sign(total)}{formatCurrencyVolume(total, symbol)}
+        </span>
+      </div>
+      <div className="flex justify-between gap-3">
+        <span className="text-[var(--color-text-muted)]">Realized</span>
+        <span style={{ color: "var(--color-green)" }}>{sign(byKey.realized ?? 0)}{formatCurrencyVolume(byKey.realized ?? 0, symbol)}</span>
+      </div>
+      <div className="flex justify-between gap-3">
+        <span className="text-[var(--color-text-muted)]">Unrealized</span>
+        <span style={{ color: "#f59e0b" }}>{sign(byKey.unrealized ?? 0)}{formatCurrencyVolume(byKey.unrealized ?? 0, symbol)}</span>
+      </div>
+    </div>
+  );
+}
+
+function BottomTooltip({ active, payload, label, symbol }: {
+  active?: boolean;
+  payload?: Array<{ dataKey: string; value: number }>;
+  label?: number;
+  symbol: string;
+}) {
+  if (!active || !payload?.length || !label) return null;
+  const byKey: Record<string, number> = {};
+  for (const p of payload) byKey[p.dataKey] = p.value;
+
+  return (
+    <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg)]/95 backdrop-blur-sm px-2.5 py-2 text-[11px] leading-relaxed shadow-lg min-w-[130px]">
+      <div className="text-[var(--color-text-muted)] text-[10px] mb-1">{formatDateTime(label)}</div>
+      <div className="flex justify-between gap-3">
+        <span style={{ color: "#3b82f6" }}>Volume</span>
+        <span style={{ color: "#3b82f6" }}>{formatCurrencyVolume(byKey.volume ?? 0, symbol)}</span>
+      </div>
+      {byKey.position !== undefined && byKey.position !== 0 && (
+        <div className="flex justify-between gap-3">
+          <span style={{ color: "#a78bfa" }}>Position</span>
+          <span style={{ color: "#a78bfa" }}>{formatCurrencyVolume(byKey.position, symbol)}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Controller color palette ──
+
+const CTRL_COLORS = ["#22c55e", "#3b82f6", "#f59e0b", "#ef4444", "#a78bfa", "#ec4899", "#14b8a6", "#f97316"];
+
+// ── Main component ──
 
 interface Props {
   snapshots: ControllerPerformanceSnapshot[];
+  controllers: ControllerInfo[];
   currencySymbol?: string;
-  height?: number;
 }
 
-/**
- * Aggregates all controller snapshots by timestamp bucket,
- * summing PnL and volume across all running controllers.
- */
-export function AggregatedPnlChart({ snapshots, currencySymbol = "$", height = 280 }: Props) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const tooltipRef = useRef<HTMLDivElement>(null);
-  const chartRef = useRef<import("lightweight-charts").IChartApi | null>(null);
-
-  const aggregated = useMemo(() => {
-    if (!snapshots || snapshots.length === 0) return [];
-
-    // Group by controller, then align on time buckets
-    const byController: Record<string, ControllerPerformanceSnapshot[]> = {};
-    for (const snap of snapshots) {
-      const key = snap.controller_id || snap.controller_name;
-      if (!key) continue;
-      (byController[key] ??= []).push(snap);
-    }
-
-    // Sort each controller's snapshots by time
-    for (const snaps of Object.values(byController)) {
-      snaps.sort((a, b) => toSeconds(a.timestamp) - toSeconds(b.timestamp));
-    }
-
-    // Collect all unique timestamps
-    const timeSet = new Set<number>();
-    for (const snaps of Object.values(byController)) {
-      for (const s of snaps) timeSet.add(toSeconds(s.timestamp));
-    }
-    const times = Array.from(timeSet).sort((a, b) => a - b);
-    if (times.length === 0) return [];
-
-    // For each time, sum the latest known value per controller up to that time
-    const controllerIds = Object.keys(byController);
-    const points: AggregatedPoint[] = [];
-    // Track index cursor per controller for efficient lookup
-    const cursors: Record<string, number> = {};
-    for (const cid of controllerIds) cursors[cid] = 0;
-
-    for (const t of times) {
-      let realized = 0;
-      let unrealized = 0;
-      let volume = 0;
-
-      for (const cid of controllerIds) {
-        const snaps = byController[cid];
-        // Advance cursor to latest snap <= t
-        while (cursors[cid] < snaps.length - 1 && toSeconds(snaps[cursors[cid] + 1].timestamp) <= t) {
-          cursors[cid]++;
-        }
-        // Only include if this controller has data at or before time t
-        if (toSeconds(snaps[cursors[cid]].timestamp) <= t) {
-          const s = snaps[cursors[cid]];
-          realized += s.realized_pnl_quote;
-          unrealized += s.unrealized_pnl_quote;
-          volume += s.volume_traded;
-        }
+export function AggregatedPnlChart({ snapshots, controllers, currencySymbol = "$" }: Props) {
+  const controllerIds = useMemo(() => {
+    const ids: { id: string }[] = [];
+    const seen = new Set<string>();
+    for (const c of controllers) {
+      const cid = c.controller_id || c.controller_name;
+      if (!seen.has(cid)) {
+        seen.add(cid);
+        ids.push({ id: cid });
       }
-
-      points.push({ time: t, realized, unrealized, total: realized + unrealized, volume });
     }
+    return ids;
+  }, [controllers]);
 
-    return points;
-  }, [snapshots]);
+  const [enabled, setEnabled] = useState<Set<string>>(() => new Set(controllerIds.map((c) => c.id)));
 
-  // Latest values for the header
-  const latest = aggregated.length > 0 ? aggregated[aggregated.length - 1] : null;
-
-  useEffect(() => {
-    if (!containerRef.current || aggregated.length === 0) return;
-
-    let cancelled = false;
-
-    import("lightweight-charts").then((mod) => {
-      if (cancelled || !containerRef.current) return;
-
-      if (chartRef.current) {
-        chartRef.current.remove();
-        chartRef.current = null;
+  // Sync when controllers change
+  useMemo(() => {
+    const allIds = new Set(controllerIds.map((c) => c.id));
+    setEnabled((prev) => {
+      const next = new Set(prev);
+      for (const id of prev) {
+        if (!allIds.has(id)) next.delete(id);
       }
-
-      const colors = getChartColors();
-      const chart = mod.createChart(containerRef.current!, {
-        autoSize: true,
-        layout: {
-          background: { type: mod.ColorType.Solid, color: colors.bg },
-          textColor: colors.text,
-        },
-        grid: {
-          vertLines: { color: colors.grid },
-          horzLines: { color: colors.grid },
-        },
-        crosshair: { mode: mod.CrosshairMode.Normal },
-        timeScale: { timeVisible: true, secondsVisible: false },
-        rightPriceScale: { borderVisible: false },
-        localization: {
-          priceFormatter: (price: number) => `${currencySymbol}${price >= 0 ? "+" : ""}${price.toFixed(2)}`,
-        },
-      });
-      chartRef.current = chart;
-
-      // Total PnL area
-      const totalSeries = chart.addSeries(mod.AreaSeries, {
-        lineColor: aggregated[aggregated.length - 1]?.total >= 0 ? colors.green : colors.red,
-        topColor: aggregated[aggregated.length - 1]?.total >= 0 ? `${colors.green}20` : `${colors.red}20`,
-        bottomColor: "transparent",
-        lineWidth: 2,
-        priceLineVisible: false,
-        lastValueVisible: true,
-        title: "Total PnL",
-        crosshairMarkerVisible: true,
-      });
-
-      // Realized PnL line
-      const realizedSeries = chart.addSeries(mod.LineSeries, {
-        color: colors.green,
-        lineWidth: 1,
-        lineStyle: mod.LineStyle.Solid,
-        priceLineVisible: false,
-        lastValueVisible: false,
-        title: "Realized",
-        crosshairMarkerVisible: true,
-      });
-
-      // Unrealized PnL line
-      const unrealizedSeries = chart.addSeries(mod.LineSeries, {
-        color: colors.orange,
-        lineWidth: 1,
-        lineStyle: mod.LineStyle.Dashed,
-        priceLineVisible: false,
-        lastValueVisible: false,
-        title: "Unrealized",
-        crosshairMarkerVisible: true,
-      });
-
-      // Volume (secondary axis)
-      const volumeSeries = chart.addSeries(mod.LineSeries, {
-        color: `${colors.blue}70`,
-        lineWidth: 1,
-        priceScaleId: "volume",
-        priceLineVisible: false,
-        lastValueVisible: false,
-        title: "Cum. Vol",
-        priceFormat: { type: "volume" },
-      });
-      chart.priceScale("volume").applyOptions({
-        scaleMargins: { top: 0.8, bottom: 0 },
-      });
-
-      type TS = import("lightweight-charts").UTCTimestamp;
-
-      totalSeries.setData(aggregated.map((p) => ({ time: p.time as TS, value: p.total })));
-      realizedSeries.setData(aggregated.map((p) => ({ time: p.time as TS, value: p.realized })));
-      unrealizedSeries.setData(aggregated.map((p) => ({ time: p.time as TS, value: p.unrealized })));
-      volumeSeries.setData(aggregated.map((p) => ({ time: p.time as TS, value: p.volume })));
-
-      chart.timeScale().fitContent();
-
-      // Crosshair tooltip
-      chart.subscribeCrosshairMove((param) => {
-        const tooltip = tooltipRef.current;
-        if (!tooltip || !containerRef.current) return;
-
-        if (!param.time || !param.point || param.point.x < 0 || param.point.y < 0) {
-          tooltip.style.display = "none";
-          return;
-        }
-
-        const totalData = param.seriesData.get(totalSeries);
-        const realizedData = param.seriesData.get(realizedSeries);
-        const unrealizedData = param.seriesData.get(unrealizedSeries);
-        const volData = param.seriesData.get(volumeSeries);
-
-        if (!totalData || !("value" in totalData)) {
-          tooltip.style.display = "none";
-          return;
-        }
-
-        const total = (totalData as { value: number }).value;
-        const realized = realizedData && "value" in realizedData ? (realizedData as { value: number }).value : 0;
-        const unrealized = unrealizedData && "value" in unrealizedData ? (unrealizedData as { value: number }).value : 0;
-        const vol = volData && "value" in volData ? (volData as { value: number }).value : 0;
-        const ts = typeof param.time === "number" ? param.time : 0;
-        const date = new Date(ts * 1000);
-        const timeStr = date.toLocaleString("en-US", {
-          month: "short",
-          day: "numeric",
-          hour: "2-digit",
-          minute: "2-digit",
-        });
-
-        const sign = (v: number) => (v >= 0 ? "+" : "");
-        const totalColor = total >= 0 ? colors.green : colors.red;
-
-        tooltip.innerHTML = `
-          <div style="color:#9ca3af;font-size:10px;margin-bottom:3px">${timeStr}</div>
-          <div style="display:flex;justify-content:space-between;gap:12px">
-            <span style="color:#9ca3af;font-size:10px">Total</span>
-            <span style="color:${totalColor};font-weight:600;font-size:12px">${currencySymbol}${sign(total)}${total.toFixed(2)}</span>
-          </div>
-          <div style="display:flex;justify-content:space-between;gap:12px">
-            <span style="color:#9ca3af;font-size:10px">Realized</span>
-            <span style="color:${colors.green};font-size:11px">${currencySymbol}${sign(realized)}${realized.toFixed(2)}</span>
-          </div>
-          <div style="display:flex;justify-content:space-between;gap:12px">
-            <span style="color:#9ca3af;font-size:10px">Unrealized</span>
-            <span style="color:${colors.orange};font-size:11px">${currencySymbol}${sign(unrealized)}${unrealized.toFixed(2)}</span>
-          </div>
-          ${vol > 0 ? `<div style="display:flex;justify-content:space-between;gap:12px;margin-top:2px;border-top:1px solid rgba(107,121,148,0.2);padding-top:2px"><span style="color:#9ca3af;font-size:10px">Cum. Vol</span><span style="color:${colors.blue};font-size:10px">${currencySymbol}${vol >= 1000 ? (vol / 1000).toFixed(1) + "K" : vol.toFixed(0)}</span></div>` : ""}
-        `;
-        tooltip.style.display = "block";
-
-        const containerRect = containerRef.current.getBoundingClientRect();
-        const tooltipW = 200;
-        let left = containerRect.left + param.point.x + 16;
-        if (left + tooltipW > window.innerWidth - 8) left = containerRect.left + param.point.x - tooltipW - 10;
-        const top = containerRect.top + Math.max(4, param.point.y - 30);
-        tooltip.style.left = `${left}px`;
-        tooltip.style.top = `${top}px`;
-      });
+      if (next.size === 0) return allIds;
+      return next;
     });
+  }, [controllerIds]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    return () => {
-      cancelled = true;
-      if (chartRef.current) {
-        chartRef.current.remove();
-        chartRef.current = null;
+  const toggleController = (id: string) => {
+    setEnabled((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+        if (next.size === 0) return prev;
+      } else {
+        next.add(id);
       }
-    };
-  }, [aggregated, currencySymbol]);
+      return next;
+    });
+  };
 
-  if (!snapshots || snapshots.length === 0) return null;
+  const allEnabled = enabled.size === controllerIds.length;
+  const toggleAll = () => {
+    if (allEnabled) return;
+    setEnabled(new Set(controllerIds.map((c) => c.id)));
+  };
 
-  if (aggregated.length < 2) return null;
+  const data = useMemo(() => aggregate(snapshots, enabled), [snapshots, enabled]);
+  const latest = data.length > 0 ? data[data.length - 1] : null;
+  const hasPosition = data.some((p) => p.position !== 0);
+
+  if (!snapshots || snapshots.length === 0 || data.length < 2) return null;
+
+  const fmtPnl = (v: number) => `${v >= 0 ? "+" : ""}${formatCurrencyVolume(v, currencySymbol)}`;
+  const fmtAxis = (v: number) => `${currencySymbol}${Math.abs(v) >= 1000 ? (v / 1000).toFixed(1) + "K" : v.toFixed(Math.abs(v) < 10 ? 2 : 0)}`;
+  const fmtVolAxis = (v: number) => `${currencySymbol}${Math.abs(v) >= 1000 ? (v / 1000).toFixed(1) + "K" : v.toFixed(0)}`;
 
   return (
     <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] overflow-hidden">
+      {/* Header */}
       <div className="flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-1.5">
         <div className="flex items-center gap-4">
           <p className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-muted)]">
@@ -283,13 +249,13 @@ export function AggregatedPnlChart({ snapshots, currencySymbol = "$", height = 2
           {latest && (
             <div className="flex items-center gap-3 text-xs tabular-nums">
               <span style={{ color: pnlColor(latest.total) }} className="font-semibold">
-                {latest.total >= 0 ? "+" : ""}{formatCurrencyVolume(latest.total, currencySymbol)}
+                {fmtPnl(latest.total)}
               </span>
               <span className="text-[var(--color-text-muted)]">
-                R: <span style={{ color: "var(--color-green)" }}>{latest.realized >= 0 ? "+" : ""}{formatCurrencyVolume(latest.realized, currencySymbol)}</span>
+                R: <span style={{ color: "var(--color-green)" }}>{fmtPnl(latest.realized)}</span>
               </span>
               <span className="text-[var(--color-text-muted)]">
-                U: <span style={{ color: "#f59e0b" }}>{latest.unrealized >= 0 ? "+" : ""}{formatCurrencyVolume(latest.unrealized, currencySymbol)}</span>
+                U: <span style={{ color: "#f59e0b" }}>{fmtPnl(latest.unrealized)}</span>
               </span>
               <span className="text-[var(--color-text-muted)]">
                 Vol: {formatCurrencyVolume(latest.volume, currencySymbol)}
@@ -297,44 +263,138 @@ export function AggregatedPnlChart({ snapshots, currencySymbol = "$", height = 2
             </div>
           )}
         </div>
-        <div className="flex items-center gap-2 text-[9px]">
-          <span className="flex items-center gap-1">
-            <span className="inline-block w-2.5 h-0.5 rounded" style={{ background: "#22c55e" }} />
-            Realized
-          </span>
-          <span className="flex items-center gap-1">
-            <span className="inline-block w-2.5 h-0.5 rounded" style={{ background: "#f59e0b" }} />
-            Unrealized
-          </span>
-          <span className="flex items-center gap-1">
-            <span className="inline-block w-2.5 h-0.5 rounded" style={{ background: "#3b82f690" }} />
-            Volume
-          </span>
-        </div>
       </div>
-      <div>
-        <div ref={containerRef} style={{ height, width: "100%" }} />
-        <div
-          ref={tooltipRef}
-          style={{
-            display: "none",
-            position: "fixed",
-            top: 0,
-            left: 0,
-            zIndex: 9999,
-            pointerEvents: "none",
-            background: "rgba(15, 21, 37, 0.95)",
-            border: "1px solid rgba(107, 121, 148, 0.3)",
-            borderRadius: 6,
-            padding: "6px 10px",
-            fontSize: 11,
-            color: "#e2e8f0",
-            minWidth: 160,
-            whiteSpace: "nowrap",
-            lineHeight: 1.5,
-            backdropFilter: "blur(8px)",
-          }}
-        />
+
+      {/* Controller filter chips */}
+      {controllerIds.length > 1 && (
+        <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-[var(--color-border)] bg-[var(--color-bg)] overflow-x-auto">
+          <button
+            onClick={toggleAll}
+            className={`rounded-full px-2.5 py-0.5 text-[10px] font-medium transition-colors whitespace-nowrap ${
+              allEnabled
+                ? "bg-[var(--color-text-muted)]/20 text-[var(--color-text)]"
+                : "text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+            }`}
+          >
+            All
+          </button>
+          {controllerIds.map((c, i) => {
+            const color = CTRL_COLORS[i % CTRL_COLORS.length];
+            const active = enabled.has(c.id);
+            return (
+              <button
+                key={c.id}
+                onClick={() => toggleController(c.id)}
+                className={`rounded-full px-2.5 py-0.5 text-[10px] font-medium transition-all whitespace-nowrap ${
+                  active ? "text-white" : "opacity-40 hover:opacity-70"
+                }`}
+                style={{
+                  backgroundColor: active ? color : "transparent",
+                  border: `1px solid ${color}`,
+                  color: active ? "white" : color,
+                }}
+              >
+                {c.id}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* PnL chart (top) */}
+      <div className="px-1">
+        <ResponsiveContainer width="100%" height={220}>
+          <ComposedChart data={data} margin={{ top: 12, right: 12, left: 0, bottom: 0 }} syncId="agg">
+            <defs>
+              <linearGradient id="aggPnlGrad" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor={(latest?.total ?? 0) >= 0 ? "#22c55e" : "#ef4444"} stopOpacity={0.15} />
+                <stop offset="95%" stopColor={(latest?.total ?? 0) >= 0 ? "#22c55e" : "#ef4444"} stopOpacity={0.02} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" strokeOpacity={0.5} />
+            <XAxis
+              dataKey="time"
+              type="number"
+              domain={["dataMin", "dataMax"]}
+              tickFormatter={formatTime}
+              tick={{ fontSize: 10, fill: "var(--color-text-muted)" }}
+              stroke="var(--color-border)"
+              tickLine={false}
+            />
+            <YAxis
+              tickFormatter={fmtAxis}
+              tick={{ fontSize: 10, fill: "var(--color-text-muted)" }}
+              stroke="var(--color-border)"
+              tickLine={false}
+              axisLine={false}
+              width={52}
+            />
+            <ReferenceLine y={0} stroke="var(--color-text-muted)" strokeOpacity={0.3} strokeDasharray="4 4" />
+            <Tooltip content={<PnlTooltip symbol={currencySymbol} />} />
+            <Area type="monotone" dataKey="total" stroke="none" fill="url(#aggPnlGrad)" activeDot={false} legendType="none" />
+            <Line type="monotone" dataKey="total" stroke={(latest?.total ?? 0) >= 0 ? "#22c55e" : "#ef4444"} strokeWidth={2} dot={false} strokeOpacity={0.6} />
+            <Line type="monotone" dataKey="realized" stroke="#22c55e" strokeWidth={2} dot={false} />
+            <Line type="monotone" dataKey="unrealized" stroke="#f59e0b" strokeWidth={2} strokeDasharray="5 3" dot={false} />
+            <Legend
+              verticalAlign="top"
+              align="right"
+              iconType="plainline"
+              wrapperStyle={{ fontSize: 10, paddingBottom: 4 }}
+              formatter={(value: string) => <span className="text-[var(--color-text-muted)] text-[10px] capitalize">{value}</span>}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Volume + Position chart (bottom) */}
+      <div className="px-1 border-t border-[var(--color-border)]/30">
+        <ResponsiveContainer width="100%" height={120}>
+          <ComposedChart data={data} margin={{ top: 8, right: 12, left: 0, bottom: 4 }} syncId="agg">
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" strokeOpacity={0.5} />
+            <XAxis
+              dataKey="time"
+              type="number"
+              domain={["dataMin", "dataMax"]}
+              tickFormatter={formatTime}
+              tick={{ fontSize: 10, fill: "var(--color-text-muted)" }}
+              stroke="var(--color-border)"
+              tickLine={false}
+            />
+            <YAxis
+              yAxisId="vol"
+              tickFormatter={fmtVolAxis}
+              tick={{ fontSize: 10, fill: "#3b82f6" }}
+              stroke="var(--color-border)"
+              tickLine={false}
+              axisLine={false}
+              width={52}
+            />
+            {hasPosition && (
+              <YAxis
+                yAxisId="pos"
+                orientation="right"
+                tickFormatter={fmtVolAxis}
+                tick={{ fontSize: 10, fill: "#a78bfa" }}
+                stroke="var(--color-border)"
+                tickLine={false}
+                axisLine={false}
+                width={52}
+              />
+            )}
+            <Tooltip content={<BottomTooltip symbol={currencySymbol} />} />
+            <Line yAxisId="vol" type="monotone" dataKey="volume" stroke="#3b82f6" strokeWidth={1.5} dot={false} />
+            {hasPosition && (
+              <Line yAxisId="pos" type="monotone" dataKey="position" stroke="#a78bfa" strokeWidth={1.5} dot={false} />
+            )}
+            <Legend
+              verticalAlign="top"
+              align="right"
+              iconType="plainline"
+              wrapperStyle={{ fontSize: 10, paddingBottom: 0 }}
+              formatter={(value: string) => <span className="text-[var(--color-text-muted)] text-[10px] capitalize">{value}</span>}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
       </div>
     </div>
   );

--- a/frontend/src/components/bots/AggregatedPnlChart.tsx
+++ b/frontend/src/components/bots/AggregatedPnlChart.tsx
@@ -1,0 +1,341 @@
+import { useEffect, useMemo, useRef } from "react";
+
+import type { ControllerPerformanceSnapshot } from "@/lib/api";
+import { formatCurrencyVolume, pnlColor } from "@/lib/formatters";
+
+function getChartColors() {
+  const style = getComputedStyle(document.documentElement);
+  return {
+    bg: style.getPropertyValue("--chart-bg").trim() || "#0f1525",
+    grid: style.getPropertyValue("--chart-grid").trim() || "#1c2541",
+    text: style.getPropertyValue("--chart-text").trim() || "#6b7994",
+    green: style.getPropertyValue("--chart-up").trim() || "#22c55e",
+    red: style.getPropertyValue("--chart-down").trim() || "#ef4444",
+    blue: "#3b82f6",
+    orange: "#f59e0b",
+  };
+}
+
+function toSeconds(ts: string | number): number {
+  if (typeof ts === "number") return ts > 1e12 ? Math.floor(ts / 1000) : ts;
+  const parsed = Date.parse(ts);
+  if (!isNaN(parsed)) return Math.floor(parsed / 1000);
+  return 0;
+}
+
+interface AggregatedPoint {
+  time: number;
+  realized: number;
+  unrealized: number;
+  total: number;
+  volume: number;
+}
+
+interface Props {
+  snapshots: ControllerPerformanceSnapshot[];
+  currencySymbol?: string;
+  height?: number;
+}
+
+/**
+ * Aggregates all controller snapshots by timestamp bucket,
+ * summing PnL and volume across all running controllers.
+ */
+export function AggregatedPnlChart({ snapshots, currencySymbol = "$", height = 280 }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<import("lightweight-charts").IChartApi | null>(null);
+
+  const aggregated = useMemo(() => {
+    if (!snapshots || snapshots.length === 0) return [];
+
+    // Group by controller, then align on time buckets
+    const byController: Record<string, ControllerPerformanceSnapshot[]> = {};
+    for (const snap of snapshots) {
+      const key = snap.controller_id || snap.controller_name;
+      if (!key) continue;
+      (byController[key] ??= []).push(snap);
+    }
+
+    // Sort each controller's snapshots by time
+    for (const snaps of Object.values(byController)) {
+      snaps.sort((a, b) => toSeconds(a.timestamp) - toSeconds(b.timestamp));
+    }
+
+    // Collect all unique timestamps
+    const timeSet = new Set<number>();
+    for (const snaps of Object.values(byController)) {
+      for (const s of snaps) timeSet.add(toSeconds(s.timestamp));
+    }
+    const times = Array.from(timeSet).sort((a, b) => a - b);
+    if (times.length === 0) return [];
+
+    // For each time, sum the latest known value per controller up to that time
+    const controllerIds = Object.keys(byController);
+    const points: AggregatedPoint[] = [];
+    // Track index cursor per controller for efficient lookup
+    const cursors: Record<string, number> = {};
+    for (const cid of controllerIds) cursors[cid] = 0;
+
+    for (const t of times) {
+      let realized = 0;
+      let unrealized = 0;
+      let volume = 0;
+
+      for (const cid of controllerIds) {
+        const snaps = byController[cid];
+        // Advance cursor to latest snap <= t
+        while (cursors[cid] < snaps.length - 1 && toSeconds(snaps[cursors[cid] + 1].timestamp) <= t) {
+          cursors[cid]++;
+        }
+        // Only include if this controller has data at or before time t
+        if (toSeconds(snaps[cursors[cid]].timestamp) <= t) {
+          const s = snaps[cursors[cid]];
+          realized += s.realized_pnl_quote;
+          unrealized += s.unrealized_pnl_quote;
+          volume += s.volume_traded;
+        }
+      }
+
+      points.push({ time: t, realized, unrealized, total: realized + unrealized, volume });
+    }
+
+    return points;
+  }, [snapshots]);
+
+  // Latest values for the header
+  const latest = aggregated.length > 0 ? aggregated[aggregated.length - 1] : null;
+
+  useEffect(() => {
+    if (!containerRef.current || aggregated.length === 0) return;
+
+    let cancelled = false;
+
+    import("lightweight-charts").then((mod) => {
+      if (cancelled || !containerRef.current) return;
+
+      if (chartRef.current) {
+        chartRef.current.remove();
+        chartRef.current = null;
+      }
+
+      const colors = getChartColors();
+      const chart = mod.createChart(containerRef.current!, {
+        autoSize: true,
+        layout: {
+          background: { type: mod.ColorType.Solid, color: colors.bg },
+          textColor: colors.text,
+        },
+        grid: {
+          vertLines: { color: colors.grid },
+          horzLines: { color: colors.grid },
+        },
+        crosshair: { mode: mod.CrosshairMode.Normal },
+        timeScale: { timeVisible: true, secondsVisible: false },
+        rightPriceScale: { borderVisible: false },
+        localization: {
+          priceFormatter: (price: number) => `${currencySymbol}${price >= 0 ? "+" : ""}${price.toFixed(2)}`,
+        },
+      });
+      chartRef.current = chart;
+
+      // Total PnL area
+      const totalSeries = chart.addSeries(mod.AreaSeries, {
+        lineColor: aggregated[aggregated.length - 1]?.total >= 0 ? colors.green : colors.red,
+        topColor: aggregated[aggregated.length - 1]?.total >= 0 ? `${colors.green}20` : `${colors.red}20`,
+        bottomColor: "transparent",
+        lineWidth: 2,
+        priceLineVisible: false,
+        lastValueVisible: true,
+        title: "Total PnL",
+        crosshairMarkerVisible: true,
+      });
+
+      // Realized PnL line
+      const realizedSeries = chart.addSeries(mod.LineSeries, {
+        color: colors.green,
+        lineWidth: 1,
+        lineStyle: mod.LineStyle.Solid,
+        priceLineVisible: false,
+        lastValueVisible: false,
+        title: "Realized",
+        crosshairMarkerVisible: true,
+      });
+
+      // Unrealized PnL line
+      const unrealizedSeries = chart.addSeries(mod.LineSeries, {
+        color: colors.orange,
+        lineWidth: 1,
+        lineStyle: mod.LineStyle.Dashed,
+        priceLineVisible: false,
+        lastValueVisible: false,
+        title: "Unrealized",
+        crosshairMarkerVisible: true,
+      });
+
+      // Volume (secondary axis)
+      const volumeSeries = chart.addSeries(mod.LineSeries, {
+        color: `${colors.blue}70`,
+        lineWidth: 1,
+        priceScaleId: "volume",
+        priceLineVisible: false,
+        lastValueVisible: false,
+        title: "Cum. Vol",
+        priceFormat: { type: "volume" },
+      });
+      chart.priceScale("volume").applyOptions({
+        scaleMargins: { top: 0.8, bottom: 0 },
+      });
+
+      type TS = import("lightweight-charts").UTCTimestamp;
+
+      totalSeries.setData(aggregated.map((p) => ({ time: p.time as TS, value: p.total })));
+      realizedSeries.setData(aggregated.map((p) => ({ time: p.time as TS, value: p.realized })));
+      unrealizedSeries.setData(aggregated.map((p) => ({ time: p.time as TS, value: p.unrealized })));
+      volumeSeries.setData(aggregated.map((p) => ({ time: p.time as TS, value: p.volume })));
+
+      chart.timeScale().fitContent();
+
+      // Crosshair tooltip
+      chart.subscribeCrosshairMove((param) => {
+        const tooltip = tooltipRef.current;
+        if (!tooltip || !containerRef.current) return;
+
+        if (!param.time || !param.point || param.point.x < 0 || param.point.y < 0) {
+          tooltip.style.display = "none";
+          return;
+        }
+
+        const totalData = param.seriesData.get(totalSeries);
+        const realizedData = param.seriesData.get(realizedSeries);
+        const unrealizedData = param.seriesData.get(unrealizedSeries);
+        const volData = param.seriesData.get(volumeSeries);
+
+        if (!totalData || !("value" in totalData)) {
+          tooltip.style.display = "none";
+          return;
+        }
+
+        const total = (totalData as { value: number }).value;
+        const realized = realizedData && "value" in realizedData ? (realizedData as { value: number }).value : 0;
+        const unrealized = unrealizedData && "value" in unrealizedData ? (unrealizedData as { value: number }).value : 0;
+        const vol = volData && "value" in volData ? (volData as { value: number }).value : 0;
+        const ts = typeof param.time === "number" ? param.time : 0;
+        const date = new Date(ts * 1000);
+        const timeStr = date.toLocaleString("en-US", {
+          month: "short",
+          day: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+        });
+
+        const sign = (v: number) => (v >= 0 ? "+" : "");
+        const totalColor = total >= 0 ? colors.green : colors.red;
+
+        tooltip.innerHTML = `
+          <div style="color:#9ca3af;font-size:10px;margin-bottom:3px">${timeStr}</div>
+          <div style="display:flex;justify-content:space-between;gap:12px">
+            <span style="color:#9ca3af;font-size:10px">Total</span>
+            <span style="color:${totalColor};font-weight:600;font-size:12px">${currencySymbol}${sign(total)}${total.toFixed(2)}</span>
+          </div>
+          <div style="display:flex;justify-content:space-between;gap:12px">
+            <span style="color:#9ca3af;font-size:10px">Realized</span>
+            <span style="color:${colors.green};font-size:11px">${currencySymbol}${sign(realized)}${realized.toFixed(2)}</span>
+          </div>
+          <div style="display:flex;justify-content:space-between;gap:12px">
+            <span style="color:#9ca3af;font-size:10px">Unrealized</span>
+            <span style="color:${colors.orange};font-size:11px">${currencySymbol}${sign(unrealized)}${unrealized.toFixed(2)}</span>
+          </div>
+          ${vol > 0 ? `<div style="display:flex;justify-content:space-between;gap:12px;margin-top:2px;border-top:1px solid rgba(107,121,148,0.2);padding-top:2px"><span style="color:#9ca3af;font-size:10px">Cum. Vol</span><span style="color:${colors.blue};font-size:10px">${currencySymbol}${vol >= 1000 ? (vol / 1000).toFixed(1) + "K" : vol.toFixed(0)}</span></div>` : ""}
+        `;
+        tooltip.style.display = "block";
+
+        const containerRect = containerRef.current.getBoundingClientRect();
+        const tooltipW = 200;
+        let left = containerRect.left + param.point.x + 16;
+        if (left + tooltipW > window.innerWidth - 8) left = containerRect.left + param.point.x - tooltipW - 10;
+        const top = containerRect.top + Math.max(4, param.point.y - 30);
+        tooltip.style.left = `${left}px`;
+        tooltip.style.top = `${top}px`;
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      if (chartRef.current) {
+        chartRef.current.remove();
+        chartRef.current = null;
+      }
+    };
+  }, [aggregated, currencySymbol]);
+
+  if (!snapshots || snapshots.length === 0) return null;
+
+  if (aggregated.length < 2) return null;
+
+  return (
+    <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] overflow-hidden">
+      <div className="flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-1.5">
+        <div className="flex items-center gap-4">
+          <p className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-muted)]">
+            Portfolio PnL
+          </p>
+          {latest && (
+            <div className="flex items-center gap-3 text-xs tabular-nums">
+              <span style={{ color: pnlColor(latest.total) }} className="font-semibold">
+                {latest.total >= 0 ? "+" : ""}{formatCurrencyVolume(latest.total, currencySymbol)}
+              </span>
+              <span className="text-[var(--color-text-muted)]">
+                R: <span style={{ color: "var(--color-green)" }}>{latest.realized >= 0 ? "+" : ""}{formatCurrencyVolume(latest.realized, currencySymbol)}</span>
+              </span>
+              <span className="text-[var(--color-text-muted)]">
+                U: <span style={{ color: "#f59e0b" }}>{latest.unrealized >= 0 ? "+" : ""}{formatCurrencyVolume(latest.unrealized, currencySymbol)}</span>
+              </span>
+              <span className="text-[var(--color-text-muted)]">
+                Vol: {formatCurrencyVolume(latest.volume, currencySymbol)}
+              </span>
+            </div>
+          )}
+        </div>
+        <div className="flex items-center gap-2 text-[9px]">
+          <span className="flex items-center gap-1">
+            <span className="inline-block w-2.5 h-0.5 rounded" style={{ background: "#22c55e" }} />
+            Realized
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block w-2.5 h-0.5 rounded" style={{ background: "#f59e0b" }} />
+            Unrealized
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block w-2.5 h-0.5 rounded" style={{ background: "#3b82f690" }} />
+            Volume
+          </span>
+        </div>
+      </div>
+      <div>
+        <div ref={containerRef} style={{ height, width: "100%" }} />
+        <div
+          ref={tooltipRef}
+          style={{
+            display: "none",
+            position: "fixed",
+            top: 0,
+            left: 0,
+            zIndex: 9999,
+            pointerEvents: "none",
+            background: "rgba(15, 21, 37, 0.95)",
+            border: "1px solid rgba(107, 121, 148, 0.3)",
+            borderRadius: 6,
+            padding: "6px 10px",
+            fontSize: 11,
+            color: "#e2e8f0",
+            minWidth: 160,
+            whiteSpace: "nowrap",
+            lineHeight: 1.5,
+            backdropFilter: "blur(8px)",
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/bots/ControllerBrowser.tsx
+++ b/frontend/src/components/bots/ControllerBrowser.tsx
@@ -49,13 +49,18 @@ function parseSide(raw: string): string {
 }
 
 function StatusDot({ status }: { status: string }) {
+  const isStopping = status === "stopping";
   const color =
     status === "running"
       ? "text-[var(--color-green)]"
       : status === "stopped" || status === "error"
         ? "text-[var(--color-red)]"
         : "text-[var(--color-yellow)]";
-  return <Circle className={`h-2 w-2 fill-current ${color}`} />;
+  return isStopping ? (
+    <span className="h-2.5 w-2.5 animate-spin rounded-full border-[1.5px] border-[var(--color-yellow)] border-t-transparent" />
+  ) : (
+    <Circle className={`h-2 w-2 fill-current ${color}`} />
+  );
 }
 
 // ── Types ──
@@ -259,6 +264,7 @@ export function ControllerBrowser({
   const activeCtrl = controllers.find((c) => ctrlKey(c) === activeKey) ?? controllers[0];
 
   const isKilled = activeCtrl?.config?.manual_kill_switch === true;
+  const isStopping = activeCtrl?.status === "stopping";
 
   const toggleMutation = useMutation({
     mutationFn: () =>
@@ -343,6 +349,7 @@ export function ControllerBrowser({
             const key = ctrlKey(c);
             const isActive = key === activeKey;
             const killed = c.config?.manual_kill_switch === true;
+            const ctrlStopping = c.status === "stopping";
 
             if (isCompact) {
               return (
@@ -357,7 +364,7 @@ export function ControllerBrowser({
                   }`}
                   title={c.controller_name}
                 >
-                  <StatusDot status={killed ? "stopped" : c.status} />
+                  <StatusDot status={ctrlStopping ? "stopping" : killed ? "stopped" : c.status} />
                 </button>
               );
             }
@@ -374,7 +381,7 @@ export function ControllerBrowser({
                 }`}
               >
                 <div className="flex items-center gap-2">
-                  <StatusDot status={killed ? "stopped" : c.status} />
+                  <StatusDot status={ctrlStopping ? "stopping" : killed ? "stopped" : c.status} />
                   <span className={`truncate text-xs font-medium ${isActive ? "text-[var(--color-text)]" : "text-[var(--color-text-muted)]"}`}>
                     {c.controller_name}
                   </span>
@@ -437,22 +444,24 @@ export function ControllerBrowser({
               </span>
             )}
             <div className="flex items-center gap-1.5 shrink-0">
-              <StatusDot status={isKilled ? "stopped" : activeCtrl.status} />
-              <span className="text-xs capitalize">{isKilled ? "stopped" : activeCtrl.status}</span>
+              <StatusDot status={isStopping ? "stopping" : isKilled ? "stopped" : activeCtrl.status} />
+              <span className="text-xs capitalize">{isStopping ? "stopping" : isKilled ? "stopped" : activeCtrl.status}</span>
             </div>
           </div>
           <div className="flex items-center gap-1.5">
             <button
               onClick={() => toggleMutation.mutate()}
-              disabled={toggleMutation.isPending}
+              disabled={toggleMutation.isPending || isStopping}
               className={`flex items-center gap-1.5 rounded px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50 ${
-                isKilled
-                  ? "text-[var(--color-green)] hover:bg-[var(--color-green)]/10"
-                  : "text-[var(--color-yellow)] hover:bg-[var(--color-yellow)]/10"
+                isStopping
+                  ? "text-[var(--color-yellow)]"
+                  : isKilled
+                    ? "text-[var(--color-green)] hover:bg-[var(--color-green)]/10"
+                    : "text-[var(--color-yellow)] hover:bg-[var(--color-yellow)]/10"
               }`}
-              title={isKilled ? "Start controller" : "Pause controller"}
+              title={isStopping ? "Stopping..." : isKilled ? "Start controller" : "Pause controller"}
             >
-              {toggleMutation.isPending ? (
+              {toggleMutation.isPending || isStopping ? (
                 <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
               ) : isKilled ? (
                 <>

--- a/frontend/src/components/bots/ControllerBrowser.tsx
+++ b/frontend/src/components/bots/ControllerBrowser.tsx
@@ -78,11 +78,13 @@ function InlineConfigEditor({
   config,
   server,
   configId,
+  botName,
   onSaved,
 }: {
   config: Record<string, unknown>;
   server: string;
   configId: string;
+  botName: string;
   onSaved: () => void;
 }) {
   const [edits, setEdits] = useState<Record<string, string>>({});
@@ -99,7 +101,7 @@ function InlineConfigEditor({
       for (const [key, raw] of Object.entries(edits)) {
         parsed[key] = parseValue(raw, inferInputType(config[key]));
       }
-      return api.updateConfig(server, configId, parsed);
+      return api.updateBotControllerConfig(server, botName, configId, parsed);
     },
     onSuccess: () => {
       setEdits({});
@@ -655,6 +657,7 @@ export function ControllerBrowser({
               config={activeCtrl.config || {}}
               server={server}
               configId={configId}
+              botName={activeCtrl.bot_name}
               onSaved={() => queryClient.invalidateQueries({ queryKey: ["bots", server] })}
             />
           </div>

--- a/frontend/src/components/bots/ControllerBrowser.tsx
+++ b/frontend/src/components/bots/ControllerBrowser.tsx
@@ -263,8 +263,8 @@ export function ControllerBrowser({
   const toggleMutation = useMutation({
     mutationFn: () =>
       isKilled
-        ? api.startControllers(server, activeCtrl.bot_name, [activeCtrl.controller_name])
-        : api.stopControllers(server, activeCtrl.bot_name, [activeCtrl.controller_name]),
+        ? api.startControllers(server, activeCtrl.bot_name, [activeCtrl.controller_id])
+        : api.stopControllers(server, activeCtrl.bot_name, [activeCtrl.controller_id]),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["bots", server] });
     },

--- a/frontend/src/components/bots/ControllerBrowser.tsx
+++ b/frontend/src/components/bots/ControllerBrowser.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
-  Check,
   ChevronDown,
   ChevronLeft,
   ChevronRight,
@@ -14,9 +13,10 @@ import {
   Save,
   X,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import yamlLib from "js-yaml";
 
-import { HIDDEN_KEYS, inferInputType, parseValue } from "@/components/bots/DeployBotDialog";
+import { CodeEditor } from "@/components/editor/CodeEditor";
 import { ControllerPnlChart } from "@/components/bots/ControllerPnlChart";
 import { api, type ControllerInfo } from "@/lib/api";
 import { setViewContext } from "@/lib/viewContext";
@@ -72,9 +72,20 @@ interface ControllerBrowserProps {
   onClose: () => void;
 }
 
-// ── Inline Config Editor ──
+// Keys to strip from the YAML display (internal / read-only fields)
+const YAML_HIDDEN_KEYS = new Set(["id", "controller_name", "controller_type"]);
 
-function InlineConfigEditor({
+function configToYaml(config: Record<string, unknown>): string {
+  const filtered: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(config)) {
+    if (!YAML_HIDDEN_KEYS.has(k) && !k.startsWith("_")) filtered[k] = v;
+  }
+  return yamlLib.dump(filtered, { lineWidth: -1, noRefs: true, sortKeys: true });
+}
+
+// ── YAML Config Editor ──
+
+function YamlConfigEditor({
   config,
   server,
   configId,
@@ -87,39 +98,41 @@ function InlineConfigEditor({
   botName: string;
   onSaved: () => void;
 }) {
-  const [edits, setEdits] = useState<Record<string, string>>({});
-  const entries = useMemo(
-    () => Object.entries(config).filter(([k]) => !HIDDEN_KEYS.has(k)),
-    [config],
-  );
+  const originalYaml = configToYaml(config);
+  const [yamlContent, setYamlContent] = useState(originalYaml);
+  const [parseError, setParseError] = useState<string | null>(null);
 
-  const isDirty = Object.keys(edits).length > 0;
+  // Sync when config changes externally (e.g. after save or controller switch)
+  useEffect(() => {
+    const newYaml = configToYaml(config);
+    setYamlContent(newYaml);
+    setParseError(null);
+  }, [config]);
+
+  const isDirty = yamlContent !== originalYaml;
+
+  const handleChange = useCallback((value: string) => {
+    setYamlContent(value);
+    try {
+      yamlLib.load(value);
+      setParseError(null);
+    } catch (e) {
+      setParseError((e as Error).message?.split("\n")[0] || "Invalid YAML");
+    }
+  }, []);
 
   const saveMutation = useMutation({
     mutationFn: () => {
-      const parsed: Record<string, unknown> = {};
-      for (const [key, raw] of Object.entries(edits)) {
-        parsed[key] = parseValue(raw, inferInputType(config[key]));
+      const parsed = yamlLib.load(yamlContent) as Record<string, unknown>;
+      if (!parsed || typeof parsed !== "object") {
+        throw new Error("YAML must be a mapping");
       }
       return api.updateBotControllerConfig(server, botName, configId, parsed);
     },
     onSuccess: () => {
-      setEdits({});
       onSaved();
     },
   });
-
-  const handleEdit = useCallback((key: string, value: string) => {
-    setEdits((prev) => ({ ...prev, [key]: value }));
-  }, []);
-
-  const handleReset = useCallback((key: string) => {
-    setEdits((prev) => {
-      const next = { ...prev };
-      delete next[key];
-      return next;
-    });
-  }, []);
 
   return (
     <div className="flex flex-col h-full">
@@ -131,7 +144,7 @@ function InlineConfigEditor({
         <div className="flex items-center gap-1.5">
           {isDirty && (
             <button
-              onClick={() => setEdits({})}
+              onClick={() => { setYamlContent(originalYaml); setParseError(null); }}
               className="flex items-center gap-1 text-[10px] text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
             >
               <RotateCcw className="h-3 w-3" />
@@ -140,7 +153,7 @@ function InlineConfigEditor({
           )}
           <button
             onClick={() => saveMutation.mutate()}
-            disabled={!isDirty || saveMutation.isPending}
+            disabled={!isDirty || !!parseError || saveMutation.isPending}
             className="flex items-center gap-1 rounded px-2.5 py-1 text-[10px] font-semibold transition-colors disabled:opacity-30 bg-[var(--color-primary)] text-white hover:bg-[var(--color-primary)]/80 disabled:hover:bg-[var(--color-primary)]"
           >
             {saveMutation.isPending ? (
@@ -153,6 +166,11 @@ function InlineConfigEditor({
         </div>
       </div>
 
+      {parseError && (
+        <div className="px-4 py-1.5 text-[10px] text-[var(--color-red)] bg-[var(--color-red)]/5 truncate" title={parseError}>
+          {parseError}
+        </div>
+      )}
       {saveMutation.isError && (
         <div className="px-4 py-1.5 text-[10px] text-[var(--color-red)] bg-[var(--color-red)]/5">
           {(saveMutation.error as Error).message}
@@ -164,82 +182,15 @@ function InlineConfigEditor({
         </div>
       )}
 
-      {/* Scrollable fields */}
-      <div className="flex-1 overflow-y-auto scrollbar-thin px-4 py-3 space-y-2">
-        {entries.map(([key, originalValue]) => {
-          const inputType = inferInputType(originalValue);
-          const isEdited = key in edits;
-          const displayValue = isEdited
-            ? edits[key]
-            : inputType === "json"
-              ? JSON.stringify(originalValue, null, 2)
-              : String(originalValue ?? "");
-
-          return (
-            <div key={key} className="grid grid-cols-[minmax(100px,1fr)_1.5fr] gap-2 items-start">
-              <label
-                className={`text-[11px] pt-1.5 truncate ${isEdited ? "text-[var(--color-warning)] font-medium" : "text-[var(--color-text-muted)]"}`}
-                title={key}
-              >
-                {key}
-              </label>
-              <div className="flex items-start gap-1">
-                {inputType === "boolean" ? (
-                  <button
-                    onClick={() => {
-                      const current = isEdited ? edits[key] === "true" : Boolean(originalValue);
-                      handleEdit(key, String(!current));
-                    }}
-                    className={`flex items-center gap-2 rounded-md border px-2.5 py-1 text-[11px] transition-colors ${
-                      (isEdited ? edits[key] === "true" : Boolean(originalValue))
-                        ? "border-[var(--color-primary)]/40 bg-[var(--color-primary)]/10 text-[var(--color-primary)]"
-                        : "border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-muted)]"
-                    }`}
-                  >
-                    <div className={`h-3 w-3 rounded-sm border flex items-center justify-center ${
-                      (isEdited ? edits[key] === "true" : Boolean(originalValue))
-                        ? "border-[var(--color-primary)] bg-[var(--color-primary)]"
-                        : "border-[var(--color-border)]"
-                    }`}>
-                      {(isEdited ? edits[key] === "true" : Boolean(originalValue)) && (
-                        <Check className="h-2 w-2 text-white" />
-                      )}
-                    </div>
-                    {isEdited ? edits[key] : String(originalValue)}
-                  </button>
-                ) : inputType === "json" ? (
-                  <textarea
-                    value={displayValue}
-                    onChange={(e) => handleEdit(key, e.target.value)}
-                    rows={Math.min(4, displayValue.split("\n").length + 1)}
-                    className={`w-full rounded-md border bg-[var(--color-bg)] px-2 py-1 font-mono text-[11px] text-[var(--color-text)] outline-none transition-colors focus:border-[var(--color-primary)] resize-y ${
-                      isEdited ? "border-[var(--color-warning)]/60" : "border-[var(--color-border)]"
-                    }`}
-                  />
-                ) : (
-                  <input
-                    type={inputType === "number" ? "number" : "text"}
-                    step={inputType === "number" ? "any" : undefined}
-                    value={displayValue}
-                    onChange={(e) => handleEdit(key, e.target.value)}
-                    className={`w-full rounded-md border bg-[var(--color-bg)] px-2 py-1 text-[11px] text-[var(--color-text)] outline-none transition-colors focus:border-[var(--color-primary)] ${
-                      inputType === "number" ? "font-mono tabular-nums" : ""
-                    } ${isEdited ? "border-[var(--color-warning)]/60" : "border-[var(--color-border)]"}`}
-                  />
-                )}
-                {isEdited && (
-                  <button
-                    onClick={() => handleReset(key)}
-                    className="mt-0.5 p-1 rounded text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
-                    title="Reset to original"
-                  >
-                    <RotateCcw className="h-2.5 w-2.5" />
-                  </button>
-                )}
-              </div>
-            </div>
-          );
-        })}
+      {/* YAML editor */}
+      <div className="flex-1 min-h-0">
+        <CodeEditor
+          value={yamlContent}
+          onChange={handleChange}
+          language="yaml"
+          height="100%"
+          className="border-0 rounded-none"
+        />
       </div>
     </div>
   );
@@ -652,7 +603,7 @@ export function ControllerBrowser({
 
           {/* Right column: Config + Logs */}
           <div className="w-[380px] xl:w-[440px] shrink-0 border-l border-[var(--color-border)] flex flex-col bg-[var(--color-surface)]">
-            <InlineConfigEditor
+            <YamlConfigEditor
               key={configId}
               config={activeCtrl.config || {}}
               server={server}

--- a/frontend/src/components/bots/ControllerBrowser.tsx
+++ b/frontend/src/components/bots/ControllerBrowser.tsx
@@ -17,7 +17,8 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { HIDDEN_KEYS, inferInputType, parseValue } from "@/components/bots/DeployBotDialog";
-import { api, type BotLogEntry, type ControllerInfo } from "@/lib/api";
+import { ControllerPnlChart } from "@/components/bots/ControllerPnlChart";
+import { api, type ControllerInfo } from "@/lib/api";
 import { setViewContext } from "@/lib/viewContext";
 
 // ── Shared formatters ──
@@ -57,23 +58,12 @@ function StatusDot({ status }: { status: string }) {
   return <Circle className={`h-2 w-2 fill-current ${color}`} />;
 }
 
-function formatLogTime(ts?: number): string {
-  if (!ts) return "";
-  try {
-    const d = new Date(ts * 1000);
-    return d.toLocaleTimeString("en-US", { hour12: false, hour: "2-digit", minute: "2-digit", second: "2-digit" });
-  } catch {
-    return "";
-  }
-}
-
 // ── Types ──
 
 interface ControllerBrowserProps {
   controllers: ControllerInfo[];
   server: string;
   initialControllerKey: string;
-  allLogs: Record<string, BotLogEntry[]>;
   onClose: () => void;
 }
 
@@ -254,12 +244,10 @@ export function ControllerBrowser({
   controllers,
   server,
   initialControllerKey,
-  allLogs,
   onClose,
 }: ControllerBrowserProps) {
   const queryClient = useQueryClient();
   const [isCompact, setIsCompact] = useState(false);
-  const [rightTab, setRightTab] = useState<"config" | "logs">("config");
   const sidebarRef = useRef<HTMLDivElement>(null);
 
   const ctrlKey = useCallback(
@@ -324,7 +312,6 @@ export function ControllerBrowser({
 
   if (!activeCtrl) return null;
 
-  const logs = allLogs[activeCtrl.bot_name] ?? [];
   const configId = activeCtrl.controller_id || activeCtrl.controller_name;
 
   return (
@@ -504,6 +491,15 @@ export function ControllerBrowser({
         <div className="flex flex-1 min-h-0">
           {/* Left column: Performance data */}
           <div className="flex-1 overflow-y-auto p-5 space-y-4 min-w-0">
+            {/* PnL Evolution Chart */}
+            <ControllerPnlChart
+              key={configId}
+              server={server}
+              controllerId={configId}
+              botName={activeCtrl.bot_name}
+              height={200}
+            />
+
             {/* PnL Breakdown - compact horizontal */}
             <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
               <div className="grid grid-cols-2 lg:grid-cols-5 gap-4 text-sm">
@@ -644,49 +640,13 @@ export function ControllerBrowser({
 
           {/* Right column: Config + Logs */}
           <div className="w-[380px] xl:w-[440px] shrink-0 border-l border-[var(--color-border)] flex flex-col bg-[var(--color-surface)]">
-            {/* Tabs */}
-            <div className="flex border-b border-[var(--color-border)]">
-              <button
-                onClick={() => setRightTab("config")}
-                className={`flex-1 px-3 py-2 text-xs font-medium transition-colors ${
-                  rightTab === "config"
-                    ? "text-[var(--color-primary)] border-b-2 border-[var(--color-primary)] -mb-px"
-                    : "text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
-                }`}
-              >
-                Config
-              </button>
-              <button
-                onClick={() => setRightTab("logs")}
-                className={`flex-1 px-3 py-2 text-xs font-medium transition-colors ${
-                  rightTab === "logs"
-                    ? "text-[var(--color-primary)] border-b-2 border-[var(--color-primary)] -mb-px"
-                    : "text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
-                }`}
-              >
-                Logs
-                {logs.filter((l) => l.log_category === "error").length > 0 && (
-                  <span className="ml-1.5 inline-flex items-center justify-center rounded-full bg-[var(--color-red)]/15 px-1.5 text-[9px] font-semibold text-[var(--color-red)]">
-                    {logs.filter((l) => l.log_category === "error").length}
-                  </span>
-                )}
-              </button>
-            </div>
-
-            {/* Tab content */}
-            {rightTab === "config" ? (
-              <InlineConfigEditor
-                key={configId}
-                config={activeCtrl.config || {}}
-                server={server}
-                configId={configId}
-                onSaved={() => queryClient.invalidateQueries({ queryKey: ["bots", server] })}
-              />
-            ) : (
-              <div className="flex-1 overflow-y-auto">
-                <LogsSection logs={logs} />
-              </div>
-            )}
+            <InlineConfigEditor
+              key={configId}
+              config={activeCtrl.config || {}}
+              server={server}
+              configId={configId}
+              onSaved={() => queryClient.invalidateQueries({ queryKey: ["bots", server] })}
+            />
           </div>
         </div>
       </div>
@@ -694,66 +654,3 @@ export function ControllerBrowser({
   );
 }
 
-// ── Logs section ──
-
-function LogsSection({ logs }: { logs: BotLogEntry[] }) {
-  const [filter, setFilter] = useState<"all" | "error" | "general">("all");
-  const filtered = filter === "all" ? logs : logs.filter((l) => l.log_category === filter);
-
-  const errorCount = logs.filter((l) => l.log_category === "error").length;
-  const generalCount = logs.filter((l) => l.log_category === "general").length;
-
-  if (logs.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center h-full text-[var(--color-text-muted)]">
-        <p className="text-xs">No logs available</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex flex-col h-full">
-      <div className="flex items-center gap-1.5 px-3 py-2 border-b border-[var(--color-border)]/50">
-        {(["all", "general", "error"] as const).map((f) => {
-          const count = f === "all" ? logs.length : f === "error" ? errorCount : generalCount;
-          return (
-            <button
-              key={f}
-              onClick={() => setFilter(f)}
-              className={`rounded px-2 py-0.5 text-[10px] font-medium transition-colors ${
-                filter === f
-                  ? f === "error"
-                    ? "bg-[var(--color-red)]/15 text-[var(--color-red)]"
-                    : "bg-[var(--color-primary)]/15 text-[var(--color-primary)]"
-                  : "text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
-              }`}
-            >
-              {f} ({count})
-            </button>
-          );
-        })}
-      </div>
-      <div className="flex-1 overflow-y-auto font-mono text-[11px] leading-relaxed">
-        {filtered.map((log, i) => (
-          <div
-            key={i}
-            className={`flex gap-2 px-2.5 py-1 border-b border-[var(--color-border)]/10 ${
-              log.log_category === "error" ? "bg-[var(--color-red)]/5" : ""
-            }`}
-          >
-            <span className="text-[var(--color-text-muted)] shrink-0 tabular-nums">
-              {formatLogTime(log.timestamp)}
-            </span>
-            <span
-              className={`break-all ${
-                log.log_category === "error" ? "text-[var(--color-red)]" : "text-[var(--color-text)]"
-              }`}
-            >
-              {log.msg || JSON.stringify(log)}
-            </span>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}

--- a/frontend/src/components/bots/ControllerBrowser.tsx
+++ b/frontend/src/components/bots/ControllerBrowser.tsx
@@ -506,6 +506,7 @@ export function ControllerBrowser({
               server={server}
               controllerId={configId}
               botName={activeCtrl.bot_name}
+              deployedAt={activeCtrl.deployed_at}
               height={200}
             />
 

--- a/frontend/src/components/bots/ControllerPnlChart.tsx
+++ b/frontend/src/components/bots/ControllerPnlChart.tsx
@@ -1,256 +1,178 @@
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useRef } from "react";
+import { useMemo } from "react";
+import {
+  Area,
+  CartesianGrid,
+  ComposedChart,
+  Legend,
+  Line,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 
 import { api } from "@/lib/api";
+import { formatCurrencyVolume, pnlColor } from "@/lib/formatters";
 
-function getChartColors() {
-  const style = getComputedStyle(document.documentElement);
-  return {
-    bg: style.getPropertyValue("--chart-bg").trim() || "#0f1525",
-    grid: style.getPropertyValue("--chart-grid").trim() || "#1c2541",
-    text: style.getPropertyValue("--chart-text").trim() || "#6b7994",
-    green: style.getPropertyValue("--chart-up").trim() || "#22c55e",
-    red: style.getPropertyValue("--chart-down").trim() || "#ef4444",
-    blue: "#3b82f6",
-    orange: "#f59e0b",
-    purple: "#a855f7",
-  };
+function toMs(ts: string | number): number {
+  if (typeof ts === "number") return ts > 1e12 ? ts : ts * 1000;
+  const parsed = Date.parse(ts);
+  return isNaN(parsed) ? 0 : parsed;
 }
+
+function formatTime(ms: number): string {
+  return new Date(ms).toLocaleTimeString("en-US", { hour12: false, hour: "2-digit", minute: "2-digit" });
+}
+
+function formatDateTime(ms: number): string {
+  const d = new Date(ms);
+  return `${d.toLocaleDateString("en-US", { month: "short", day: "numeric" })} ${d.toLocaleTimeString("en-US", { hour12: false, hour: "2-digit", minute: "2-digit" })}`;
+}
+
+/** Compute net position value in quote from positions_summary */
+function positionQuoteValue(positions: Record<string, unknown>[]): number {
+  let value = 0;
+  for (const pos of positions) {
+    const amt = Number(pos.amount || pos.net_amount_base || 0);
+    const price = Number(pos.breakeven_price || pos.entry_price || pos.current_price || 0);
+    const side = String(pos.side || pos.position_side || "");
+    const isSell = side.toLowerCase().includes("sell") || side.toLowerCase().includes("short");
+    const notional = amt * price;
+    value += isSell ? -notional : notional;
+  }
+  return value;
+}
+
+interface DataPoint {
+  time: number;
+  realized: number;
+  unrealized: number;
+  total: number;
+  volume: number;
+  position: number;
+}
+
+// ── Tooltips ──
+
+function PnlTooltip({ active, payload, label, symbol }: {
+  active?: boolean;
+  payload?: Array<{ dataKey: string; value: number }>;
+  label?: number;
+  symbol: string;
+}) {
+  if (!active || !payload?.length || !label) return null;
+  const byKey: Record<string, number> = {};
+  for (const p of payload) byKey[p.dataKey] = p.value;
+  const total = byKey.total ?? (byKey.realized ?? 0) + (byKey.unrealized ?? 0);
+  const sign = (v: number) => (v >= 0 ? "+" : "");
+
+  return (
+    <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg)]/95 backdrop-blur-sm px-2.5 py-2 text-[11px] leading-relaxed shadow-lg min-w-[150px]">
+      <div className="text-[var(--color-text-muted)] text-[10px] mb-1">{formatDateTime(label)}</div>
+      <div className="flex justify-between gap-3">
+        <span className="text-[var(--color-text-muted)]">Total</span>
+        <span className="font-semibold" style={{ color: pnlColor(total) }}>
+          {sign(total)}{formatCurrencyVolume(total, symbol)}
+        </span>
+      </div>
+      <div className="flex justify-between gap-3">
+        <span className="text-[var(--color-text-muted)]">Realized</span>
+        <span style={{ color: "var(--color-green)" }}>{sign(byKey.realized ?? 0)}{formatCurrencyVolume(byKey.realized ?? 0, symbol)}</span>
+      </div>
+      <div className="flex justify-between gap-3">
+        <span className="text-[var(--color-text-muted)]">Unrealized</span>
+        <span style={{ color: "#f59e0b" }}>{sign(byKey.unrealized ?? 0)}{formatCurrencyVolume(byKey.unrealized ?? 0, symbol)}</span>
+      </div>
+    </div>
+  );
+}
+
+function BottomTooltip({ active, payload, label, symbol }: {
+  active?: boolean;
+  payload?: Array<{ dataKey: string; value: number }>;
+  label?: number;
+  symbol: string;
+}) {
+  if (!active || !payload?.length || !label) return null;
+  const byKey: Record<string, number> = {};
+  for (const p of payload) byKey[p.dataKey] = p.value;
+
+  return (
+    <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg)]/95 backdrop-blur-sm px-2.5 py-2 text-[11px] leading-relaxed shadow-lg min-w-[130px]">
+      <div className="text-[var(--color-text-muted)] text-[10px] mb-1">{formatDateTime(label)}</div>
+      <div className="flex justify-between gap-3">
+        <span style={{ color: "#3b82f6" }}>Volume</span>
+        <span style={{ color: "#3b82f6" }}>{formatCurrencyVolume(byKey.volume ?? 0, symbol)}</span>
+      </div>
+      {byKey.position !== undefined && byKey.position !== 0 && (
+        <div className="flex justify-between gap-3">
+          <span style={{ color: "#a78bfa" }}>Position</span>
+          <span style={{ color: "#a78bfa" }}>{formatCurrencyVolume(byKey.position, symbol)}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Component ──
 
 interface Props {
   server: string;
   controllerId: string;
   botName: string;
+  deployedAt?: string | null;
   height?: number;
+  currencySymbol?: string;
 }
 
-export function ControllerPnlChart({ server, controllerId, botName, height = 400 }: Props) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const tooltipRef = useRef<HTMLDivElement>(null);
-  const chartRef = useRef<import("lightweight-charts").IChartApi | null>(null);
-
-  const { data, isLoading } = useQuery({
-    queryKey: ["controller-perf-history", server, controllerId],
+export function ControllerPnlChart({ server, controllerId, botName, deployedAt, height = 400, currencySymbol = "$" }: Props) {
+  const { data: raw, isLoading } = useQuery({
+    queryKey: ["controller-perf-history", server, controllerId, deployedAt],
     queryFn: () =>
       api.getControllerPerformanceHistory(server, {
         controller_id: controllerId,
         bot_name: botName,
         interval: "5m",
         limit: 1000,
+        start_time: deployedAt ?? undefined,
       }),
     refetchInterval: 60_000,
     staleTime: 30_000,
   });
 
-  const snapshots = data?.snapshots ?? [];
+  const snapshots = raw?.snapshots ?? [];
 
-  useEffect(() => {
-    if (!containerRef.current || snapshots.length === 0) return;
+  const { data, hasPosition, latest } = useMemo(() => {
+    if (snapshots.length === 0) return { data: [], hasPosition: false, latest: null };
 
-    let cancelled = false;
+    const sorted = [...snapshots].sort((a, b) => toMs(a.timestamp) - toMs(b.timestamp));
+    let hasPos = false;
 
-    import("lightweight-charts").then((mod) => {
-      if (cancelled || !containerRef.current) return;
-
-      if (chartRef.current) {
-        chartRef.current.remove();
-        chartRef.current = null;
+    const pts: DataPoint[] = sorted.map((s) => {
+      let posValue = 0;
+      if (s.positions_summary) {
+        posValue = positionQuoteValue(s.positions_summary as Record<string, unknown>[]);
       }
+      if (posValue !== 0) hasPos = true;
 
-      const colors = getChartColors();
-      const chart = mod.createChart(containerRef.current!, {
-        autoSize: true,
-        layout: {
-          background: { type: mod.ColorType.Solid, color: colors.bg },
-          textColor: colors.text,
-        },
-        grid: {
-          vertLines: { color: colors.grid },
-          horzLines: { color: colors.grid },
-        },
-        crosshair: { mode: mod.CrosshairMode.Normal },
-        timeScale: { timeVisible: true, secondsVisible: false },
-        rightPriceScale: { borderVisible: false },
-        localization: {
-          priceFormatter: (price: number) => `$${price >= 0 ? "+" : ""}${price.toFixed(2)}`,
-        },
-      });
-      chartRef.current = chart;
-
-      const sorted = [...snapshots].sort((a, b) => toSeconds(a.timestamp) - toSeconds(b.timestamp));
-
-      // Realized PnL line (green)
-      const realizedSeries = chart.addSeries(mod.LineSeries, {
-        color: colors.green,
-        lineWidth: 2,
-        priceLineVisible: false,
-        lastValueVisible: true,
-        title: "Realized",
-      });
-
-      // Unrealized PnL line (orange)
-      const unrealizedSeries = chart.addSeries(mod.LineSeries, {
-        color: colors.orange,
-        lineWidth: 2,
-        lineStyle: mod.LineStyle.Dashed,
-        priceLineVisible: false,
-        lastValueVisible: true,
-        title: "Unrealized",
-      });
-
-      // Net position (purple, secondary axis)
-      const positionSeries = chart.addSeries(mod.LineSeries, {
-        color: colors.purple,
-        lineWidth: 1,
-        priceScaleId: "position",
-        priceLineVisible: false,
-        lastValueVisible: true,
-        title: "Position",
-      });
-      chart.priceScale("position").applyOptions({
-        scaleMargins: { top: 0.7, bottom: 0.02 },
-      });
-
-      // Cumulative volume line (blue, secondary axis)
-      const volumeSeries = chart.addSeries(mod.LineSeries, {
-        color: `${colors.blue}90`,
-        lineWidth: 1,
-        priceScaleId: "volume",
-        priceLineVisible: false,
-        lastValueVisible: true,
-        title: "Cum. Vol",
-        priceFormat: { type: "volume" },
-      });
-      chart.priceScale("volume").applyOptions({
-        scaleMargins: { top: 0.75, bottom: 0 },
-      });
-
-      realizedSeries.setData(
-        sorted.map((s) => ({
-          time: toSeconds(s.timestamp) as import("lightweight-charts").UTCTimestamp,
-          value: s.realized_pnl_quote,
-        })),
-      );
-
-      unrealizedSeries.setData(
-        sorted.map((s) => ({
-          time: toSeconds(s.timestamp) as import("lightweight-charts").UTCTimestamp,
-          value: s.unrealized_pnl_quote,
-        })),
-      );
-
-      // Extract net position from positions_summary
-      const hasPosition = sorted.some((s) => s.positions_summary?.length > 0);
-      if (hasPosition) {
-        positionSeries.setData(
-          sorted.map((s) => {
-            let netAmount = 0;
-            if (s.positions_summary) {
-              for (const pos of s.positions_summary) {
-                netAmount += Number(pos.amount || pos.net_amount || pos.position_amount || 0);
-              }
-            }
-            return {
-              time: toSeconds(s.timestamp) as import("lightweight-charts").UTCTimestamp,
-              value: netAmount,
-            };
-          }),
-        );
-      } else {
-        // Hide position scale if no data
-        positionSeries.applyOptions({ visible: false });
-      }
-
-      volumeSeries.setData(
-        sorted.map((s) => ({
-          time: toSeconds(s.timestamp) as import("lightweight-charts").UTCTimestamp,
-          value: s.volume_traded,
-        })),
-      );
-
-      chart.timeScale().fitContent();
-
-      // Crosshair tooltip
-      chart.subscribeCrosshairMove((param) => {
-        const tooltip = tooltipRef.current;
-        if (!tooltip || !containerRef.current) return;
-
-        if (!param.time || !param.point || param.point.x < 0 || param.point.y < 0) {
-          tooltip.style.display = "none";
-          return;
-        }
-
-        const realizedData = param.seriesData.get(realizedSeries);
-        const unrealizedData = param.seriesData.get(unrealizedSeries);
-        const volData = param.seriesData.get(volumeSeries);
-        const posData = param.seriesData.get(positionSeries);
-
-        if (!realizedData || !("value" in realizedData)) {
-          tooltip.style.display = "none";
-          return;
-        }
-
-        const realized = (realizedData as { value: number }).value;
-        const unrealized = unrealizedData && "value" in unrealizedData ? (unrealizedData as { value: number }).value : 0;
-        const total = realized + unrealized;
-        const vol = volData && "value" in volData ? (volData as { value: number }).value : 0;
-        const pos = posData && "value" in posData ? (posData as { value: number }).value : null;
-        const ts = typeof param.time === "number" ? param.time : 0;
-        const date = new Date(ts * 1000);
-        const timeStr = date.toLocaleString("en-US", {
-          month: "short",
-          day: "numeric",
-          hour: "2-digit",
-          minute: "2-digit",
-        });
-
-        const sign = (v: number) => (v >= 0 ? "+" : "");
-        const totalColor = total >= 0 ? colors.green : colors.red;
-
-        tooltip.innerHTML = `
-          <div style="color:#9ca3af;font-size:10px;margin-bottom:3px">${timeStr}</div>
-          <div style="display:flex;justify-content:space-between;gap:12px">
-            <span style="color:#9ca3af;font-size:10px">Total</span>
-            <span style="color:${totalColor};font-weight:600;font-size:12px">$${sign(total)}${total.toFixed(2)}</span>
-          </div>
-          <div style="display:flex;justify-content:space-between;gap:12px">
-            <span style="color:#9ca3af;font-size:10px">Realized</span>
-            <span style="color:${colors.green};font-size:11px">$${sign(realized)}${realized.toFixed(2)}</span>
-          </div>
-          <div style="display:flex;justify-content:space-between;gap:12px">
-            <span style="color:#9ca3af;font-size:10px">Unrealized</span>
-            <span style="color:${colors.orange};font-size:11px">$${sign(unrealized)}${unrealized.toFixed(2)}</span>
-          </div>
-          ${vol > 0 ? `<div style="display:flex;justify-content:space-between;gap:12px;margin-top:2px;border-top:1px solid rgba(107,121,148,0.2);padding-top:2px"><span style="color:#9ca3af;font-size:10px">Cum. Vol</span><span style="color:${colors.blue};font-size:10px">$${vol >= 1000 ? (vol / 1000).toFixed(1) + "K" : vol.toFixed(0)}</span></div>` : ""}
-          ${pos !== null && hasPosition ? `<div style="display:flex;justify-content:space-between;gap:12px"><span style="color:#9ca3af;font-size:10px">Position</span><span style="color:${colors.purple};font-size:10px">${pos.toFixed(4)}</span></div>` : ""}
-        `;
-        tooltip.style.display = "block";
-
-        const containerRect = containerRef.current.getBoundingClientRect();
-        const tooltipW = 200;
-        let left = containerRect.left + param.point.x + 16;
-        if (left + tooltipW > window.innerWidth - 8) left = containerRect.left + param.point.x - tooltipW - 10;
-        const top = containerRect.top + Math.max(4, param.point.y - 30);
-        tooltip.style.left = `${left}px`;
-        tooltip.style.top = `${top}px`;
-      });
+      return {
+        time: toMs(s.timestamp),
+        realized: s.realized_pnl_quote,
+        unrealized: s.unrealized_pnl_quote,
+        total: s.realized_pnl_quote + s.unrealized_pnl_quote,
+        volume: s.volume_traded,
+        position: posValue,
+      };
     });
 
-    return () => {
-      cancelled = true;
-      if (chartRef.current) {
-        chartRef.current.remove();
-        chartRef.current = null;
-      }
-    };
+    return { data: pts, hasPosition: hasPos, latest: pts[pts.length - 1] || null };
   }, [snapshots]);
 
   if (isLoading) {
     return (
-      <div
-        className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center"
-        style={{ height }}
-      >
+      <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center" style={{ height }}>
         <div className="flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
           <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
           Loading performance history...
@@ -259,78 +181,123 @@ export function ControllerPnlChart({ server, controllerId, botName, height = 400
     );
   }
 
-  if (snapshots.length === 0) {
+  if (data.length === 0) {
     return (
-      <div
-        className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center"
-        style={{ height }}
-      >
+      <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center" style={{ height }}>
         <p className="text-xs text-[var(--color-text-muted)]">No performance history available</p>
       </div>
     );
   }
 
+  const pnlH = Math.round(height * 0.65);
+  const bottomH = height - pnlH;
+  const fmtAxis = (v: number) => `${currencySymbol}${Math.abs(v) >= 1000 ? (v / 1000).toFixed(1) + "K" : v.toFixed(Math.abs(v) < 10 ? 2 : 0)}`;
+  const fmtVolAxis = (v: number) => `${currencySymbol}${Math.abs(v) >= 1000 ? (v / 1000).toFixed(1) + "K" : v.toFixed(0)}`;
+
   return (
     <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] overflow-hidden">
       <div className="flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-1.5">
-        <div className="flex items-center gap-3">
-          <p className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-muted)]">
-            PnL Evolution
-          </p>
-          <div className="flex items-center gap-2 text-[9px]">
-            <span className="flex items-center gap-1">
-              <span className="inline-block w-2.5 h-0.5 rounded" style={{ background: "#22c55e" }} />
-              Realized
-            </span>
-            <span className="flex items-center gap-1">
-              <span className="inline-block w-2.5 h-0.5 rounded" style={{ background: "#f59e0b", borderTop: "1px dashed #f59e0b" }} />
-              Unrealized
-            </span>
-            <span className="flex items-center gap-1">
-              <span className="inline-block w-2.5 h-0.5 rounded" style={{ background: "#3b82f690" }} />
-              Volume
-            </span>
-            <span className="flex items-center gap-1">
-              <span className="inline-block w-2.5 h-0.5 rounded" style={{ background: "#a855f7" }} />
-              Position
-            </span>
-          </div>
-        </div>
-        <span className="text-[10px] text-[var(--color-text-muted)]">
-          {snapshots.length} snapshots
-        </span>
+        <p className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-muted)]">
+          PnL Evolution
+        </p>
+        <span className="text-[10px] text-[var(--color-text-muted)]">{snapshots.length} snapshots</span>
       </div>
-      <div>
-        <div ref={containerRef} style={{ height, width: "100%" }} />
-        <div
-          ref={tooltipRef}
-          style={{
-            display: "none",
-            position: "fixed",
-            top: 0,
-            left: 0,
-            zIndex: 9999,
-            pointerEvents: "none",
-            background: "rgba(15, 21, 37, 0.95)",
-            border: "1px solid rgba(107, 121, 148, 0.3)",
-            borderRadius: 6,
-            padding: "6px 10px",
-            fontSize: 11,
-            color: "#e2e8f0",
-            minWidth: 160,
-            whiteSpace: "nowrap",
-            lineHeight: 1.5,
-            backdropFilter: "blur(8px)",
-          }}
-        />
+
+      {/* PnL chart */}
+      <div className="px-1">
+        <ResponsiveContainer width="100%" height={pnlH}>
+          <ComposedChart data={data} margin={{ top: 12, right: 12, left: 0, bottom: 0 }} syncId="ctrl">
+            <defs>
+              <linearGradient id="ctrlPnlGrad" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor={(latest?.total ?? 0) >= 0 ? "#22c55e" : "#ef4444"} stopOpacity={0.15} />
+                <stop offset="95%" stopColor={(latest?.total ?? 0) >= 0 ? "#22c55e" : "#ef4444"} stopOpacity={0.02} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" strokeOpacity={0.5} />
+            <XAxis
+              dataKey="time"
+              type="number"
+              domain={["dataMin", "dataMax"]}
+              tickFormatter={formatTime}
+              tick={{ fontSize: 10, fill: "var(--color-text-muted)" }}
+              stroke="var(--color-border)"
+              tickLine={false}
+            />
+            <YAxis
+              tickFormatter={fmtAxis}
+              tick={{ fontSize: 10, fill: "var(--color-text-muted)" }}
+              stroke="var(--color-border)"
+              tickLine={false}
+              axisLine={false}
+              width={52}
+            />
+            <ReferenceLine y={0} stroke="var(--color-text-muted)" strokeOpacity={0.3} strokeDasharray="4 4" />
+            <Tooltip content={<PnlTooltip symbol={currencySymbol} />} />
+            <Area type="monotone" dataKey="total" stroke="none" fill="url(#ctrlPnlGrad)" activeDot={false} legendType="none" />
+            <Line type="monotone" dataKey="total" stroke={(latest?.total ?? 0) >= 0 ? "#22c55e" : "#ef4444"} strokeWidth={2} dot={false} strokeOpacity={0.6} />
+            <Line type="monotone" dataKey="realized" stroke="#22c55e" strokeWidth={2} dot={false} />
+            <Line type="monotone" dataKey="unrealized" stroke="#f59e0b" strokeWidth={2} strokeDasharray="5 3" dot={false} />
+            <Legend
+              verticalAlign="top"
+              align="right"
+              iconType="plainline"
+              wrapperStyle={{ fontSize: 10, paddingBottom: 4 }}
+              formatter={(value: string) => <span className="text-[var(--color-text-muted)] text-[10px] capitalize">{value}</span>}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Volume + Position chart */}
+      <div className="px-1 border-t border-[var(--color-border)]/30">
+        <ResponsiveContainer width="100%" height={bottomH}>
+          <ComposedChart data={data} margin={{ top: 8, right: 12, left: 0, bottom: 4 }} syncId="ctrl">
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" strokeOpacity={0.5} />
+            <XAxis
+              dataKey="time"
+              type="number"
+              domain={["dataMin", "dataMax"]}
+              tickFormatter={formatTime}
+              tick={{ fontSize: 10, fill: "var(--color-text-muted)" }}
+              stroke="var(--color-border)"
+              tickLine={false}
+            />
+            <YAxis
+              yAxisId="vol"
+              tickFormatter={fmtVolAxis}
+              tick={{ fontSize: 10, fill: "#3b82f6" }}
+              stroke="var(--color-border)"
+              tickLine={false}
+              axisLine={false}
+              width={52}
+            />
+            {hasPosition && (
+              <YAxis
+                yAxisId="pos"
+                orientation="right"
+                tickFormatter={fmtVolAxis}
+                tick={{ fontSize: 10, fill: "#a78bfa" }}
+                stroke="var(--color-border)"
+                tickLine={false}
+                axisLine={false}
+                width={52}
+              />
+            )}
+            <Tooltip content={<BottomTooltip symbol={currencySymbol} />} />
+            <Line yAxisId="vol" type="monotone" dataKey="volume" stroke="#3b82f6" strokeWidth={1.5} dot={false} />
+            {hasPosition && (
+              <Line yAxisId="pos" type="monotone" dataKey="position" stroke="#a78bfa" strokeWidth={1.5} dot={false} />
+            )}
+            <Legend
+              verticalAlign="top"
+              align="right"
+              iconType="plainline"
+              wrapperStyle={{ fontSize: 10, paddingBottom: 0 }}
+              formatter={(value: string) => <span className="text-[var(--color-text-muted)] text-[10px] capitalize">{value}</span>}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
       </div>
     </div>
   );
-}
-
-function toSeconds(ts: string | number): number {
-  if (typeof ts === "number") return ts > 1e12 ? Math.floor(ts / 1000) : ts;
-  const parsed = Date.parse(ts);
-  if (!isNaN(parsed)) return Math.floor(parsed / 1000);
-  return 0;
 }

--- a/frontend/src/components/bots/ControllerPnlChart.tsx
+++ b/frontend/src/components/bots/ControllerPnlChart.tsx
@@ -1,0 +1,336 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+
+import { api } from "@/lib/api";
+
+function getChartColors() {
+  const style = getComputedStyle(document.documentElement);
+  return {
+    bg: style.getPropertyValue("--chart-bg").trim() || "#0f1525",
+    grid: style.getPropertyValue("--chart-grid").trim() || "#1c2541",
+    text: style.getPropertyValue("--chart-text").trim() || "#6b7994",
+    green: style.getPropertyValue("--chart-up").trim() || "#22c55e",
+    red: style.getPropertyValue("--chart-down").trim() || "#ef4444",
+    blue: "#3b82f6",
+    orange: "#f59e0b",
+    purple: "#a855f7",
+  };
+}
+
+interface Props {
+  server: string;
+  controllerId: string;
+  botName: string;
+  height?: number;
+}
+
+export function ControllerPnlChart({ server, controllerId, botName, height = 400 }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<import("lightweight-charts").IChartApi | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["controller-perf-history", server, controllerId],
+    queryFn: () =>
+      api.getControllerPerformanceHistory(server, {
+        controller_id: controllerId,
+        bot_name: botName,
+        interval: "5m",
+        limit: 1000,
+      }),
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+
+  const snapshots = data?.snapshots ?? [];
+
+  useEffect(() => {
+    if (!containerRef.current || snapshots.length === 0) return;
+
+    let cancelled = false;
+
+    import("lightweight-charts").then((mod) => {
+      if (cancelled || !containerRef.current) return;
+
+      if (chartRef.current) {
+        chartRef.current.remove();
+        chartRef.current = null;
+      }
+
+      const colors = getChartColors();
+      const chart = mod.createChart(containerRef.current!, {
+        autoSize: true,
+        layout: {
+          background: { type: mod.ColorType.Solid, color: colors.bg },
+          textColor: colors.text,
+        },
+        grid: {
+          vertLines: { color: colors.grid },
+          horzLines: { color: colors.grid },
+        },
+        crosshair: { mode: mod.CrosshairMode.Normal },
+        timeScale: { timeVisible: true, secondsVisible: false },
+        rightPriceScale: { borderVisible: false },
+        localization: {
+          priceFormatter: (price: number) => `$${price >= 0 ? "+" : ""}${price.toFixed(2)}`,
+        },
+      });
+      chartRef.current = chart;
+
+      const sorted = [...snapshots].sort((a, b) => toSeconds(a.timestamp) - toSeconds(b.timestamp));
+
+      // Realized PnL line (green)
+      const realizedSeries = chart.addSeries(mod.LineSeries, {
+        color: colors.green,
+        lineWidth: 2,
+        priceLineVisible: false,
+        lastValueVisible: true,
+        title: "Realized",
+      });
+
+      // Unrealized PnL line (orange)
+      const unrealizedSeries = chart.addSeries(mod.LineSeries, {
+        color: colors.orange,
+        lineWidth: 2,
+        lineStyle: mod.LineStyle.Dashed,
+        priceLineVisible: false,
+        lastValueVisible: true,
+        title: "Unrealized",
+      });
+
+      // Net position (purple, secondary axis)
+      const positionSeries = chart.addSeries(mod.LineSeries, {
+        color: colors.purple,
+        lineWidth: 1,
+        priceScaleId: "position",
+        priceLineVisible: false,
+        lastValueVisible: true,
+        title: "Position",
+      });
+      chart.priceScale("position").applyOptions({
+        scaleMargins: { top: 0.7, bottom: 0.02 },
+      });
+
+      // Cumulative volume line (blue, secondary axis)
+      const volumeSeries = chart.addSeries(mod.LineSeries, {
+        color: `${colors.blue}90`,
+        lineWidth: 1,
+        priceScaleId: "volume",
+        priceLineVisible: false,
+        lastValueVisible: true,
+        title: "Cum. Vol",
+        priceFormat: { type: "volume" },
+      });
+      chart.priceScale("volume").applyOptions({
+        scaleMargins: { top: 0.75, bottom: 0 },
+      });
+
+      realizedSeries.setData(
+        sorted.map((s) => ({
+          time: toSeconds(s.timestamp) as import("lightweight-charts").UTCTimestamp,
+          value: s.realized_pnl_quote,
+        })),
+      );
+
+      unrealizedSeries.setData(
+        sorted.map((s) => ({
+          time: toSeconds(s.timestamp) as import("lightweight-charts").UTCTimestamp,
+          value: s.unrealized_pnl_quote,
+        })),
+      );
+
+      // Extract net position from positions_summary
+      const hasPosition = sorted.some((s) => s.positions_summary?.length > 0);
+      if (hasPosition) {
+        positionSeries.setData(
+          sorted.map((s) => {
+            let netAmount = 0;
+            if (s.positions_summary) {
+              for (const pos of s.positions_summary) {
+                netAmount += Number(pos.amount || pos.net_amount || pos.position_amount || 0);
+              }
+            }
+            return {
+              time: toSeconds(s.timestamp) as import("lightweight-charts").UTCTimestamp,
+              value: netAmount,
+            };
+          }),
+        );
+      } else {
+        // Hide position scale if no data
+        positionSeries.applyOptions({ visible: false });
+      }
+
+      volumeSeries.setData(
+        sorted.map((s) => ({
+          time: toSeconds(s.timestamp) as import("lightweight-charts").UTCTimestamp,
+          value: s.volume_traded,
+        })),
+      );
+
+      chart.timeScale().fitContent();
+
+      // Crosshair tooltip
+      chart.subscribeCrosshairMove((param) => {
+        const tooltip = tooltipRef.current;
+        if (!tooltip || !containerRef.current) return;
+
+        if (!param.time || !param.point || param.point.x < 0 || param.point.y < 0) {
+          tooltip.style.display = "none";
+          return;
+        }
+
+        const realizedData = param.seriesData.get(realizedSeries);
+        const unrealizedData = param.seriesData.get(unrealizedSeries);
+        const volData = param.seriesData.get(volumeSeries);
+        const posData = param.seriesData.get(positionSeries);
+
+        if (!realizedData || !("value" in realizedData)) {
+          tooltip.style.display = "none";
+          return;
+        }
+
+        const realized = (realizedData as { value: number }).value;
+        const unrealized = unrealizedData && "value" in unrealizedData ? (unrealizedData as { value: number }).value : 0;
+        const total = realized + unrealized;
+        const vol = volData && "value" in volData ? (volData as { value: number }).value : 0;
+        const pos = posData && "value" in posData ? (posData as { value: number }).value : null;
+        const ts = typeof param.time === "number" ? param.time : 0;
+        const date = new Date(ts * 1000);
+        const timeStr = date.toLocaleString("en-US", {
+          month: "short",
+          day: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+        });
+
+        const sign = (v: number) => (v >= 0 ? "+" : "");
+        const totalColor = total >= 0 ? colors.green : colors.red;
+
+        tooltip.innerHTML = `
+          <div style="color:#9ca3af;font-size:10px;margin-bottom:3px">${timeStr}</div>
+          <div style="display:flex;justify-content:space-between;gap:12px">
+            <span style="color:#9ca3af;font-size:10px">Total</span>
+            <span style="color:${totalColor};font-weight:600;font-size:12px">$${sign(total)}${total.toFixed(2)}</span>
+          </div>
+          <div style="display:flex;justify-content:space-between;gap:12px">
+            <span style="color:#9ca3af;font-size:10px">Realized</span>
+            <span style="color:${colors.green};font-size:11px">$${sign(realized)}${realized.toFixed(2)}</span>
+          </div>
+          <div style="display:flex;justify-content:space-between;gap:12px">
+            <span style="color:#9ca3af;font-size:10px">Unrealized</span>
+            <span style="color:${colors.orange};font-size:11px">$${sign(unrealized)}${unrealized.toFixed(2)}</span>
+          </div>
+          ${vol > 0 ? `<div style="display:flex;justify-content:space-between;gap:12px;margin-top:2px;border-top:1px solid rgba(107,121,148,0.2);padding-top:2px"><span style="color:#9ca3af;font-size:10px">Cum. Vol</span><span style="color:${colors.blue};font-size:10px">$${vol >= 1000 ? (vol / 1000).toFixed(1) + "K" : vol.toFixed(0)}</span></div>` : ""}
+          ${pos !== null && hasPosition ? `<div style="display:flex;justify-content:space-between;gap:12px"><span style="color:#9ca3af;font-size:10px">Position</span><span style="color:${colors.purple};font-size:10px">${pos.toFixed(4)}</span></div>` : ""}
+        `;
+        tooltip.style.display = "block";
+
+        const containerRect = containerRef.current.getBoundingClientRect();
+        const tooltipW = 200;
+        let left = containerRect.left + param.point.x + 16;
+        if (left + tooltipW > window.innerWidth - 8) left = containerRect.left + param.point.x - tooltipW - 10;
+        const top = containerRect.top + Math.max(4, param.point.y - 30);
+        tooltip.style.left = `${left}px`;
+        tooltip.style.top = `${top}px`;
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      if (chartRef.current) {
+        chartRef.current.remove();
+        chartRef.current = null;
+      }
+    };
+  }, [snapshots]);
+
+  if (isLoading) {
+    return (
+      <div
+        className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center"
+        style={{ height }}
+      >
+        <div className="flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
+          <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+          Loading performance history...
+        </div>
+      </div>
+    );
+  }
+
+  if (snapshots.length === 0) {
+    return (
+      <div
+        className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center"
+        style={{ height }}
+      >
+        <p className="text-xs text-[var(--color-text-muted)]">No performance history available</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] overflow-hidden">
+      <div className="flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-1.5">
+        <div className="flex items-center gap-3">
+          <p className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-text-muted)]">
+            PnL Evolution
+          </p>
+          <div className="flex items-center gap-2 text-[9px]">
+            <span className="flex items-center gap-1">
+              <span className="inline-block w-2.5 h-0.5 rounded" style={{ background: "#22c55e" }} />
+              Realized
+            </span>
+            <span className="flex items-center gap-1">
+              <span className="inline-block w-2.5 h-0.5 rounded" style={{ background: "#f59e0b", borderTop: "1px dashed #f59e0b" }} />
+              Unrealized
+            </span>
+            <span className="flex items-center gap-1">
+              <span className="inline-block w-2.5 h-0.5 rounded" style={{ background: "#3b82f690" }} />
+              Volume
+            </span>
+            <span className="flex items-center gap-1">
+              <span className="inline-block w-2.5 h-0.5 rounded" style={{ background: "#a855f7" }} />
+              Position
+            </span>
+          </div>
+        </div>
+        <span className="text-[10px] text-[var(--color-text-muted)]">
+          {snapshots.length} snapshots
+        </span>
+      </div>
+      <div>
+        <div ref={containerRef} style={{ height, width: "100%" }} />
+        <div
+          ref={tooltipRef}
+          style={{
+            display: "none",
+            position: "fixed",
+            top: 0,
+            left: 0,
+            zIndex: 9999,
+            pointerEvents: "none",
+            background: "rgba(15, 21, 37, 0.95)",
+            border: "1px solid rgba(107, 121, 148, 0.3)",
+            borderRadius: 6,
+            padding: "6px 10px",
+            fontSize: 11,
+            color: "#e2e8f0",
+            minWidth: 160,
+            whiteSpace: "nowrap",
+            lineHeight: 1.5,
+            backdropFilter: "blur(8px)",
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function toSeconds(ts: string | number): number {
+  if (typeof ts === "number") return ts > 1e12 ? Math.floor(ts / 1000) : ts;
+  const parsed = Date.parse(ts);
+  if (!isNaN(parsed)) return Math.floor(parsed / 1000);
+  return 0;
+}

--- a/frontend/src/components/bots/CustomInfoEvolution.tsx
+++ b/frontend/src/components/bots/CustomInfoEvolution.tsx
@@ -1,0 +1,219 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+
+import { PnlSparkline } from "@/components/bots/PnlSparkline";
+import { api } from "@/lib/api";
+
+interface Props {
+  server: string;
+  controllerId: string;
+  botName: string;
+}
+
+/** Fields to always skip (not useful for evolution tracking) */
+const SKIP_FIELDS = new Set([
+  "controller_id",
+  "controller_name",
+  "bot_name",
+  "connector",
+  "connector_name",
+  "trading_pair",
+  "timestamp",
+]);
+
+interface FieldEvolution {
+  key: string;
+  values: number[];
+  current: number;
+  min: number;
+  max: number;
+  change: number; // last - first
+}
+
+export function CustomInfoEvolution({ server, controllerId, botName }: Props) {
+  const [expandedField, setExpandedField] = useState<string | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["controller-perf-history", server, controllerId],
+    queryFn: () =>
+      api.getControllerPerformanceHistory(server, {
+        controller_id: controllerId,
+        bot_name: botName,
+        interval: "5m",
+        limit: 2000,
+      }),
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+
+  const fields = useMemo(() => {
+    const snapshots = data?.snapshots;
+    if (!snapshots || snapshots.length === 0) return [];
+
+    const sorted = [...snapshots].sort(
+      (a, b) => (Date.parse(a.timestamp) || 0) - (Date.parse(b.timestamp) || 0),
+    );
+
+    // Collect all numeric fields from custom_info across snapshots
+    // fieldMap: key -> (snapshotIndex -> value)
+    const fieldMap = new Map<string, (number | undefined)[]>();
+    const n = sorted.length;
+
+    for (let i = 0; i < n; i++) {
+      const info = sorted[i].custom_info;
+      if (!info || typeof info !== "object") continue;
+      extractNumericFields(info, "", (key, val) => {
+        if (!fieldMap.has(key)) fieldMap.set(key, new Array(n).fill(undefined));
+        fieldMap.get(key)![i] = val;
+      });
+    }
+
+    const result: FieldEvolution[] = [];
+    for (const [key, rawValues] of fieldMap) {
+      if (SKIP_FIELDS.has(key)) continue;
+      const defined = rawValues.filter((v): v is number => v !== undefined);
+      if (defined.length < 2) continue;
+
+      // Fill gaps with last known value
+      const filled: number[] = [];
+      let lastKnown = 0;
+      for (const v of rawValues) {
+        if (v !== undefined) lastKnown = v;
+        filled.push(lastKnown);
+      }
+
+      const min = Math.min(...filled);
+      const max = Math.max(...filled);
+      if (min === max) continue;
+
+      result.push({
+        key,
+        values: filled,
+        current: filled[filled.length - 1],
+        min,
+        max,
+        change: filled[filled.length - 1] - filled[0],
+      });
+    }
+
+    // Sort by absolute change descending (most interesting first)
+    result.sort((a, b) => Math.abs(b.change) - Math.abs(a.change));
+    return result;
+  }, [data]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-32">
+        <div className="flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
+          <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+          Loading...
+        </div>
+      </div>
+    );
+  }
+
+  if (fields.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-32 text-[var(--color-text-muted)]">
+        <p className="text-xs">No custom info evolution data</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-[var(--color-border)]/50">
+        <h3 className="text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+          Custom Info Evolution
+        </h3>
+        <span className="text-[10px] text-[var(--color-text-muted)]">
+          {fields.length} fields
+        </span>
+      </div>
+      <div className="flex-1 overflow-y-auto scrollbar-thin">
+        {fields.map((field) => {
+          const isExpanded = expandedField === field.key;
+          const changeColor = field.change >= 0 ? "var(--color-green)" : "var(--color-red)";
+          const changeSign = field.change >= 0 ? "+" : "";
+
+          return (
+            <div
+              key={field.key}
+              className="border-b border-[var(--color-border)]/20 last:border-b-0"
+            >
+              <button
+                onClick={() => setExpandedField(isExpanded ? null : field.key)}
+                className="w-full flex items-center gap-3 px-4 py-2.5 hover:bg-[var(--color-surface-hover)]/50 transition-colors"
+              >
+                <div className="flex-1 min-w-0 text-left">
+                  <span className="text-[11px] font-medium text-[var(--color-text)] truncate block">
+                    {field.key}
+                  </span>
+                  <div className="flex items-center gap-2 mt-0.5">
+                    <span className="text-[10px] text-[var(--color-text-muted)] tabular-nums">
+                      {formatCompact(field.current)}
+                    </span>
+                    <span
+                      className="text-[10px] font-medium tabular-nums"
+                      style={{ color: changeColor }}
+                    >
+                      {changeSign}{formatCompact(field.change)}
+                    </span>
+                  </div>
+                </div>
+                <PnlSparkline values={field.values} width={64} height={20} />
+              </button>
+
+              {isExpanded && (
+                <div className="px-4 pb-3 pt-1">
+                  <div className="grid grid-cols-3 gap-2 text-[10px]">
+                    <div>
+                      <span className="text-[var(--color-text-muted)]">Min</span>
+                      <div className="font-mono tabular-nums">{formatCompact(field.min)}</div>
+                    </div>
+                    <div>
+                      <span className="text-[var(--color-text-muted)]">Max</span>
+                      <div className="font-mono tabular-nums">{formatCompact(field.max)}</div>
+                    </div>
+                    <div>
+                      <span className="text-[var(--color-text-muted)]">Current</span>
+                      <div className="font-mono tabular-nums">{formatCompact(field.current)}</div>
+                    </div>
+                  </div>
+                  {/* Larger sparkline when expanded */}
+                  <div className="mt-2 rounded border border-[var(--color-border)]/30 bg-[var(--color-bg)] p-2">
+                    <PnlSparkline values={field.values} width={280} height={48} />
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function formatCompact(val: number): string {
+  if (Math.abs(val) >= 1_000_000) return (val / 1_000_000).toFixed(2) + "M";
+  if (Math.abs(val) >= 1_000) return (val / 1_000).toFixed(1) + "K";
+  if (Math.abs(val) >= 1) return val.toFixed(2);
+  if (Math.abs(val) >= 0.001) return val.toFixed(4);
+  if (val === 0) return "0";
+  return val.toExponential(2);
+}
+
+function extractNumericFields(
+  obj: Record<string, unknown>,
+  prefix: string,
+  emit: (key: string, val: number) => void,
+) {
+  for (const [key, val] of Object.entries(obj)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (typeof val === "number" && isFinite(val)) {
+      emit(fullKey, val);
+    } else if (val && typeof val === "object" && !Array.isArray(val)) {
+      extractNumericFields(val as Record<string, unknown>, fullKey, emit);
+    }
+  }
+}

--- a/frontend/src/components/bots/DeployBotDialog.tsx
+++ b/frontend/src/components/bots/DeployBotDialog.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  ArrowLeft,
   Check,
   ChevronDown,
   ChevronRight,
@@ -9,6 +8,7 @@ import {
   Rocket,
   RotateCcw,
   Search,
+  Settings,
   X,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -52,18 +52,21 @@ export function ConfigEditor({
   server,
   configId,
   onDirtyChange,
+  onRemove,
 }: {
   server: string;
   configId: string;
   onDirtyChange: (configId: string, edits: Record<string, unknown> | null) => void;
+  onRemove?: (configId: string) => void;
 }) {
+  const [edits, setEdits] = useState<Record<string, string>>({});
+  const [expanded, setExpanded] = useState(false);
+
   const { data, isLoading } = useQuery({
     queryKey: ["config-detail", server, configId],
     queryFn: () => api.getConfigDetail(server, configId),
+    enabled: expanded,
   });
-
-  const [edits, setEdits] = useState<Record<string, string>>({});
-  const [expanded, setExpanded] = useState(true);
 
   const config = data?.config ?? {};
   const entries = useMemo(
@@ -117,29 +120,40 @@ export function ConfigEditor({
   return (
     <div className={`rounded-lg border overflow-hidden transition-colors ${isDirty ? "border-[var(--color-warning)]/60" : "border-[var(--color-border)]"}`}>
       {/* Header */}
-      <button
-        className="flex w-full items-center gap-2 px-4 py-3 text-left bg-[var(--color-surface)] hover:bg-[var(--color-surface-hover)] transition-colors"
-        onClick={() => setExpanded(!expanded)}
-      >
-        {expanded ? (
-          <ChevronDown className="h-3.5 w-3.5 text-[var(--color-text-muted)]" />
-        ) : (
-          <ChevronRight className="h-3.5 w-3.5 text-[var(--color-text-muted)]" />
+      <div className="flex items-center bg-[var(--color-surface)]">
+        <button
+          className="flex flex-1 items-center gap-2 px-4 py-3 text-left hover:bg-[var(--color-surface-hover)] transition-colors"
+          onClick={() => setExpanded(!expanded)}
+        >
+          {expanded ? (
+            <ChevronDown className="h-3.5 w-3.5 text-[var(--color-text-muted)]" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5 text-[var(--color-text-muted)]" />
+          )}
+          <Package className="h-3.5 w-3.5 text-[var(--color-text-muted)]" />
+          <span className="text-sm font-medium truncate">{configId}</span>
+          {data?.controller_name && (
+            <span className="text-xs text-[var(--color-text-muted)]">
+              {data.controller_name}
+            </span>
+          )}
+          {isDirty && (
+            <span className="flex items-center gap-1 text-xs text-[var(--color-warning)]">
+              <Pencil className="h-3 w-3" />
+              {Object.keys(edits).length} edited
+            </span>
+          )}
+        </button>
+        {onRemove && (
+          <button
+            onClick={() => onRemove(configId)}
+            className="px-3 py-3 text-[var(--color-text-muted)] hover:text-[var(--color-red)] transition-colors"
+            title="Remove config"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
         )}
-        <Package className="h-3.5 w-3.5 text-[var(--color-text-muted)]" />
-        <span className="text-sm font-medium truncate flex-1">{configId}</span>
-        {data?.controller_name && (
-          <span className="text-xs text-[var(--color-text-muted)]">
-            {data.controller_name}
-          </span>
-        )}
-        {isDirty && (
-          <span className="flex items-center gap-1 text-xs text-[var(--color-warning)]">
-            <Pencil className="h-3 w-3" />
-            {Object.keys(edits).length} edited
-          </span>
-        )}
-      </button>
+      </div>
 
       {/* Fields */}
       {expanded && (
@@ -238,50 +252,6 @@ export function ConfigEditor({
   );
 }
 
-// ── Config selection inline detail (read-only, for step 1) ──
-
-function ConfigDetailInline({
-  server,
-  configId,
-}: {
-  server: string;
-  configId: string;
-}) {
-  const { data, isLoading } = useQuery({
-    queryKey: ["config-detail", server, configId],
-    queryFn: () => api.getConfigDetail(server, configId),
-  });
-
-  if (isLoading) {
-    return (
-      <div className="px-4 py-2 text-xs text-[var(--color-text-muted)]">
-        Loading...
-      </div>
-    );
-  }
-
-  if (!data) return null;
-
-  const entries = Object.entries(data.config).filter(
-    ([k]) => !HIDDEN_KEYS.has(k),
-  );
-
-  return (
-    <div className="grid grid-cols-2 gap-x-4 gap-y-1 px-4 py-2 bg-[var(--color-bg)] border-t border-[var(--color-border)]/30 text-xs">
-      {entries.map(([key, val]) => (
-        <div key={key} className="flex justify-between gap-2 py-0.5 min-w-0">
-          <span className="text-[var(--color-text-muted)] truncate">{key}</span>
-          <span className="tabular-nums text-right truncate" title={String(val ?? "")}>
-            {typeof val === "object" && val !== null
-              ? JSON.stringify(val)
-              : String(val ?? "")}
-          </span>
-        </div>
-      ))}
-    </div>
-  );
-}
-
 // ── Main Dialog ──
 
 export function DeployBotDialog({
@@ -294,13 +264,12 @@ export function DeployBotDialog({
   server: string;
 }) {
   const queryClient = useQueryClient();
-  const [step, setStep] = useState<1 | 2>(1);
   const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [expandedConfig, setExpandedConfig] = useState<string | null>(null);
-  const [expandedTypes, setExpandedTypes] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState("");
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [deployError, setDeployError] = useState<string | null>(null);
 
-  // Step 2 fields
+  // Bot settings
   const [botName, setBotName] = useState(
     () => `bot_${new Date().toISOString().slice(0, 19).replace(/[-:T]/g, "").slice(0, 15)}`,
   );
@@ -308,9 +277,8 @@ export function DeployBotDialog({
   const [image, setImage] = useState("hummingbot/hummingbot:latest");
   const [maxGlobalDrawdown, setMaxGlobalDrawdown] = useState("");
   const [maxControllerDrawdown, setMaxControllerDrawdown] = useState("");
-  const [deployError, setDeployError] = useState<string | null>(null);
 
-  // Track edits per config: configId -> edited fields (null = not dirty)
+  // Track edits per config
   const [configEdits, setConfigEdits] = useState<Record<string, Record<string, unknown> | null>>({});
 
   const dirtyConfigs = useMemo(
@@ -323,11 +291,8 @@ export function DeployBotDialog({
       if (prev[configId] === edits) return prev;
       if (edits === null && !(configId in prev)) return prev;
       const next = { ...prev };
-      if (edits === null) {
-        delete next[configId];
-      } else {
-        next[configId] = edits;
-      }
+      if (edits === null) delete next[configId];
+      else next[configId] = edits;
       return next;
     });
   }, []);
@@ -352,56 +317,50 @@ export function DeployBotDialog({
     );
   }, [configs, search]);
 
-  const groupedConfigs = useMemo(() => {
+  // Group unselected configs by type for browsing
+  const unselectedConfigs = useMemo(
+    () => filteredConfigs.filter((c) => !selected.has(c.id)),
+    [filteredConfigs, selected],
+  );
+
+  const groupedUnselected = useMemo(() => {
     const groups: Record<string, ControllerConfigSummary[]> = {};
-    for (const c of filteredConfigs) {
+    for (const c of unselectedConfigs) {
       const type = c.controller_type || "other";
-      if (!groups[type]) groups[type] = [];
-      groups[type].push(c);
+      (groups[type] ??= []).push(c);
     }
     return groups;
-  }, [filteredConfigs]);
+  }, [unselectedConfigs]);
 
   const toggleSelect = (id: string) => {
     setSelected((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
+      if (next.has(id)) {
+        next.delete(id);
+        setConfigEdits((ce) => { const n = { ...ce }; delete n[id]; return n; });
+      } else {
+        next.add(id);
+      }
       return next;
     });
   };
 
-  const toggleType = (type: string) => {
-    setExpandedTypes((prev) => {
-      const next = new Set(prev);
-      if (next.has(type)) next.delete(type);
-      else next.add(type);
-      return next;
-    });
-  };
-
-  // Save modified configs then deploy
+  // Deploy
   const deployMutation = useMutation({
     mutationFn: async () => {
-      // First, save any configs that were edited
       for (const [configId, edits] of dirtyConfigs) {
         await api.updateConfig(server, configId, edits);
       }
-
-      // Then deploy
       return api.deployBot(server, {
         bot_name: botName,
         controllers_config: Array.from(selected),
         account_name: accountName,
         image,
         max_global_drawdown_quote: maxGlobalDrawdown ? parseFloat(maxGlobalDrawdown) : null,
-        max_controller_drawdown_quote: maxControllerDrawdown
-          ? parseFloat(maxControllerDrawdown)
-          : null,
+        max_controller_drawdown_quote: maxControllerDrawdown ? parseFloat(maxControllerDrawdown) : null,
       });
     },
     onSuccess: () => {
-      // Invalidate config caches since we may have updated them
       queryClient.invalidateQueries({ queryKey: ["bots", server] });
       queryClient.invalidateQueries({ queryKey: ["config-detail"] });
       queryClient.invalidateQueries({ queryKey: ["available-configs", server] });
@@ -413,17 +372,24 @@ export function DeployBotDialog({
   });
 
   const handleClose = () => {
-    setStep(1);
     setSelected(new Set());
-    setExpandedConfig(null);
-    setExpandedTypes(new Set());
     setSearch("");
+    setShowAdvanced(false);
     setDeployError(null);
     setConfigEdits({});
     onClose();
   };
 
+  // Reset bot name on open
+  useEffect(() => {
+    if (open) {
+      setBotName(`bot_${new Date().toISOString().slice(0, 19).replace(/[-:T]/g, "").slice(0, 15)}`);
+    }
+  }, [open]);
+
   if (!open) return null;
+
+  const hasSelected = selected.size > 0;
 
   return (
     <div
@@ -437,17 +403,9 @@ export function DeployBotDialog({
         {/* Header */}
         <div className="flex items-center justify-between border-b border-[var(--color-border)] px-6 py-4">
           <div className="flex items-center gap-3">
-            {step === 2 && (
-              <button
-                onClick={() => { setStep(1); setDeployError(null); }}
-                className="p-1 rounded hover:bg-[var(--color-surface-hover)] transition-colors"
-              >
-                <ArrowLeft className="h-4 w-4" />
-              </button>
-            )}
             <Rocket className="h-5 w-5 text-[var(--color-primary)]" />
             <h2 className="text-lg font-semibold text-[var(--color-text)]">
-              {step === 1 ? "Select Configs" : "Review & Deploy"}
+              Deploy Bot
             </h2>
           </div>
           <button
@@ -459,227 +417,163 @@ export function DeployBotDialog({
         </div>
 
         {/* Body */}
-        <div className="flex-1 overflow-y-auto p-6">
-          {step === 1 ? (
-            <div className="space-y-4">
-              {/* Search */}
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--color-text-muted)]" />
-                <input
-                  type="text"
-                  value={search}
-                  onChange={(e) => setSearch(e.target.value)}
-                  placeholder="Filter configs..."
-                  className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] pl-10 pr-3 py-2 text-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)]/50 outline-none transition-colors focus:border-[var(--color-primary)]"
-                  autoFocus
-                />
+        <div className="flex-1 overflow-y-auto p-6 space-y-5">
+
+          {/* Selected configs with inline editors */}
+          {hasSelected && (
+            <div>
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+                Selected ({selected.size})
+              </h3>
+              <div className="space-y-2">
+                {Array.from(selected).map((id) => (
+                  <ConfigEditor
+                    key={id}
+                    server={server}
+                    configId={id}
+                    onDirtyChange={handleDirtyChange}
+                    onRemove={toggleSelect}
+                  />
+                ))}
               </div>
-
-              {isLoading ? (
-                <div className="flex h-40 items-center justify-center text-[var(--color-text-muted)]">
-                  <div className="h-5 w-5 animate-spin rounded-full border-2 border-[var(--color-border)] border-t-[var(--color-primary)]" />
-                </div>
-              ) : filteredConfigs.length === 0 ? (
-                <div className="flex h-40 flex-col items-center justify-center text-[var(--color-text-muted)]">
-                  <Package className="mb-2 h-8 w-8 opacity-30" />
-                  <p className="text-sm">No configs found</p>
-                </div>
-              ) : (
-                <div className="space-y-2">
-                  {Object.entries(groupedConfigs).map(([type, cfgs]) => {
-                    const isTypeExpanded = expandedTypes.has(type);
-                    return (
-                      <div
-                        key={type}
-                        className="rounded-lg border border-[var(--color-border)] overflow-hidden"
-                      >
-                        <button
-                          className="flex w-full items-center gap-2 px-4 py-2.5 text-left bg-[var(--color-surface)] hover:bg-[var(--color-surface-hover)] transition-colors"
-                          onClick={() => toggleType(type)}
-                        >
-                          {isTypeExpanded ? (
-                            <ChevronDown className="h-3.5 w-3.5 text-[var(--color-text-muted)]" />
-                          ) : (
-                            <ChevronRight className="h-3.5 w-3.5 text-[var(--color-text-muted)]" />
-                          )}
-                          <span className="text-xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
-                            {type}
-                          </span>
-                          <span className="text-xs text-[var(--color-text-muted)]">
-                            ({cfgs.length})
-                          </span>
-                        </button>
-
-                        {isTypeExpanded && (
-                          <div className="divide-y divide-[var(--color-border)]/30">
-                            {cfgs.map((cfg) => {
-                              const isSelected = selected.has(cfg.id);
-                              const isExpanded = expandedConfig === cfg.id;
-                              return (
-                                <div key={cfg.id}>
-                                  <div
-                                    className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors hover:bg-[var(--color-surface-hover)]/50 ${
-                                      isSelected ? "bg-[var(--color-primary)]/5" : ""
-                                    }`}
-                                  >
-                                    <input
-                                      type="checkbox"
-                                      checked={isSelected}
-                                      onChange={() => toggleSelect(cfg.id)}
-                                      className="h-4 w-4 rounded border-[var(--color-border)] accent-[var(--color-primary)]"
-                                    />
-                                    <button
-                                      className="flex-1 flex items-center gap-3 text-left min-w-0"
-                                      onClick={() =>
-                                        setExpandedConfig(isExpanded ? null : cfg.id)
-                                      }
-                                    >
-                                      <span className="text-sm font-medium truncate">
-                                        {cfg.id}
-                                      </span>
-                                      <span className="text-xs text-[var(--color-text-muted)] truncate">
-                                        {cfg.controller_name}
-                                      </span>
-                                      {cfg.connector_name && (
-                                        <span className="text-xs text-[var(--color-text-muted)]">
-                                          {cfg.connector_name}
-                                        </span>
-                                      )}
-                                      {cfg.trading_pair && (
-                                        <span className="text-xs font-mono">
-                                          {cfg.trading_pair}
-                                        </span>
-                                      )}
-                                      <span className="ml-auto">
-                                        {isExpanded ? (
-                                          <ChevronDown className="h-3.5 w-3.5 text-[var(--color-text-muted)]" />
-                                        ) : (
-                                          <ChevronRight className="h-3.5 w-3.5 text-[var(--color-text-muted)]" />
-                                        )}
-                                      </span>
-                                    </button>
-                                  </div>
-                                  {isExpanded && (
-                                    <ConfigDetailInline
-                                      server={server}
-                                      configId={cfg.id}
-                                    />
-                                  )}
-                                </div>
-                              );
-                            })}
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
             </div>
-          ) : (
-            /* Step 2: Review configs + Deploy settings */
-            <div className="space-y-6">
-              {/* Config editors */}
-              <div>
-                <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
-                  Controller Configs ({selected.size})
-                </h3>
-                <div className="space-y-3">
-                  {Array.from(selected).map((id) => (
-                    <ConfigEditor
-                      key={id}
-                      server={server}
-                      configId={id}
-                      onDirtyChange={handleDirtyChange}
-                    />
-                  ))}
-                </div>
+          )}
+
+          {/* Available configs */}
+          <div>
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+              {hasSelected ? "Add more" : "Select configs"}
+            </h3>
+            <div className="relative mb-3">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--color-text-muted)]" />
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search configs..."
+                className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] pl-10 pr-3 py-2 text-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)]/50 outline-none transition-colors focus:border-[var(--color-primary)]"
+                autoFocus
+              />
+            </div>
+
+            {isLoading ? (
+              <div className="flex h-24 items-center justify-center text-[var(--color-text-muted)]">
+                <div className="h-5 w-5 animate-spin rounded-full border-2 border-[var(--color-border)] border-t-[var(--color-primary)]" />
               </div>
+            ) : unselectedConfigs.length === 0 ? (
+              <div className="flex h-16 items-center justify-center text-[var(--color-text-muted)]">
+                <p className="text-xs">{configs.length === 0 ? "No configs available" : "All configs selected"}</p>
+              </div>
+            ) : (
+              <div className="rounded-lg border border-[var(--color-border)] overflow-hidden max-h-[300px] overflow-y-auto">
+                {Object.entries(groupedUnselected).map(([type, cfgs]) => (
+                  <div key={type}>
+                    <div className="px-4 py-1.5 bg-[var(--color-surface)] text-xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)] sticky top-0 border-b border-[var(--color-border)]/30">
+                      {type} ({cfgs.length})
+                    </div>
+                    {cfgs.map((cfg) => (
+                      <button
+                        key={cfg.id}
+                        onClick={() => toggleSelect(cfg.id)}
+                        className="flex w-full items-center gap-3 px-4 py-2 text-left hover:bg-[var(--color-surface-hover)]/50 transition-colors border-b border-[var(--color-border)]/20 last:border-b-0"
+                      >
+                        <div className="h-4 w-4 rounded border border-[var(--color-border)] flex items-center justify-center shrink-0" />
+                        <span className="text-sm font-medium truncate">{cfg.id}</span>
+                        {cfg.connector_name && (
+                          <span className="text-xs text-[var(--color-text-muted)]">{cfg.connector_name}</span>
+                        )}
+                        {cfg.trading_pair && (
+                          <span className="text-xs font-mono text-[var(--color-text-muted)]">{cfg.trading_pair}</span>
+                        )}
+                      </button>
+                    ))}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
 
-              {/* Divider */}
-              <div className="border-t border-[var(--color-border)]" />
+          {/* Advanced settings (collapsed by default) */}
+          <div className="border-t border-[var(--color-border)] pt-4">
+            <button
+              onClick={() => setShowAdvanced(!showAdvanced)}
+              className="flex items-center gap-2 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
+            >
+              <Settings className="h-3.5 w-3.5" />
+              <span className="font-medium">Advanced Settings</span>
+              {showAdvanced ? (
+                <ChevronDown className="h-3 w-3" />
+              ) : (
+                <ChevronRight className="h-3 w-3" />
+              )}
+            </button>
 
-              {/* Deploy settings */}
-              <div>
-                <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
-                  Bot Settings
-                </h3>
-                <div className="space-y-3">
+            {showAdvanced && (
+              <div className="mt-3 space-y-3">
+                <div>
+                  <label className="mb-1 block text-xs text-[var(--color-text-muted)]">Bot Name</label>
+                  <input
+                    type="text"
+                    value={botName}
+                    onChange={(e) => setBotName(e.target.value)}
+                    className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] outline-none transition-colors focus:border-[var(--color-primary)]"
+                  />
+                </div>
+                <div className="grid grid-cols-2 gap-3">
                   <div>
-                    <label className="mb-1 block text-xs text-[var(--color-text-muted)]">
-                      Bot Name
-                    </label>
+                    <label className="mb-1 block text-xs text-[var(--color-text-muted)]">Account</label>
                     <input
                       type="text"
-                      value={botName}
-                      onChange={(e) => setBotName(e.target.value)}
+                      value={accountName}
+                      onChange={(e) => setAccountName(e.target.value)}
                       className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] outline-none transition-colors focus:border-[var(--color-primary)]"
                     />
                   </div>
-                  <div className="grid grid-cols-2 gap-3">
-                    <div>
-                      <label className="mb-1 block text-xs text-[var(--color-text-muted)]">
-                        Account
-                      </label>
-                      <input
-                        type="text"
-                        value={accountName}
-                        onChange={(e) => setAccountName(e.target.value)}
-                        className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] outline-none transition-colors focus:border-[var(--color-primary)]"
-                      />
-                    </div>
-                    <div>
-                      <label className="mb-1 block text-xs text-[var(--color-text-muted)]">
-                        Image
-                      </label>
-                      <input
-                        type="text"
-                        value={image}
-                        onChange={(e) => setImage(e.target.value)}
-                        className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] outline-none transition-colors focus:border-[var(--color-primary)]"
-                      />
-                    </div>
+                  <div>
+                    <label className="mb-1 block text-xs text-[var(--color-text-muted)]">Image</label>
+                    <input
+                      type="text"
+                      value={image}
+                      onChange={(e) => setImage(e.target.value)}
+                      className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] outline-none transition-colors focus:border-[var(--color-primary)]"
+                    />
                   </div>
-                  <div className="grid grid-cols-2 gap-3">
-                    <div>
-                      <label className="mb-1 block text-xs text-[var(--color-text-muted)]">
-                        Max Global Drawdown
-                      </label>
-                      <input
-                        type="number"
-                        value={maxGlobalDrawdown}
-                        onChange={(e) => setMaxGlobalDrawdown(e.target.value)}
-                        placeholder="Optional"
-                        className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)]/50 outline-none transition-colors focus:border-[var(--color-primary)]"
-                      />
-                    </div>
-                    <div>
-                      <label className="mb-1 block text-xs text-[var(--color-text-muted)]">
-                        Max Controller Drawdown
-                      </label>
-                      <input
-                        type="number"
-                        value={maxControllerDrawdown}
-                        onChange={(e) => setMaxControllerDrawdown(e.target.value)}
-                        placeholder="Optional"
-                        className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)]/50 outline-none transition-colors focus:border-[var(--color-primary)]"
-                      />
-                    </div>
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="mb-1 block text-xs text-[var(--color-text-muted)]">Max Global Drawdown</label>
+                    <input
+                      type="number"
+                      value={maxGlobalDrawdown}
+                      onChange={(e) => setMaxGlobalDrawdown(e.target.value)}
+                      placeholder="Optional"
+                      className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)]/50 outline-none transition-colors focus:border-[var(--color-primary)]"
+                    />
+                  </div>
+                  <div>
+                    <label className="mb-1 block text-xs text-[var(--color-text-muted)]">Max Controller Drawdown</label>
+                    <input
+                      type="number"
+                      value={maxControllerDrawdown}
+                      onChange={(e) => setMaxControllerDrawdown(e.target.value)}
+                      placeholder="Optional"
+                      className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)]/50 outline-none transition-colors focus:border-[var(--color-primary)]"
+                    />
                   </div>
                 </div>
               </div>
+            )}
+          </div>
 
-              {deployError && (
-                <div className="rounded-lg border border-[var(--color-red)]/40 bg-[var(--color-red)]/10 px-4 py-3">
-                  <p className="text-sm text-[var(--color-red)]">{deployError}</p>
-                  <button
-                    onClick={() => { setDeployError(null); deployMutation.mutate(); }}
-                    className="mt-2 text-xs font-medium text-[var(--color-red)] underline"
-                  >
-                    Retry
-                  </button>
-                </div>
-              )}
+          {deployError && (
+            <div className="rounded-lg border border-[var(--color-red)]/40 bg-[var(--color-red)]/10 px-4 py-3">
+              <p className="text-sm text-[var(--color-red)]">{deployError}</p>
+              <button
+                onClick={() => { setDeployError(null); deployMutation.mutate(); }}
+                className="mt-2 text-xs font-medium text-[var(--color-red)] underline"
+              >
+                Retry
+              </button>
             </div>
           )}
         </div>
@@ -687,11 +581,8 @@ export function DeployBotDialog({
         {/* Footer */}
         <div className="flex items-center justify-between border-t border-[var(--color-border)] px-6 py-4">
           <span className="text-xs text-[var(--color-text-muted)]">
-            {step === 1
-              ? `${selected.size} config${selected.size !== 1 ? "s" : ""} selected`
-              : dirtyConfigs.length > 0
-                ? `${dirtyConfigs.length} config${dirtyConfigs.length !== 1 ? "s" : ""} modified`
-                : ""}
+            {selected.size} config{selected.size !== 1 ? "s" : ""}
+            {dirtyConfigs.length > 0 && ` · ${dirtyConfigs.length} modified`}
           </span>
           <div className="flex gap-3">
             <button
@@ -700,30 +591,16 @@ export function DeployBotDialog({
             >
               Cancel
             </button>
-            {step === 1 ? (
-              <button
-                onClick={() => setStep(2)}
-                disabled={selected.size === 0}
-                className="rounded-lg bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-white transition-opacity disabled:opacity-40"
-              >
-                Next
-              </button>
-            ) : (
-              <button
-                onClick={() => deployMutation.mutate()}
-                disabled={!botName.trim() || deployMutation.isPending}
-                className="flex items-center gap-2 rounded-lg bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-white transition-opacity disabled:opacity-40"
-              >
-                <Rocket className="h-4 w-4" />
-                {deployMutation.isPending
-                  ? dirtyConfigs.length > 0
-                    ? "Saving & Deploying..."
-                    : "Deploying..."
-                  : dirtyConfigs.length > 0
-                    ? "Save & Deploy"
-                    : "Deploy"}
-              </button>
-            )}
+            <button
+              onClick={() => deployMutation.mutate()}
+              disabled={!hasSelected || !botName.trim() || deployMutation.isPending}
+              className="flex items-center gap-2 rounded-lg bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-white transition-opacity disabled:opacity-40"
+            >
+              <Rocket className="h-4 w-4" />
+              {deployMutation.isPending
+                ? dirtyConfigs.length > 0 ? "Saving & Deploying..." : "Deploying..."
+                : dirtyConfigs.length > 0 ? "Save & Deploy" : "Deploy"}
+            </button>
           </div>
         </div>
       </div>

--- a/frontend/src/components/bots/PnlSparkline.tsx
+++ b/frontend/src/components/bots/PnlSparkline.tsx
@@ -1,0 +1,40 @@
+import { useMemo } from "react";
+
+interface Props {
+  /** PnL values over time (already sorted chronologically) */
+  values: number[];
+  width?: number;
+  height?: number;
+}
+
+export function PnlSparkline({ values, width = 80, height = 24 }: Props) {
+  const path = useMemo(() => {
+    if (values.length < 2) return null;
+
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const range = max - min || 1;
+    const padding = 1;
+    const innerH = height - padding * 2;
+    const stepX = (width - 2) / (values.length - 1);
+
+    const points = values.map((v, i) => {
+      const x = 1 + i * stepX;
+      const y = padding + innerH - ((v - min) / range) * innerH;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    });
+
+    return `M${points.join("L")}`;
+  }, [values, width, height]);
+
+  if (!path) return <div style={{ width, height }} />;
+
+  const lastVal = values[values.length - 1];
+  const color = lastVal >= 0 ? "var(--color-green)" : "var(--color-red)";
+
+  return (
+    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
+      <path d={path} fill="none" stroke={color} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}

--- a/frontend/src/components/charts/ArchivedPerformanceCharts.tsx
+++ b/frontend/src/components/charts/ArchivedPerformanceCharts.tsx
@@ -8,6 +8,7 @@ import {
   getOverlayTimeRange,
   type ExecutorOverlay,
 } from "@/lib/executor-overlays";
+import { getThemeColors } from "@/lib/theme-colors";
 
 interface Props {
   server: string;
@@ -331,8 +332,9 @@ export function ArchivedPerformanceCharts({
         // HIGH-FREQUENCY MODE: Show buy/sell volume histogram on candle pane
         // Buy volume (green bars)
         if (volumeBuckets.length > 0) {
+          const tc = getThemeColors();
           const buyVolSeries = chart.addSeries(mod.HistogramSeries, {
-            color: "#22c55e60",
+            color: tc.green + "60",
             priceLineVisible: false,
             lastValueVisible: false,
             priceScaleId: "vol",
@@ -347,13 +349,13 @@ export function ArchivedPerformanceCharts({
               .map((b) => ({
                 time: b.time as UTCTimestamp,
                 value: b.buyVol,
-                color: "#22c55e60",
+                color: tc.green + "60",
               })),
           );
 
           // Sell volume (red bars, shown as negative direction via separate series)
           const sellVolSeries = chart.addSeries(mod.HistogramSeries, {
-            color: "#ef444460",
+            color: tc.red + "60",
             priceLineVisible: false,
             lastValueVisible: false,
             priceScaleId: "vol",
@@ -364,7 +366,7 @@ export function ArchivedPerformanceCharts({
               .map((b) => ({
                 time: b.time as UTCTimestamp,
                 value: -b.sellVol,
-                color: "#ef444460",
+                color: tc.red + "60",
               })),
           );
 
@@ -465,14 +467,15 @@ export function ArchivedPerformanceCharts({
       if (hasPnl) {
         const pnlPane = 1;
 
+        const pnlTc = getThemeColors();
         const netPnlSeries = chart.addSeries(mod.BaselineSeries, {
           baseValue: { type: "price" as const, price: 0 },
-          topLineColor: "#22c55e",
-          topFillColor1: "#22c55e22",
-          topFillColor2: "#22c55e08",
-          bottomLineColor: "#ef4444",
-          bottomFillColor1: "#ef444408",
-          bottomFillColor2: "#ef444422",
+          topLineColor: pnlTc.green,
+          topFillColor1: pnlTc.green + "22",
+          topFillColor2: pnlTc.green + "08",
+          bottomLineColor: pnlTc.red,
+          bottomFillColor1: pnlTc.red + "08",
+          bottomFillColor2: pnlTc.red + "22",
           lineWidth: 2,
           priceLineVisible: false,
           lastValueVisible: true,
@@ -538,14 +541,15 @@ export function ArchivedPerformanceCharts({
         const posPane = hasPnl ? 2 : 1;
 
         // Baseline series: green above 0, red below 0
+        const posTc = getThemeColors();
         const posSeries = chart.addSeries(mod.BaselineSeries, {
           baseValue: { type: "price" as const, price: 0 },
-          topLineColor: "#22c55e",
-          topFillColor1: "#22c55e33",
-          topFillColor2: "#22c55e08",
-          bottomLineColor: "#ef4444",
-          bottomFillColor1: "#ef444408",
-          bottomFillColor2: "#ef444433",
+          topLineColor: posTc.green,
+          topFillColor1: posTc.green + "33",
+          topFillColor2: posTc.green + "08",
+          bottomLineColor: posTc.red,
+          bottomFillColor1: posTc.red + "08",
+          bottomFillColor2: posTc.red + "33",
           lineWidth: 1,
           priceLineVisible: false,
           lastValueVisible: true,

--- a/frontend/src/components/charts/ExecutorChart.tsx
+++ b/frontend/src/components/charts/ExecutorChart.tsx
@@ -50,6 +50,14 @@ function tsToSeconds(ts: number): number {
   return ts > 1e12 ? Math.floor(ts / 1000) : ts;
 }
 
+/** Vertical line definition for grid box edges drawn directly on the canvas */
+interface GridVerticalLine {
+  time: number;
+  topPrice: number;
+  bottomPrice: number;
+  color: string;
+}
+
 /** Parse snapshot timestamp string to unix seconds */
 function parseSnapshotTs(ts: string): number {
   // Handle formats like "2024-01-15 14:30:22" or ISO
@@ -77,6 +85,7 @@ export function ExecutorChart({
   const chartRef = useRef<import("lightweight-charts").IChartApi | null>(null);
   const seriesRef = useRef<import("lightweight-charts").ISeriesApi<"Candlestick"> | null>(null);
   const segmentSeriesRef = useRef<import("lightweight-charts").ISeriesApi<"Line">[]>([]);
+  const gridVerticalLinesRef = useRef<GridVerticalLine[]>([]);
   const overlaysRef = useRef<ExecutorOverlay[]>([]);
   const initializedRef = useRef(false);
   const [chartReady, setChartReady] = useState(false);
@@ -315,6 +324,72 @@ export function ExecutorChart({
         tooltip.style.top = `${top}px`;
       });
 
+      // Draw vertical lines for grid boxes on a canvas overlay
+      const drawVerticalLines = () => {
+        const lines = gridVerticalLinesRef.current;
+        const chartEl = containerRef.current;
+        if (!chartEl) return;
+
+        // If no lines, clear the overlay canvas if it exists
+        if (!lines.length) {
+          const existing = chartEl.querySelector<HTMLCanvasElement>(".grid-vlines-canvas");
+          if (existing) {
+            const ctx2 = existing.getContext("2d");
+            if (ctx2) ctx2.clearRect(0, 0, existing.width, existing.height);
+          }
+          return;
+        }
+        // lightweight-charts renders into a canvas inside the container
+        const sourceCanvas = chartEl.querySelector("canvas");
+        if (!sourceCanvas) return;
+
+        // Get or create overlay canvas
+        let overlay = chartEl.querySelector<HTMLCanvasElement>(".grid-vlines-canvas");
+        if (!overlay) {
+          overlay = document.createElement("canvas");
+          overlay.className = "grid-vlines-canvas";
+          overlay.style.position = "absolute";
+          overlay.style.top = "0";
+          overlay.style.left = "0";
+          overlay.style.pointerEvents = "none";
+          overlay.style.zIndex = "3";
+          chartEl.style.position = "relative";
+          chartEl.appendChild(overlay);
+        }
+
+        const dpr = window.devicePixelRatio || 1;
+        const w = sourceCanvas.clientWidth;
+        const h = sourceCanvas.clientHeight;
+        overlay.width = w * dpr;
+        overlay.height = h * dpr;
+        overlay.style.width = `${w}px`;
+        overlay.style.height = `${h}px`;
+
+        const ctx = overlay.getContext("2d");
+        if (!ctx) return;
+        ctx.scale(dpr, dpr);
+        ctx.clearRect(0, 0, w, h);
+
+        const ts = chart.timeScale();
+        for (const line of lines) {
+          const x = ts.timeToCoordinate(line.time as import("lightweight-charts").UTCTimestamp);
+          if (x === null) continue;
+          const yTop = series.priceToCoordinate(line.topPrice);
+          const yBottom = series.priceToCoordinate(line.bottomPrice);
+          if (yTop === null || yBottom === null) continue;
+
+          ctx.beginPath();
+          ctx.strokeStyle = line.color;
+          ctx.lineWidth = 1;
+          ctx.moveTo(x, Math.min(yTop, yBottom));
+          ctx.lineTo(x, Math.max(yTop, yBottom));
+          ctx.stroke();
+        }
+      };
+
+      chart.timeScale().subscribeVisibleLogicalRangeChange(drawVerticalLines);
+      chart.subscribeCrosshairMove(drawVerticalLines);
+
       setChartReady(true);
     });
 
@@ -363,10 +438,11 @@ export function ExecutorChart({
     const mod = chartModuleRef.current;
     if (!series || !chart || !mod || !chartReady) return;
 
-    // Clean up old segment series
+    // Clean up old segment series and vertical lines
     for (const s of segmentSeriesRef.current) {
       try { chart.removeSeries(s); } catch { /* ok */ }
     }
+    gridVerticalLinesRef.current = [];
     segmentSeriesRef.current = [];
 
     const isMulti = overlays.length > 1;
@@ -421,27 +497,11 @@ export function ExecutorChart({
           ]);
           segmentSeriesRef.current.push(bottom);
 
-          // Left edge (vertical at start)
-          const left = chart.addSeries(mod.LineSeries, {
-            color: boxColor, lineWidth: 1,
-            priceLineVisible: false, lastValueVisible: false, crosshairMarkerVisible: false,
-          });
-          left.setData([
-            { time: t1 as TS, value: box.startPrice },
-            { time: (t1 + 1) as TS, value: box.endPrice },
-          ]);
-          segmentSeriesRef.current.push(left);
-
-          // Right edge (vertical at end)
-          const right = chart.addSeries(mod.LineSeries, {
-            color: boxColor, lineWidth: 1,
-            priceLineVisible: false, lastValueVisible: false, crosshairMarkerVisible: false,
-          });
-          right.setData([
-            { time: (t2 - 1) as TS, value: box.endPrice },
-            { time: t2 as TS, value: box.startPrice },
-          ]);
-          segmentSeriesRef.current.push(right);
+          // Vertical edges — drawn on canvas overlay (see drawVerticalLines)
+          gridVerticalLinesRef.current.push(
+            { time: t1, topPrice: box.endPrice, bottomPrice: box.startPrice, color: boxColor },
+            { time: t2, topPrice: box.endPrice, bottomPrice: box.startPrice, color: boxColor },
+          );
 
           // Limit price line (if present) — dotted red
           if (box.limitPrice) {
@@ -487,6 +547,14 @@ export function ExecutorChart({
 
       segmentSeriesRef.current.push(lineSeries);
     });
+
+    // Trigger a redraw of grid vertical lines on the overlay canvas
+    if (gridVerticalLinesRef.current.length > 0) {
+      // Small delay to let chart render first
+      setTimeout(() => {
+        chart.timeScale().scrollToPosition(chart.timeScale().scrollPosition(), false);
+      }, 50);
+    }
   }, [overlays, chartReady]);
 
   // Position snapshot bubbles along the time axis

--- a/frontend/src/components/charts/ExecutorChart.tsx
+++ b/frontend/src/components/charts/ExecutorChart.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
+import { createPortal } from "react-dom";
 import { useQuery } from "@tanstack/react-query";
 
 import { useCondorWebSocket } from "@/hooks/useWebSocket";
@@ -294,17 +295,21 @@ export function ExecutorChart({
         `;
         tooltip.style.display = "block";
 
-        // Position tooltip on opposite side of cursor
+        // Position tooltip on opposite side of cursor (fixed/viewport coords)
         const containerRect = containerRef.current.getBoundingClientRect();
         const tooltipW = 280;
+        const tooltipH = tooltip.offsetHeight || 200;
         const cursorInRightHalf = param.point.x > containerRect.width / 2;
         let left = cursorInRightHalf
-          ? param.point.x - tooltipW - 16
-          : param.point.x + 16;
+          ? containerRect.left + param.point.x - tooltipW - 16
+          : containerRect.left + param.point.x + 16;
         if (left < 4) left = 4;
-        if (left + tooltipW > containerRect.width - 4) left = containerRect.width - tooltipW - 4;
-        let top = param.point.y - 10;
-        if (top < 0) top = 4;
+        if (left + tooltipW > window.innerWidth - 4) left = window.innerWidth - tooltipW - 4;
+        let top = containerRect.top + param.point.y - 10;
+        if (top + tooltipH > window.innerHeight - 4) {
+          top = window.innerHeight - tooltipH - 4;
+        }
+        if (top < 4) top = 4;
 
         tooltip.style.left = `${left}px`;
         tooltip.style.top = `${top}px`;
@@ -698,30 +703,33 @@ export function ExecutorChart({
           ref={containerRef}
           style={{ height: fullscreen ? "100%" : height, width: "100%" }}
         />
-        {/* Executor tooltip overlay */}
-        <div
-          ref={tooltipRef}
-          className="chart-tooltip"
-          style={{
-            display: "none",
-            position: "absolute",
-            top: 0,
-            left: 0,
-            zIndex: 10,
-            pointerEvents: "none",
-            background: "var(--color-surface)",
-            border: "1px solid var(--color-border)",
-            borderRadius: 6,
-            padding: "6px 10px",
-            fontSize: 11,
-            color: "var(--color-text)",
-            maxWidth: 280,
-            minWidth: 200,
-            lineHeight: 1.4,
-            backdropFilter: "blur(8px)",
-            boxShadow: "0 4px 16px rgba(0,0,0,0.2)",
-          }}
-        />
+        {/* Executor tooltip overlay — rendered via portal to escape overflow-hidden */}
+        {createPortal(
+          <div
+            ref={tooltipRef}
+            className="chart-tooltip"
+            style={{
+              display: "none",
+              position: "fixed",
+              top: 0,
+              left: 0,
+              zIndex: 9999,
+              pointerEvents: "none",
+              background: "var(--color-surface)",
+              border: "1px solid var(--color-border)",
+              borderRadius: 6,
+              padding: "6px 10px",
+              fontSize: 11,
+              color: "var(--color-text)",
+              maxWidth: 280,
+              minWidth: 200,
+              lineHeight: 1.4,
+              backdropFilter: "blur(8px)",
+              boxShadow: "0 4px 16px rgba(0,0,0,0.2)",
+            }}
+          />,
+          document.body,
+        )}
         {/* Snapshot tooltip overlay */}
         <div
           ref={snapshotTooltipRef}

--- a/frontend/src/components/charts/ExecutorChart.tsx
+++ b/frontend/src/components/charts/ExecutorChart.tsx
@@ -9,7 +9,7 @@ import {
   getOverlayTimeRange,
   type ExecutorOverlay,
 } from "@/lib/executor-overlays";
-import { getThemeColors, pnlColor, sideColor } from "@/lib/theme-colors";
+import { getThemeColors, pnlHexColor, sideColor } from "@/lib/theme-colors";
 
 export interface SnapshotBubble {
   tick: number;
@@ -216,7 +216,7 @@ export function ExecutorChart({
         const textColor = cs.getPropertyValue("--color-text").trim() || "#e2e8f0";
         const borderColor = cs.getPropertyValue("--color-border").trim() || "#1c2541";
 
-        const pnlClr = pnlColor(o.pnl);
+        const pnlClr = pnlHexColor(o.pnl);
         const pnlSign = o.pnl >= 0 ? "+" : "";
         const pnlStr = Math.abs(o.pnl) >= 1000 ? `${pnlSign}$${(o.pnl / 1000).toFixed(1)}K` : `${pnlSign}$${o.pnl.toFixed(2)}`;
         const pctStr = o.pnlPct !== 0 ? `${o.pnlPct > 0 ? "+" : ""}${(o.pnlPct * 100).toFixed(2)}%` : "";

--- a/frontend/src/components/charts/ExecutorChart.tsx
+++ b/frontend/src/components/charts/ExecutorChart.tsx
@@ -9,6 +9,7 @@ import {
   getOverlayTimeRange,
   type ExecutorOverlay,
 } from "@/lib/executor-overlays";
+import { getThemeColors, pnlColor, sideColor } from "@/lib/theme-colors";
 
 export interface SnapshotBubble {
   tick: number;
@@ -215,17 +216,17 @@ export function ExecutorChart({
         const textColor = cs.getPropertyValue("--color-text").trim() || "#e2e8f0";
         const borderColor = cs.getPropertyValue("--color-border").trim() || "#1c2541";
 
-        const pnlClr = o.pnl >= 0 ? "#22c55e" : "#ef4444";
+        const pnlClr = pnlColor(o.pnl);
         const pnlSign = o.pnl >= 0 ? "+" : "";
         const pnlStr = Math.abs(o.pnl) >= 1000 ? `${pnlSign}$${(o.pnl / 1000).toFixed(1)}K` : `${pnlSign}$${o.pnl.toFixed(2)}`;
         const pctStr = o.pnlPct !== 0 ? `${o.pnlPct > 0 ? "+" : ""}${(o.pnlPct * 100).toFixed(2)}%` : "";
         const volStr = Math.abs(o.volume) >= 1000 ? `$${(o.volume / 1000).toFixed(1)}K` : `$${o.volume.toFixed(0)}`;
         const feesStr = o.fees ? `$${o.fees.toFixed(2)}` : "";
 
-        const sideClr = o.side === "buy" ? "#22c55e" : "#ef4444";
+        const sideClr = sideColor(o.side);
         const sideBg = o.side === "buy" ? "rgba(34,197,94,0.15)" : "rgba(239,68,68,0.15)";
         const statusBg = isActive(o.status) ? "rgba(34,197,94,0.15)" : "rgba(156,163,175,0.15)";
-        const statusClr = isActive(o.status) ? "#22c55e" : textMuted;
+        const statusClr = isActive(o.status) ? getThemeColors().green : textMuted;
 
         // Build config detail rows
         const cfg = o.config || {};
@@ -269,9 +270,9 @@ export function ExecutorChart({
         else if (cfg.amount != null && Number(cfg.amount) > 0) addRow("Amount", String(cfg.amount));
 
         const tp = Number(tripleBarrier.take_profit || cfg.take_profit);
-        if (tp > 0 && tp !== -1) addRow("Take Profit", `${(tp * 100).toFixed(2)}%`, "#22c55e");
+        if (tp > 0 && tp !== -1) addRow("Take Profit", `${(tp * 100).toFixed(2)}%`, getThemeColors().green);
         const sl = Number(cfg.stop_loss);
-        if (sl > 0 && sl !== -1) addRow("Stop Loss", `${(sl * 100).toFixed(2)}%`, "#ef4444");
+        if (sl > 0 && sl !== -1) addRow("Stop Loss", `${(sl * 100).toFixed(2)}%`, getThemeColors().red);
 
         tooltip.innerHTML = `
           <div style="display:flex;align-items:center;gap:6px;margin-bottom:6px">
@@ -440,7 +441,7 @@ export function ExecutorChart({
           // Limit price line (if present) — dotted red
           if (box.limitPrice) {
             const limit = chart.addSeries(mod.LineSeries, {
-              color: "#ef4444", lineWidth: 1, lineStyle: mod.LineStyle.Dotted,
+              color: getThemeColors().red, lineWidth: 1, lineStyle: mod.LineStyle.Dotted,
               priceLineVisible: false, lastValueVisible: false, crosshairMarkerVisible: false,
             });
             limit.setData([

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -151,10 +151,10 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
     voiceSettingsRef.current = voiceSettings;
   }, [voiceSettings]);
 
-  // Global keyboard shortcut: ⌘M to toggle recording
+  // Global keyboard shortcut: ⌘⇧M to toggle recording
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === "m") {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "m") {
         e.preventDefault();
         if (recordingState === "recording") {
           stopRecording();

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -9,11 +9,13 @@ const TOKEN_KEY = "condor_token";
 interface ChatInputProps {
   onSend: (text: string) => void;
   disabled?: boolean;
+  isStreaming?: boolean;
+  onAbort?: () => void;
 }
 
 type RecordingState = "idle" | "recording" | "transcribing";
 
-export function ChatInput({ onSend, disabled }: ChatInputProps) {
+export function ChatInput({ onSend, disabled, isStreaming, onAbort }: ChatInputProps) {
   const [value, setValue] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -62,6 +64,10 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSubmit();
+    }
+    if (e.key === "Escape" && isStreaming && onAbort) {
+      e.preventDefault();
+      onAbort();
     }
   };
 
@@ -151,6 +157,19 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
     voiceSettingsRef.current = voiceSettings;
   }, [voiceSettings]);
 
+  // Global ESC to abort streaming
+  useEffect(() => {
+    if (!isStreaming || !onAbort) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onAbort();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [isStreaming, onAbort]);
+
   // Global keyboard shortcut: ⌘⇧M to toggle recording
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -235,14 +254,24 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
         </button>
       )}
 
-      {/* Send button */}
-      <button
-        onClick={handleSubmit}
-        disabled={disabled || !value.trim() || isRecording || isTranscribing}
-        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[var(--color-primary)] text-white transition-opacity hover:opacity-90 disabled:opacity-40"
-      >
-        <Send className="h-4 w-4" />
-      </button>
+      {/* Send / Stop button */}
+      {isStreaming ? (
+        <button
+          onClick={onAbort}
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-red-500 text-white transition-opacity hover:opacity-90"
+          title="Stop generation (Esc)"
+        >
+          <Square className="h-3.5 w-3.5" />
+        </button>
+      ) : (
+        <button
+          onClick={handleSubmit}
+          disabled={disabled || !value.trim() || isRecording || isTranscribing}
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[var(--color-primary)] text-white transition-opacity hover:opacity-90 disabled:opacity-40"
+        >
+          <Send className="h-4 w-4" />
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -224,6 +224,7 @@ export function ChatPanel({ isOpen, onToggle }: ChatPanelProps) {
                 key={slot.info.slot_id}
                 slot={slot}
                 agents={agents}
+                modes={modes}
                 isActive={slot.info.slot_id === chat.activeSlotId}
                 isStreaming={slot.info.slot_id === chat.streamingSlotId}
                 onClick={() => chat.setActiveSlotId(slot.info.slot_id)}
@@ -292,20 +293,16 @@ export function ChatPanel({ isOpen, onToggle }: ChatPanelProps) {
             />
           ) : activeSlot.messages.length === 0 ? (
             <div className="flex h-full flex-col items-center justify-center text-center">
-              {activeSlot.info.mode === "agent_builder" ? (
-                <Brain className="mb-3 h-10 w-10 text-[var(--color-text-muted)] opacity-30" />
-              ) : (
-                <MessageSquare className="mb-3 h-10 w-10 text-[var(--color-text-muted)] opacity-30" />
-              )}
+              {(() => {
+                const ModeIcon = MODE_ICONS[activeSlot.info.mode] || MessageSquare;
+                return <ModeIcon className="mb-3 h-10 w-10 text-[var(--color-text-muted)] opacity-30" />;
+              })()}
               <p className="text-sm font-medium text-[var(--color-text)]">
-                {activeSlot.info.mode === "agent_builder"
-                  ? "Agent Builder"
-                  : "Condor Assistant"}
+                {modes.find((m) => m.key === activeSlot.info.mode)?.label || "Assistant"}
               </p>
               <p className="mt-1 text-xs text-[var(--color-text-muted)]">
-                {activeSlot.info.mode === "agent_builder"
-                  ? "Create and manage autonomous trading strategies."
-                  : "Ask about your portfolio, prices, trades, or bot status."}
+                {modes.find((m) => m.key === activeSlot.info.mode)?.description ||
+                  "Ask about your portfolio, prices, trades, or bot status."}
               </p>
               <p className="mt-2 text-[10px] text-[var(--color-text-muted)] opacity-60">
                 {resolveAgentLabel(activeSlot.info.agent_key, agents)}
@@ -550,6 +547,7 @@ function EmptyState({
 function SessionTab({
   slot,
   agents,
+  modes,
   isActive,
   isStreaming,
   onClick,
@@ -557,13 +555,14 @@ function SessionTab({
 }: {
   slot: ChatSlot;
   agents: ChatAgentOption[];
+  modes: ChatModeOption[];
   isActive: boolean;
   isStreaming: boolean;
   onClick: () => void;
   onClose: () => void;
 }) {
   const modeLabel =
-    slot.info.mode === "agent_builder" ? "Builder" : "Condor";
+    modes.find((m) => m.key === slot.info.mode)?.label || slot.info.mode;
   const agentShort = shortAgentLabel(slot.info.agent_key, agents);
   const ModeIcon = MODE_ICONS[slot.info.mode] || Zap;
 

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   AlertTriangle,
   Brain,
+  ChevronDown,
   Loader2,
   MessageSquare,
   Minus,
@@ -12,15 +13,16 @@ import {
 import { useChatSocket, type ChatSlot } from "@/hooks/useChatSocket";
 import { ChatMessageView } from "./ChatMessage";
 import { ChatInput } from "./ChatInput";
+import { api, type ChatAgentOption, type ChatModeOption } from "@/lib/api";
 
 const MIN_WIDTH = 360;
 const MAX_WIDTH = 1200;
 const DEFAULT_WIDTH = 480;
 
-const MODE_OPTIONS = [
-  { key: "condor", label: "Condor", icon: Zap },
-  { key: "agent_builder", label: "Agent Builder", icon: Brain },
-] as const;
+const MODE_ICONS: Record<string, typeof Zap> = {
+  condor: Zap,
+  agent_builder: Brain,
+};
 
 interface ChatPanelProps {
   isOpen: boolean;
@@ -36,6 +38,35 @@ export function ChatPanel({ isOpen, onToggle }: ChatPanelProps) {
   const [isDragging, setIsDragging] = useState(false);
   const [showNewMenu, setShowNewMenu] = useState(false);
   const [pendingSession, setPendingSession] = useState(false);
+
+  // Chat options from backend
+  const [agents, setAgents] = useState<ChatAgentOption[]>([]);
+  const [modes, setModes] = useState<ChatModeOption[]>([]);
+  const [defaultAgent, setDefaultAgent] = useState("claude-code");
+  const [defaultMode, setDefaultMode] = useState("condor");
+  const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
+  const [selectedMode, setSelectedMode] = useState<string | null>(null);
+  const optionsFetched = useRef(false);
+
+  // Fetch chat options on first open
+  useEffect(() => {
+    if (isOpen && !optionsFetched.current) {
+      optionsFetched.current = true;
+      api.getChatOptions().then((opts) => {
+        setAgents(opts.agents);
+        setModes(opts.modes);
+        setDefaultAgent(opts.default_agent);
+        setDefaultMode(opts.default_mode);
+      }).catch(() => {
+        // Fallback defaults
+        setAgents([{ key: "claude-code", label: "Claude Code" }]);
+        setModes([
+          { key: "condor", label: "Condor", description: "" },
+          { key: "agent_builder", label: "Agent Builder", description: "" },
+        ]);
+      });
+    }
+  }, [isOpen]);
 
   // Keyboard shortcut: Cmd+K (Mac) / Ctrl+K (other) to toggle panel
   useEffect(() => {
@@ -89,19 +120,28 @@ export function ChatPanel({ isOpen, onToggle }: ChatPanelProps) {
     }
   }, [chat.activeSlot, pendingSession]);
 
-  const handleNewSession = (mode: string) => {
+  const handleNewSession = (agentKey: string, mode: string) => {
     setPendingSession(true);
     onToggle(true);
-    chat.startSession("claude-code", mode);
+    chat.startSession(agentKey, mode);
     setShowNewMenu(false);
+    setSelectedAgent(null);
+    setSelectedMode(null);
   };
 
   const activeSlot = chat.activeSlot;
   const isActiveStreaming = chat.streamingSlotId === chat.activeSlotId;
 
+  // Resolve effective selections for the new-session menu
+  const effectiveAgent = selectedAgent || defaultAgent;
+  const effectiveMode = selectedMode || defaultMode;
+
+  // Filter out sentinel keys (ending with :) that are pickers, not direct agents
+  const directAgents = agents.filter((a) => !a.key.endsWith(":"));
+
   return (
     <>
-      {/* Panel — slides from right, below navbar */}
+      {/* Panel -- slides from right, below navbar */}
       <div
         ref={panelRef}
         style={{ width: isOpen ? width : 0 }}
@@ -134,7 +174,7 @@ export function ChatPanel({ isOpen, onToggle }: ChatPanelProps) {
             )}
           </div>
           <div className="flex items-center gap-1">
-            {/* New session button with mode selector */}
+            {/* New session button */}
             <div className="relative">
               <button
                 onClick={() => setShowNewMenu((v) => !v)}
@@ -144,24 +184,16 @@ export function ChatPanel({ isOpen, onToggle }: ChatPanelProps) {
                 <Plus className="h-4 w-4" />
               </button>
               {showNewMenu && (
-                <>
-                  <div
-                    className="fixed inset-0 z-50"
-                    onClick={() => setShowNewMenu(false)}
-                  />
-                  <div className="absolute right-0 top-full z-50 mt-1 w-44 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] py-1 shadow-xl">
-                    {MODE_OPTIONS.map(({ key, label, icon: Icon }) => (
-                      <button
-                        key={key}
-                        onClick={() => handleNewSession(key)}
-                        className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-[var(--color-text)] hover:bg-[var(--color-surface-hover)]"
-                      >
-                        <Icon className="h-3.5 w-3.5 text-[var(--color-text-muted)]" />
-                        {label}
-                      </button>
-                    ))}
-                  </div>
-                </>
+                <NewSessionMenu
+                  agents={directAgents}
+                  modes={modes}
+                  selectedAgent={effectiveAgent}
+                  selectedMode={effectiveMode}
+                  onSelectAgent={setSelectedAgent}
+                  onSelectMode={setSelectedMode}
+                  onStart={(agent, mode) => handleNewSession(agent, mode)}
+                  onClose={() => setShowNewMenu(false)}
+                />
               )}
             </div>
             <button
@@ -181,6 +213,7 @@ export function ChatPanel({ isOpen, onToggle }: ChatPanelProps) {
               <SessionTab
                 key={slot.info.slot_id}
                 slot={slot}
+                agents={agents}
                 isActive={slot.info.slot_id === chat.activeSlotId}
                 isStreaming={slot.info.slot_id === chat.streamingSlotId}
                 onClick={() => chat.setActiveSlotId(slot.info.slot_id)}
@@ -240,24 +273,13 @@ export function ChatPanel({ isOpen, onToggle }: ChatPanelProps) {
               </p>
             </div>
           ) : !activeSlot ? (
-            <div className="flex h-full flex-col items-center justify-center text-center">
-              <MessageSquare className="mb-3 h-10 w-10 text-[var(--color-text-muted)] opacity-30" />
-              <p className="text-sm text-[var(--color-text-muted)]">
-                Start a new session to chat with the AI assistant.
-              </p>
-              <div className="mt-4 flex gap-2">
-                {MODE_OPTIONS.map(({ key, label, icon: Icon }) => (
-                  <button
-                    key={key}
-                    onClick={() => handleNewSession(key)}
-                    className="flex items-center gap-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-surface-hover)]"
-                  >
-                    <Icon className="h-3.5 w-3.5 text-[var(--color-primary)]" />
-                    {label}
-                  </button>
-                ))}
-              </div>
-            </div>
+            <EmptyState
+              agents={directAgents}
+              modes={modes}
+              defaultAgent={defaultAgent}
+              defaultMode={defaultMode}
+              onStart={handleNewSession}
+            />
           ) : activeSlot.messages.length === 0 ? (
             <div className="flex h-full flex-col items-center justify-center text-center">
               {activeSlot.info.mode === "agent_builder" ? (
@@ -274,6 +296,9 @@ export function ChatPanel({ isOpen, onToggle }: ChatPanelProps) {
                 {activeSlot.info.mode === "agent_builder"
                   ? "Create and manage autonomous trading strategies."
                   : "Ask about your portfolio, prices, trades, or bot status."}
+              </p>
+              <p className="mt-2 text-[10px] text-[var(--color-text-muted)] opacity-60">
+                {resolveAgentLabel(activeSlot.info.agent_key, agents)}
               </p>
             </div>
           ) : (
@@ -296,14 +321,231 @@ export function ChatPanel({ isOpen, onToggle }: ChatPanelProps) {
   );
 }
 
+/** Resolve a short label for an agent key */
+function resolveAgentLabel(agentKey: string, agents: ChatAgentOption[]): string {
+  const match = agents.find((a) => a.key === agentKey);
+  if (match) return match.label;
+  // Handle dynamic keys like "openrouter:anthropic/claude-3.5-sonnet"
+  if (agentKey.includes(":")) {
+    const [provider, model] = agentKey.split(":", 2);
+    return model || provider;
+  }
+  return agentKey;
+}
+
+/** Shorten agent label for tab display */
+function shortAgentLabel(agentKey: string, agents: ChatAgentOption[]): string {
+  const full = resolveAgentLabel(agentKey, agents);
+  // Shorten common names
+  const shortMap: Record<string, string> = {
+    "Claude Code": "Claude",
+    "Gemini CLI": "Gemini",
+    "GitHub Copilot CLI": "Copilot",
+    "ChatGPT Codex": "Codex",
+  };
+  return shortMap[full] || (full.length > 12 ? full.slice(0, 12) + "..." : full);
+}
+
+// ── New Session Menu ──
+
+function NewSessionMenu({
+  agents,
+  modes,
+  selectedAgent,
+  selectedMode,
+  onSelectAgent,
+  onSelectMode,
+  onStart,
+  onClose,
+}: {
+  agents: ChatAgentOption[];
+  modes: ChatModeOption[];
+  selectedAgent: string;
+  selectedMode: string;
+  onSelectAgent: (key: string) => void;
+  onSelectMode: (key: string) => void;
+  onStart: (agent: string, mode: string) => void;
+  onClose: () => void;
+}) {
+  const [showAgentPicker, setShowAgentPicker] = useState(false);
+
+  const agentLabel = agents.find((a) => a.key === selectedAgent)?.label || selectedAgent;
+  const ModeIcon = MODE_ICONS[selectedMode] || Zap;
+
+  return (
+    <>
+      <div className="fixed inset-0 z-50" onClick={onClose} />
+      <div className="absolute right-0 top-full z-50 mt-1 w-56 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] py-1 shadow-xl">
+        {/* Model selector */}
+        <div className="px-3 pt-2 pb-1">
+          <label className="text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+            Model
+          </label>
+          <div className="relative mt-1">
+            <button
+              onClick={() => setShowAgentPicker((v) => !v)}
+              className="flex w-full items-center justify-between rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2.5 py-1.5 text-left text-xs text-[var(--color-text)] hover:border-[var(--color-primary)]/40"
+            >
+              <span className="truncate">{agentLabel}</span>
+              <ChevronDown className="ml-1 h-3 w-3 shrink-0 text-[var(--color-text-muted)]" />
+            </button>
+            {showAgentPicker && (
+              <div className="absolute left-0 top-full z-10 mt-1 max-h-48 w-full overflow-y-auto rounded border border-[var(--color-border)] bg-[var(--color-surface)] py-0.5 shadow-lg">
+                {agents.map((a) => (
+                  <button
+                    key={a.key}
+                    onClick={() => {
+                      onSelectAgent(a.key);
+                      setShowAgentPicker(false);
+                    }}
+                    className={`flex w-full items-center px-2.5 py-1.5 text-left text-xs hover:bg-[var(--color-surface-hover)] ${
+                      a.key === selectedAgent
+                        ? "text-[var(--color-primary)] font-medium"
+                        : "text-[var(--color-text)]"
+                    }`}
+                  >
+                    {a.label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Mode buttons */}
+        <div className="px-3 pt-2 pb-1">
+          <label className="text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+            Mode
+          </label>
+        </div>
+        {modes.map(({ key, label }) => {
+          const Icon = MODE_ICONS[key] || Zap;
+          return (
+            <button
+              key={key}
+              onClick={() => onSelectMode(key)}
+              className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-[var(--color-surface-hover)] ${
+                key === selectedMode
+                  ? "text-[var(--color-primary)]"
+                  : "text-[var(--color-text)]"
+              }`}
+            >
+              <Icon className="h-3.5 w-3.5 text-[var(--color-text-muted)]" />
+              {label}
+            </button>
+          );
+        })}
+
+        {/* Start button */}
+        <div className="mt-1 border-t border-[var(--color-border)] px-3 pt-2 pb-2">
+          <button
+            onClick={() => onStart(selectedAgent, selectedMode)}
+            className="flex w-full items-center justify-center gap-2 rounded-md bg-[var(--color-primary)] px-3 py-1.5 text-xs font-medium text-black hover:bg-[var(--color-primary)]/80"
+          >
+            <ModeIcon className="h-3.5 w-3.5" />
+            Start Session
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── Empty State ──
+
+function EmptyState({
+  agents,
+  modes,
+  defaultAgent,
+  defaultMode,
+  onStart,
+}: {
+  agents: ChatAgentOption[];
+  modes: ChatModeOption[];
+  defaultAgent: string;
+  defaultMode: string;
+  onStart: (agent: string, mode: string) => void;
+}) {
+  const [selectedAgent, setSelectedAgent] = useState(defaultAgent);
+  const [showAgentPicker, setShowAgentPicker] = useState(false);
+
+  const agentLabel = agents.find((a) => a.key === selectedAgent)?.label || selectedAgent;
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center text-center">
+      <MessageSquare className="mb-3 h-10 w-10 text-[var(--color-text-muted)] opacity-30" />
+      <p className="text-sm text-[var(--color-text-muted)]">
+        Start a new session to chat with the AI assistant.
+      </p>
+
+      {/* Agent picker */}
+      {agents.length > 1 && (
+        <div className="relative mt-4 mb-2">
+          <button
+            onClick={() => setShowAgentPicker((v) => !v)}
+            className="flex items-center gap-1.5 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-xs text-[var(--color-text)] hover:border-[var(--color-primary)]/40"
+          >
+            <span>{agentLabel}</span>
+            <ChevronDown className="h-3 w-3 text-[var(--color-text-muted)]" />
+          </button>
+          {showAgentPicker && (
+            <>
+              <div className="fixed inset-0 z-40" onClick={() => setShowAgentPicker(false)} />
+              <div className="absolute left-1/2 top-full z-50 mt-1 max-h-48 w-48 -translate-x-1/2 overflow-y-auto rounded border border-[var(--color-border)] bg-[var(--color-surface)] py-0.5 shadow-lg">
+                {agents.map((a) => (
+                  <button
+                    key={a.key}
+                    onClick={() => {
+                      setSelectedAgent(a.key);
+                      setShowAgentPicker(false);
+                    }}
+                    className={`flex w-full items-center px-3 py-1.5 text-left text-xs hover:bg-[var(--color-surface-hover)] ${
+                      a.key === selectedAgent
+                        ? "text-[var(--color-primary)] font-medium"
+                        : "text-[var(--color-text)]"
+                    }`}
+                  >
+                    {a.label}
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* Mode buttons */}
+      <div className="mt-2 flex gap-2">
+        {modes.map(({ key, label }) => {
+          const Icon = MODE_ICONS[key] || Zap;
+          return (
+            <button
+              key={key}
+              onClick={() => onStart(selectedAgent, key)}
+              className="flex items-center gap-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-surface-hover)]"
+            >
+              <Icon className="h-3.5 w-3.5 text-[var(--color-primary)]" />
+              {label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ── Session Tab ──
+
 function SessionTab({
   slot,
+  agents,
   isActive,
   isStreaming,
   onClick,
   onClose,
 }: {
   slot: ChatSlot;
+  agents: ChatAgentOption[];
   isActive: boolean;
   isStreaming: boolean;
   onClick: () => void;
@@ -311,8 +553,8 @@ function SessionTab({
 }) {
   const modeLabel =
     slot.info.mode === "agent_builder" ? "Builder" : "Condor";
-  const ModeIcon =
-    slot.info.mode === "agent_builder" ? Brain : Zap;
+  const agentShort = shortAgentLabel(slot.info.agent_key, agents);
+  const ModeIcon = MODE_ICONS[slot.info.mode] || Zap;
 
   return (
     <button
@@ -327,7 +569,10 @@ function SessionTab({
         <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-[var(--color-primary)]" />
       )}
       <ModeIcon className="h-3 w-3 shrink-0" />
-      <span className="max-w-[80px] truncate">{modeLabel}</span>
+      <span className="max-w-[100px] truncate">
+        {modeLabel}
+        <span className="text-[var(--color-text-muted)]"> · {agentShort}</span>
+      </span>
       {isStreaming && (
         <Loader2 className="h-3 w-3 shrink-0 animate-spin text-[var(--color-primary)]" />
       )}

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -7,6 +7,7 @@ import {
   MessageSquare,
   Minus,
   Plus,
+  Server,
   X,
   Zap,
 } from "lucide-react";
@@ -14,6 +15,7 @@ import { useChatSocket, type ChatSlot } from "@/hooks/useChatSocket";
 import { ChatMessageView } from "./ChatMessage";
 import { ChatInput } from "./ChatInput";
 import { api, type ChatAgentOption, type ChatModeOption } from "@/lib/api";
+import { useServer } from "@/hooks/useServer";
 
 const MIN_WIDTH = 360;
 const MAX_WIDTH = 1200;
@@ -31,6 +33,7 @@ interface ChatPanelProps {
 
 export function ChatPanel({ isOpen, onToggle }: ChatPanelProps) {
   const chat = useChatSocket();
+  const { server } = useServer();
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
 
@@ -123,7 +126,7 @@ export function ChatPanel({ isOpen, onToggle }: ChatPanelProps) {
   const handleNewSession = (agentKey: string, mode: string) => {
     setPendingSession(true);
     onToggle(true);
-    chat.startSession(agentKey, mode);
+    chat.startSession(agentKey, mode, server || undefined);
     setShowNewMenu(false);
     setSelectedAgent(null);
     setSelectedMode(null);
@@ -173,6 +176,13 @@ export function ChatPanel({ isOpen, onToggle }: ChatPanelProps) {
               <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
             )}
           </div>
+          {/* Active session server indicator */}
+          {activeSlot?.info.server_name && (
+            <div className="flex items-center gap-1 rounded bg-[var(--color-surface-hover)] px-2 py-0.5 text-[10px] text-[var(--color-text-muted)] border border-[var(--color-border)]">
+              <Server className="h-2.5 w-2.5" />
+              <span className="truncate max-w-[80px]">{activeSlot.info.server_name}</span>
+            </div>
+          )}
           <div className="flex items-center gap-1">
             {/* New session button */}
             <div className="relative">
@@ -314,6 +324,8 @@ export function ChatPanel({ isOpen, onToggle }: ChatPanelProps) {
           <ChatInput
             onSend={(text) => chat.sendMessage(activeSlot.info.slot_id, text)}
             disabled={isActiveStreaming}
+            isStreaming={isActiveStreaming}
+            onAbort={() => chat.activeSlotId && chat.abortPrompt(chat.activeSlotId)}
           />
         )}
       </div>
@@ -457,13 +469,12 @@ function EmptyState({
   agents,
   modes,
   defaultAgent,
-  defaultMode,
   onStart,
 }: {
   agents: ChatAgentOption[];
   modes: ChatModeOption[];
   defaultAgent: string;
-  defaultMode: string;
+  defaultMode?: string;
   onStart: (agent: string, mode: string) => void;
 }) {
   const [selectedAgent, setSelectedAgent] = useState(defaultAgent);
@@ -569,9 +580,12 @@ function SessionTab({
         <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-[var(--color-primary)]" />
       )}
       <ModeIcon className="h-3 w-3 shrink-0" />
-      <span className="max-w-[100px] truncate">
+      <span className="max-w-[140px] truncate">
         {modeLabel}
         <span className="text-[var(--color-text-muted)]"> · {agentShort}</span>
+        {slot.info.server_name && (
+          <span className="text-[var(--color-text-muted)]"> · {slot.info.server_name}</span>
+        )}
       </span>
       {isStreaming && (
         <Loader2 className="h-3 w-3 shrink-0 animate-spin text-[var(--color-primary)]" />

--- a/frontend/src/components/editor/CodeEditor.tsx
+++ b/frontend/src/components/editor/CodeEditor.tsx
@@ -39,7 +39,7 @@ export function CodeEditor({
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
   const { theme } = useTheme();
-  const isDark = theme === "dark";
+  const isDark = theme !== "light";
 
   // Create editor on mount (and recreate on theme change)
   useEffect(() => {

--- a/frontend/src/components/executor/DCAConfigPanel.tsx
+++ b/frontend/src/components/executor/DCAConfigPanel.tsx
@@ -13,6 +13,7 @@ import {
   type FieldDispatch,
 } from "./fields";
 import type { ChartPriceMapping, ExecutorValidation, ExtraLine } from "./types";
+import { getThemeColors } from "@/lib/theme-colors";
 
 // ── State ──
 
@@ -240,7 +241,7 @@ export function useDCAConfig() {
         extras.push({
           price: tpPrice,
           label: `TP (${(state.take_profit * 100).toFixed(1)}%)`,
-          color: "#22c55e",
+          color: getThemeColors().green,
           lineStyle: "dashed",
           lineWidth: 2,
         });
@@ -252,7 +253,7 @@ export function useDCAConfig() {
         extras.push({
           price: slPrice,
           label: `SL (${(state.stop_loss * 100).toFixed(1)}%)`,
-          color: "#ef4444",
+          color: getThemeColors().red,
           lineStyle: "dashed",
           lineWidth: 2,
         });

--- a/frontend/src/components/executor/PositionConfigPanel.tsx
+++ b/frontend/src/components/executor/PositionConfigPanel.tsx
@@ -15,6 +15,7 @@ import {
   type FieldDispatch,
 } from "./fields";
 import type { ChartPriceMapping, ExecutorValidation, ExtraLine } from "./types";
+import { getThemeColors } from "@/lib/theme-colors";
 
 // ── State ──
 
@@ -141,7 +142,7 @@ export function usePositionConfig() {
       extras.push({
         price: tpPrice,
         label: `TP (${(state.take_profit * 100).toFixed(1)}%)`,
-        color: "#22c55e",
+        color: getThemeColors().green,
         lineStyle: "dashed",
         lineWidth: 2,
       });
@@ -151,7 +152,7 @@ export function usePositionConfig() {
       extras.push({
         price: slPrice,
         label: `SL (${(state.stop_loss * 100).toFixed(1)}%)`,
-        color: "#ef4444",
+        color: getThemeColors().red,
         lineStyle: "dashed",
         lineWidth: 2,
       });

--- a/frontend/src/components/grid/GridChart.tsx
+++ b/frontend/src/components/grid/GridChart.tsx
@@ -5,6 +5,7 @@ import { api, type ConsolidatedPosition } from "@/lib/api";
 import { candleStore } from "@/lib/candle-store";
 import type { ExtraLine } from "@/components/executor/types";
 import { getExecutorColor, type ExecutorOverlay } from "@/lib/executor-overlays";
+import { getThemeColors, pnlColor, sideColor } from "@/lib/theme-colors";
 
 type PickField = "start" | "end" | "limit" | null;
 
@@ -224,19 +225,19 @@ export function GridChart({
         }
 
         const o = bestOverlay;
-        const pnlClr = o.pnl >= 0 ? "#22c55e" : "#ef4444";
+        const pnlClr = pnlColor(o.pnl);
         const pnlSign = o.pnl >= 0 ? "+" : "";
         const pnlStr = Math.abs(o.pnl) >= 1000 ? `${pnlSign}$${(o.pnl / 1000).toFixed(1)}K` : `${pnlSign}$${o.pnl.toFixed(2)}`;
         const pctStr = o.pnlPct !== 0 ? `${o.pnlPct > 0 ? "+" : ""}${(o.pnlPct * 100).toFixed(2)}%` : "";
         const volStr = Math.abs(o.volume) >= 1000 ? `$${(o.volume / 1000).toFixed(1)}K` : `$${o.volume.toFixed(0)}`;
         const feesStr = o.fees ? `$${o.fees.toFixed(2)}` : "";
 
-        const sideClr = o.side === "buy" ? "#22c55e" : "#ef4444";
+        const sideClr = sideColor(o.side);
         const sideBg = o.side === "buy" ? "rgba(34,197,94,0.15)" : "rgba(239,68,68,0.15)";
         const statusBg = o.status?.toLowerCase() === "running" || o.status?.toLowerCase() === "active"
           ? "rgba(34,197,94,0.15)" : "rgba(156,163,175,0.15)";
         const statusClr = o.status?.toLowerCase() === "running" || o.status?.toLowerCase() === "active"
-          ? "#22c55e" : "#9ca3af";
+          ? getThemeColors().green : "#9ca3af";
 
         // Build config detail rows
         const cfg = o.config || {};
@@ -281,9 +282,9 @@ export function GridChart({
         else if (cfg.amount != null && Number(cfg.amount) > 0) addRow("Amount", String(cfg.amount));
 
         const tp = Number(tripleBarrier.take_profit || cfg.take_profit);
-        if (tp > 0 && tp !== -1) addRow("Take Profit", `${(tp * 100).toFixed(2)}%`, "#22c55e");
+        if (tp > 0 && tp !== -1) addRow("Take Profit", `${(tp * 100).toFixed(2)}%`, getThemeColors().green);
         const sl = Number(cfg.stop_loss);
-        if (sl > 0 && sl !== -1) addRow("Stop Loss", `${(sl * 100).toFixed(2)}%`, "#ef4444");
+        if (sl > 0 && sl !== -1) addRow("Stop Loss", `${(sl * 100).toFixed(2)}%`, getThemeColors().red);
         if (cfg.keep_position != null) addRow("Keep Position", String(cfg.keep_position) === "true" ? "Yes" : "No");
 
         tooltip.innerHTML = `
@@ -433,7 +434,7 @@ export function GridChart({
     if (startPrice > 0) {
       startLineRef.current = series.createPriceLine({
         price: startPrice,
-        color: activePickField === "start" ? "#22c55e" : "#16a34a",
+        color: getThemeColors().green,
         lineWidth: 2,
         lineStyle: mod.LineStyle.Solid,
         axisLabelVisible: true,
@@ -444,7 +445,7 @@ export function GridChart({
     if (endPrice > 0) {
       endLineRef.current = series.createPriceLine({
         price: endPrice,
-        color: activePickField === "end" ? "#22c55e" : "#16a34a",
+        color: getThemeColors().green,
         lineWidth: 2,
         lineStyle: mod.LineStyle.Dashed,
         axisLabelVisible: true,
@@ -453,7 +454,7 @@ export function GridChart({
     }
 
     if (limitPrice > 0) {
-      const limitColor = side === 1 ? "#ef4444" : "#f97316";
+      const limitColor = side === 1 ? getThemeColors().red : "#f97316";
       limitLineRef.current = series.createPriceLine({
         price: limitPrice,
         color: activePickField === "limit" ? "#fbbf24" : limitColor,
@@ -625,7 +626,7 @@ export function GridChart({
 
           if (box.limitPrice) {
             const limit = chart.addSeries(mod.LineSeries, {
-              color: applyDim("#ef4444"), lineWidth: 1, lineStyle: mod.LineStyle.Dotted,
+              color: applyDim(getThemeColors().red), lineWidth: 1, lineStyle: mod.LineStyle.Dotted,
               priceLineVisible: false, lastValueVisible: false, crosshairMarkerVisible: false,
             });
             limit.setData([
@@ -741,7 +742,7 @@ export function GridChart({
         ? `${pnlSign}$${(pnl / 1000).toFixed(1)}K`
         : `${pnlSign}$${pnl.toFixed(2)}`;
       const amt = Math.abs(pos.amount);
-      const color = pnl >= 0 ? "#22c55e" : "#ef4444";
+      const color = pnlColor(pnl);
       const label = `${isLong ? "LONG" : "SHORT"} ${amt.toFixed(4)} · ${pnlStr}`;
       const pl = series.createPriceLine({
         price: pos.entry_price,

--- a/frontend/src/components/grid/GridChart.tsx
+++ b/frontend/src/components/grid/GridChart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { useCandleStore } from "@/hooks/useCandleStore";
 import { api, type ConsolidatedPosition } from "@/lib/api";
@@ -29,6 +29,13 @@ interface GridChartProps {
   executorOverlays?: ExecutorOverlay[];
   positions?: ConsolidatedPosition[];
   selectedExecutorId?: string | null;
+  /** Convert a value from the pair's quote currency to display currency */
+  convertValue?: (val: number) => string;
+  convertPnl?: (val: number) => string;
+  /** Callback when user clicks an executor in the list that's outside candle range */
+  onRequestCandleRange?: (startTime: number) => void;
+  /** Callback when user clicks chart background to deselect executor */
+  onExecutorDeselect?: () => void;
 }
 
 function getChartColors() {
@@ -62,6 +69,9 @@ export function GridChart({
   executorOverlays,
   positions,
   selectedExecutorId,
+  convertValue,
+  convertPnl,
+  onExecutorDeselect,
 }: GridChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
@@ -72,6 +82,10 @@ export function GridChart({
   const crosshairPriceRef = useRef<number | null>(null);
   const overlaysRef = useRef<ExecutorOverlay[]>([]);
   const lastZoomedIdRef = useRef<string | null>(null);
+  const convertValueRef = useRef(convertValue);
+  const convertPnlRef = useRef(convertPnl);
+  convertValueRef.current = convertValue;
+  convertPnlRef.current = convertPnl;
   const [chartReady, setChartReady] = useState(false);
 
   // Price line refs
@@ -86,6 +100,20 @@ export function GridChart({
 
   // ── Candle data from the singleton store (WS live + cached) ──
   const { candles, mergeCandles, setDuration } = useCandleStore(server, connector, pair, interval);
+
+  // ── Filter executor overlays to those within candle time range ──
+  const filteredOverlays = useMemo(() => {
+    if (!executorOverlays?.length) return executorOverlays;
+    if (!candles.length) return executorOverlays; // no candles yet → show all
+    const minTime = candles[0].timestamp;
+    return executorOverlays.filter((o) => {
+      const s = o.status?.toLowerCase();
+      if (s === "running" || s === "active") return true;
+      if (selectedExecutorId && o.executorId === selectedExecutorId) return true;
+      const end = o.timeRange.end > 1e12 ? o.timeRange.end / 1000 : o.timeRange.end;
+      return end >= minTime;
+    });
+  }, [executorOverlays, candles, selectedExecutorId]);
 
   // ── REST backfill on pair/interval/lookback change ──
   const backfillKeyRef = useRef("");
@@ -226,11 +254,12 @@ export function GridChart({
 
         const o = bestOverlay;
         const pnlClr = pnlHexColor(o.pnl);
-        const pnlSign = o.pnl >= 0 ? "+" : "";
-        const pnlStr = Math.abs(o.pnl) >= 1000 ? `${pnlSign}$${(o.pnl / 1000).toFixed(1)}K` : `${pnlSign}$${o.pnl.toFixed(2)}`;
+        const _cvtPnl = convertPnlRef.current;
+        const _cvtVal = convertValueRef.current;
+        const pnlStr = _cvtPnl ? _cvtPnl(o.pnl) : (Math.abs(o.pnl) >= 1000 ? `${o.pnl >= 0 ? "+" : ""}$${(o.pnl / 1000).toFixed(1)}K` : `${o.pnl >= 0 ? "+" : ""}$${o.pnl.toFixed(2)}`);
         const pctStr = o.pnlPct !== 0 ? `${o.pnlPct > 0 ? "+" : ""}${(o.pnlPct * 100).toFixed(2)}%` : "";
-        const volStr = Math.abs(o.volume) >= 1000 ? `$${(o.volume / 1000).toFixed(1)}K` : `$${o.volume.toFixed(0)}`;
-        const feesStr = o.fees ? `$${o.fees.toFixed(2)}` : "";
+        const volStr = _cvtVal ? _cvtVal(o.volume) : (Math.abs(o.volume) >= 1000 ? `$${(o.volume / 1000).toFixed(1)}K` : `$${o.volume.toFixed(0)}`);
+        const feesStr = o.fees ? (_cvtVal ? _cvtVal(o.fees) : `$${o.fees.toFixed(2)}`) : "";
 
         const sideClr = sideColor(o.side);
         const sideBg = o.side === "buy" ? "rgba(34,197,94,0.15)" : "rgba(239,68,68,0.15)";
@@ -278,7 +307,7 @@ export function GridChart({
         }
 
         if (cfg.leverage != null && Number(cfg.leverage) > 1) addRow("Leverage", `${cfg.leverage}x`);
-        if (cfg.total_amount_quote != null) addRow("Amount", fmtUsd(Number(cfg.total_amount_quote)));
+        if (cfg.total_amount_quote != null) addRow("Amount", _cvtVal ? _cvtVal(Number(cfg.total_amount_quote)) : fmtUsd(Number(cfg.total_amount_quote)));
         else if (cfg.amount != null && Number(cfg.amount) > 0) addRow("Amount", String(cfg.amount));
 
         const tp = Number(tripleBarrier.take_profit || cfg.take_profit);
@@ -540,12 +569,12 @@ export function GridChart({
     }
     overlayPriceLinesRef.current = [];
 
-    if (!executorOverlays?.length) return;
+    if (!filteredOverlays?.length) return;
 
     const hasSelection = !!selectedExecutorId;
-    const isMulti = executorOverlays.length > 1;
+    const isMulti = filteredOverlays.length > 1;
 
-    executorOverlays.forEach((overlay, idx) => {
+    filteredOverlays.forEach((overlay, idx) => {
       const isSelectedOverlay = hasSelection && overlay.executorId === selectedExecutorId;
       const isDimmed = hasSelection && !isSelectedOverlay;
       // When selected: use bright color and thicker lines; when dimmed: reduce opacity
@@ -662,13 +691,13 @@ export function GridChart({
     });
 
     // Full-width price lines for active or selected executor
-    if (series && executorOverlays?.length) {
+    if (series && filteredOverlays?.length) {
       const styleMap: Record<string, number> = {
         solid: mod.LineStyle.Solid,
         dashed: mod.LineStyle.Dashed,
         dotted: mod.LineStyle.Dotted,
       };
-      for (const overlay of executorOverlays) {
+      for (const overlay of filteredOverlays) {
         const isRunning = overlay.status?.toLowerCase() === "running" || overlay.status?.toLowerCase() === "active";
         const isSelectedOverlay = overlay.executorId === selectedExecutorId;
         // Show price lines for active executors, and always for the selected one
@@ -687,14 +716,14 @@ export function GridChart({
         }
       }
     }
-  }, [executorOverlays, selectedExecutorId]);
+  }, [filteredOverlays, selectedExecutorId]);
 
   // ── Zoom to selected executor (one-time action) ──
   useEffect(() => {
-    if (!selectedExecutorId || !chartRef.current || !executorOverlays?.length) return;
+    if (!selectedExecutorId || !chartRef.current || !filteredOverlays?.length) return;
     // Only zoom once per selection — don't re-zoom on overlay data refresh
     if (lastZoomedIdRef.current === selectedExecutorId) return;
-    const overlay = executorOverlays.find((o) => o.executorId === selectedExecutorId);
+    const overlay = filteredOverlays.find((o) => o.executorId === selectedExecutorId);
     if (!overlay) return;
 
     lastZoomedIdRef.current = selectedExecutorId;
@@ -708,7 +737,7 @@ export function GridChart({
       from: (start - padding) as import("lightweight-charts").UTCTimestamp,
       to: (end + padding) as import("lightweight-charts").UTCTimestamp,
     });
-  }, [selectedExecutorId, executorOverlays]);
+  }, [selectedExecutorId, filteredOverlays]);
 
   // Reset zoom tracking when executor is deselected
   useEffect(() => {
@@ -717,8 +746,8 @@ export function GridChart({
 
   // Keep overlaysRef in sync for tooltip
   useEffect(() => {
-    overlaysRef.current = executorOverlays ?? [];
-  }, [executorOverlays]);
+    overlaysRef.current = filteredOverlays ?? [];
+  }, [filteredOverlays]);
 
   // ── Position hold lines ──
   useEffect(() => {
@@ -737,10 +766,8 @@ export function GridChart({
       if (pos.entry_price <= 0) continue;
       const isLong = pos.position_side?.toUpperCase() === "LONG";
       const pnl = pos.unrealized_pnl ?? 0;
-      const pnlSign = pnl >= 0 ? "+" : "";
-      const pnlStr = Math.abs(pnl) >= 1000
-        ? `${pnlSign}$${(pnl / 1000).toFixed(1)}K`
-        : `${pnlSign}$${pnl.toFixed(2)}`;
+      const _cvtPnl2 = convertPnlRef.current;
+      const pnlStr = _cvtPnl2 ? _cvtPnl2(pnl) : (Math.abs(pnl) >= 1000 ? `${pnl >= 0 ? "+" : ""}$${(pnl / 1000).toFixed(1)}K` : `${pnl >= 0 ? "+" : ""}$${pnl.toFixed(2)}`);
       const amt = Math.abs(pos.amount);
       const color = pnlHexColor(pnl);
       const label = `${isLong ? "LONG" : "SHORT"} ${amt.toFixed(4)} · ${pnlStr}`;
@@ -756,10 +783,16 @@ export function GridChart({
     }
   }, [positions]);
 
-  // ── Click-to-set price ──
+  // ── Click-to-set price / deselect executor ──
   const handleClick = () => {
-    if (!activePickField || crosshairPriceRef.current === null) return;
-    onPriceSet(activePickField, crosshairPriceRef.current);
+    if (activePickField && crosshairPriceRef.current !== null) {
+      onPriceSet(activePickField, crosshairPriceRef.current);
+      return;
+    }
+    // Click on chart background deselects executor
+    if (selectedExecutorId && onExecutorDeselect) {
+      onExecutorDeselect();
+    }
   };
 
   return (

--- a/frontend/src/components/grid/GridChart.tsx
+++ b/frontend/src/components/grid/GridChart.tsx
@@ -5,7 +5,7 @@ import { api, type ConsolidatedPosition } from "@/lib/api";
 import { candleStore } from "@/lib/candle-store";
 import type { ExtraLine } from "@/components/executor/types";
 import { getExecutorColor, type ExecutorOverlay } from "@/lib/executor-overlays";
-import { getThemeColors, pnlColor, sideColor } from "@/lib/theme-colors";
+import { getThemeColors, pnlHexColor, sideColor } from "@/lib/theme-colors";
 
 type PickField = "start" | "end" | "limit" | null;
 
@@ -225,7 +225,7 @@ export function GridChart({
         }
 
         const o = bestOverlay;
-        const pnlClr = pnlColor(o.pnl);
+        const pnlClr = pnlHexColor(o.pnl);
         const pnlSign = o.pnl >= 0 ? "+" : "";
         const pnlStr = Math.abs(o.pnl) >= 1000 ? `${pnlSign}$${(o.pnl / 1000).toFixed(1)}K` : `${pnlSign}$${o.pnl.toFixed(2)}`;
         const pctStr = o.pnlPct !== 0 ? `${o.pnlPct > 0 ? "+" : ""}${(o.pnlPct * 100).toFixed(2)}%` : "";
@@ -742,7 +742,7 @@ export function GridChart({
         ? `${pnlSign}$${(pnl / 1000).toFixed(1)}K`
         : `${pnlSign}$${pnl.toFixed(2)}`;
       const amt = Math.abs(pos.amount);
-      const color = pnlColor(pnl);
+      const color = pnlHexColor(pnl);
       const label = `${isLong ? "LONG" : "SHORT"} ${amt.toFixed(4)} · ${pnlStr}`;
       const pl = series.createPriceLine({
         price: pos.entry_price,

--- a/frontend/src/components/grid/GridChart.tsx
+++ b/frontend/src/components/grid/GridChart.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 import { useCandleStore } from "@/hooks/useCandleStore";
 import { api, type ConsolidatedPosition } from "@/lib/api";
@@ -336,18 +337,21 @@ export function GridChart({
         `;
         tooltip.style.display = "block";
 
+        // Position tooltip using viewport-fixed coords (rendered via portal)
         const containerRect = containerRef.current.getBoundingClientRect();
         const tooltipW = 280;
-        // Show tooltip on opposite side of cursor to avoid covering the executor
+        const tooltipH = tooltip.offsetHeight || 200;
         const cursorInRightHalf = param.point.x > containerRect.width / 2;
         let left = cursorInRightHalf
-          ? param.point.x - tooltipW - 16
-          : param.point.x + 16;
-        // Clamp to container bounds
+          ? containerRect.left + param.point.x - tooltipW - 16
+          : containerRect.left + param.point.x + 16;
         if (left < 4) left = 4;
-        if (left + tooltipW > containerRect.width - 4) left = containerRect.width - tooltipW - 4;
-        let top = param.point.y - 10;
-        if (top < 0) top = 4;
+        if (left + tooltipW > window.innerWidth - 4) left = window.innerWidth - tooltipW - 4;
+        let top = containerRect.top + param.point.y - 10;
+        if (top + tooltipH > window.innerHeight - 4) {
+          top = window.innerHeight - tooltipH - 4;
+        }
+        if (top < 4) top = 4;
 
         tooltip.style.left = `${left}px`;
         tooltip.style.top = `${top}px`;
@@ -814,28 +818,31 @@ export function GridChart({
           style={{ cursor: activePickField ? "crosshair" : "default" }}
           onClick={handleClick}
         />
-        {/* Executor tooltip overlay */}
-        <div
-          ref={tooltipRef}
-          style={{
-            display: "none",
-            position: "absolute",
-            top: 0,
-            left: 0,
-            zIndex: 10,
-            pointerEvents: "none",
-            background: "var(--color-surface)",
-            border: "1px solid var(--color-border)",
-            borderRadius: 8,
-            padding: "10px 14px",
-            fontSize: 11,
-            color: "var(--color-text)",
-            width: 280,
-            lineHeight: 1.4,
-            backdropFilter: "blur(12px)",
-            boxShadow: "0 8px 32px rgba(0,0,0,0.4)",
-          }}
-        />
+        {/* Executor tooltip overlay — rendered via portal to escape overflow-hidden */}
+        {createPortal(
+          <div
+            ref={tooltipRef}
+            style={{
+              display: "none",
+              position: "fixed",
+              top: 0,
+              left: 0,
+              zIndex: 9999,
+              pointerEvents: "none",
+              background: "var(--color-surface)",
+              border: "1px solid var(--color-border)",
+              borderRadius: 8,
+              padding: "10px 14px",
+              fontSize: 11,
+              color: "var(--color-text)",
+              width: 280,
+              lineHeight: 1.4,
+              backdropFilter: "blur(12px)",
+              boxShadow: "0 8px 32px rgba(0,0,0,0.4)",
+            }}
+          />,
+          document.body,
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/grid/GridConfigPanel.tsx
+++ b/frontend/src/components/grid/GridConfigPanel.tsx
@@ -16,6 +16,7 @@ interface GridConfigPanelProps {
   dispatch: React.Dispatch<GridAction>;
   currentPrice: number | null;
   isSpot?: boolean;
+  quoteCurrency?: string;
 }
 
 function PriceField({
@@ -193,7 +194,7 @@ function SectionHeader({ children }: { children: React.ReactNode }) {
   );
 }
 
-export function GridConfigPanel({ state, dispatch, currentPrice, isSpot = false }: GridConfigPanelProps) {
+export function GridConfigPanel({ state, dispatch, currentPrice, isSpot = false, quoteCurrency = "USDT" }: GridConfigPanelProps) {
   const validation = useMemo(() => {
     const errors: string[] = [];
     const warnings: string[] = [];
@@ -361,22 +362,22 @@ export function GridConfigPanel({ state, dispatch, currentPrice, isSpot = false 
       <div className="space-y-2.5">
         <SectionHeader>Grid Structure</SectionHeader>
         <NumberField
-          label="Total Amount (quote)"
+          label={`Total Amount (${quoteCurrency})`}
           value={state.total_amount_quote}
           field="total_amount_quote"
           dispatch={dispatch}
           step={10}
           min={0}
-          suffix="USDT"
+          suffix={quoteCurrency}
         />
         <NumberField
-          label="Min Order Amount"
+          label={`Min Order Amount (${quoteCurrency})`}
           value={state.min_order_amount_quote}
           field="min_order_amount_quote"
           dispatch={dispatch}
           step={1}
           min={0}
-          suffix="USDT"
+          suffix={quoteCurrency}
         />
         <NumberField
           label="Min Spread Between Orders"

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -20,6 +20,7 @@ import { useCredentials } from "@/hooks/useCredentials";
 import { usePrefetchData } from "@/hooks/usePrefetchData";
 import { useServer } from "@/hooks/useServer";
 import { useTheme } from "@/hooks/useTheme";
+import { CurrencySelector } from "./CurrencySelector";
 import { ServerSelector } from "./ServerSelector";
 
 const NAV_ITEMS = [
@@ -79,6 +80,7 @@ export function AppShell() {
         {/* Right: server selector + controls */}
         <div className="ml-auto flex items-center gap-3">
           <ServerSelector />
+          <CurrencySelector />
 
           <div className="flex items-center gap-1">
             <NavLink

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -4,6 +4,7 @@ import {
   Bot,
   Brain,
   MessageSquare,
+  Eye,
   Moon,
   Settings,
   Sun,
@@ -100,9 +101,15 @@ export function AppShell() {
             <button
               onClick={toggleTheme}
               className="rounded p-1.5 text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-accent)]"
-              title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+              title={
+                theme === "dark" ? "Switch to light mode" :
+                theme === "light" ? "Switch to color-blind mode" :
+                "Switch to dark mode"
+              }
             >
-              {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+              {theme === "dark" ? <Sun className="h-4 w-4" /> :
+               theme === "light" ? <Eye className="h-4 w-4" /> :
+               <Moon className="h-4 w-4" />}
             </button>
 
           </div>

--- a/frontend/src/components/layout/CurrencySelector.tsx
+++ b/frontend/src/components/layout/CurrencySelector.tsx
@@ -1,0 +1,73 @@
+import { ChevronDown, DollarSign } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import {
+  useDisplayCurrency,
+  CURRENCY_OPTIONS,
+  CURRENCY_SYMBOLS,
+  type DisplayCurrency,
+} from "@/hooks/useDisplayCurrency";
+
+export function CurrencySelector() {
+  const { currency, setCurrency } = useDisplayCurrency();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-1.5 rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1.5 text-sm hover:bg-[var(--color-surface-hover)] transition-colors"
+        title="Display currency"
+      >
+        <DollarSign className="h-3.5 w-3.5 shrink-0 text-[var(--color-text-muted)]" />
+        <span className="text-xs font-medium">{currency}</span>
+        <ChevronDown
+          className={`h-3 w-3 shrink-0 text-[var(--color-text-muted)] transition-transform ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-1.5 min-w-[140px] rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] py-1 shadow-xl">
+          <div className="px-3 py-1.5 text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+            Display Currency
+          </div>
+          {CURRENCY_OPTIONS.map((c: DisplayCurrency) => (
+            <button
+              key={c}
+              onClick={() => {
+                setCurrency(c);
+                setOpen(false);
+              }}
+              className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-sm transition-colors hover:bg-[var(--color-surface-hover)] ${
+                c === currency
+                  ? "bg-[var(--color-primary)]/10 text-[var(--color-primary)]"
+                  : ""
+              }`}
+            >
+              <span className="w-5 text-center text-xs text-[var(--color-text-muted)]">
+                {CURRENCY_SYMBOLS[c]}
+              </span>
+              <span>{c}</span>
+              {c === currency && (
+                <span className="ml-auto text-[10px] font-medium text-[var(--color-primary)]">
+                  ✓
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/routines/ReportBrowser.tsx
+++ b/frontend/src/components/routines/ReportBrowser.tsx
@@ -22,6 +22,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { type RoutineInstance, api } from "@/lib/api";
+import { buildConfigValues, formatAgo, invalidateRoutineQueries, saveConfig } from "@/lib/routineUtils";
 import { setViewContext } from "@/lib/viewContext";
 import { useServer } from "@/hooks/useServer";
 import { RoutineConfigForm } from "./RoutineConfigForm";
@@ -139,16 +140,7 @@ export function ReportBrowser({
 
   useEffect(() => {
     if (!activeRoutine) return;
-    let saved: Record<string, unknown> | null = null;
-    try {
-      const raw = localStorage.getItem(`routine_config:${activeSource}`);
-      saved = raw ? JSON.parse(raw) : null;
-    } catch { /* ignore */ }
-    const values: Record<string, unknown> = {};
-    for (const [key, field] of Object.entries(activeRoutine.fields)) {
-      values[key] = saved && key in saved ? saved[key] : field.default;
-    }
-    setConfigValues(values);
+    setConfigValues(buildConfigValues(activeRoutine));
     setShowConfigPanel(false);
   }, [activeSource, activeRoutine]);
 
@@ -166,10 +158,7 @@ export function ReportBrowser({
   useEffect(() => {
     if (polledInstance && polledInstance.status !== "running") {
       setPollingInstanceId(null);
-      qc.invalidateQueries({ queryKey: ["routine-reports", activeSource] });
-      qc.invalidateQueries({ queryKey: ["reports-grouped"] });
-      qc.invalidateQueries({ queryKey: ["routines"] });
-      qc.invalidateQueries({ queryKey: ["routine-instances"] });
+      invalidateRoutineQueries(qc, activeSource);
     }
   }, [polledInstance, activeSource, qc]);
 
@@ -220,12 +209,7 @@ export function ReportBrowser({
     for (let i = 0; i < toRun.length; i++) {
       setRunAllProgress({ current: i + 1, total: toRun.length });
       const routine = toRun[i];
-      let saved: Record<string, unknown> | null = null;
-      try { const raw = localStorage.getItem(`routine_config:${routine.name}`); saved = raw ? JSON.parse(raw) : null; } catch { /* ignore */ }
-      const cfg: Record<string, unknown> = {};
-      for (const [key, field] of Object.entries(routine.fields)) {
-        cfg[key] = saved && key in saved ? saved[key] : field.default;
-      }
+      const cfg = buildConfigValues(routine);
       try {
         await api.runRoutine(server, routine.name, cfg);
       } catch {
@@ -233,10 +217,8 @@ export function ReportBrowser({
       }
     }
     setRunAllProgress(null);
+    invalidateRoutineQueries(qc);
     qc.invalidateQueries({ queryKey: ["routine-reports"] });
-    qc.invalidateQueries({ queryKey: ["reports-grouped"] });
-    qc.invalidateQueries({ queryKey: ["routines"] });
-    qc.invalidateQueries({ queryKey: ["routine-instances"] });
   }, [server, filteredRoutines, qc]);
 
   // Sync theme to iframe when it changes or report changes
@@ -708,7 +690,7 @@ export function ReportBrowser({
                 onChange={(key, value) => {
                   setConfigValues((prev) => {
                     const next = { ...prev, [key]: value };
-                    try { localStorage.setItem(`routine_config:${activeSource}`, JSON.stringify(next)); } catch { /* ignore */ }
+                    saveConfig(activeSource, next);
                     return next;
                   });
                 }}
@@ -884,12 +866,4 @@ export function ReportBrowser({
       )}
     </div>
   );
-}
-
-function formatAgo(iso: string): string {
-  const diff = (Date.now() - new Date(iso).getTime()) / 1000;
-  if (diff < 60) return `${Math.floor(diff)}s ago`;
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
-  return `${Math.floor(diff / 86400)}d ago`;
 }

--- a/frontend/src/components/routines/ReportBrowser.tsx
+++ b/frontend/src/components/routines/ReportBrowser.tsx
@@ -490,13 +490,6 @@ export function ReportBrowser({
                 {activeRoutine?.source.replace("agent:", "")}
               </span>
             )}
-            {selectedReport && (
-              <>
-                <span className="text-[var(--color-text-muted)]/40">|</span>
-                <span className="truncate text-[10px] text-[var(--color-text-muted)]">{selectedReport.title}</span>
-                <span className="text-[10px] text-[var(--color-text-muted)]/60">{new Date(selectedReport.created_at).toLocaleString()}</span>
-              </>
-            )}
             {sourceInstances.length > 0 && (
               <div className="flex items-center gap-2">
                 {sourceInstances.map((inst) => (

--- a/frontend/src/components/routines/ReportBrowser.tsx
+++ b/frontend/src/components/routines/ReportBrowser.tsx
@@ -768,6 +768,24 @@ export function ReportBrowser({
                   <p className="mt-1 text-xs text-[var(--color-text-muted)]">
                     {activeRoutine?.description ?? "Run this routine to generate your first report."}
                   </p>
+                  {activeRoutine && Object.keys(activeRoutine.fields).length > 0 && (
+                    <div className="mt-4 w-full max-w-md rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
+                      <h3 className="mb-2 text-[11px] font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+                        Configuration
+                      </h3>
+                      <RoutineConfigForm
+                        fields={activeRoutine.fields}
+                        values={configValues}
+                        onChange={(key, value) => {
+                          setConfigValues((prev) => {
+                            const next = { ...prev, [key]: value };
+                            saveConfig(activeSource, next);
+                            return next;
+                          });
+                        }}
+                      />
+                    </div>
+                  )}
                   {activeRoutine && server && (
                     <button
                       onClick={() => runMutation.mutate()}

--- a/frontend/src/components/routines/ReportBrowser.tsx
+++ b/frontend/src/components/routines/ReportBrowser.tsx
@@ -506,11 +506,6 @@ export function ReportBrowser({
                 <span className="text-[var(--color-text-muted)]/40">|</span>
                 <span className="truncate text-[10px] text-[var(--color-text-muted)]">{selectedReport.title}</span>
                 <span className="text-[10px] text-[var(--color-text-muted)]/60">{new Date(selectedReport.created_at).toLocaleString()}</span>
-                {selectedReport.tags.map((tag) => (
-                  <span key={tag} className="rounded bg-[var(--color-surface-hover)] px-1.5 py-0.5 text-[9px] text-[var(--color-text-muted)]">
-                    #{tag}
-                  </span>
-                ))}
               </>
             )}
             {sourceInstances.length > 0 && (

--- a/frontend/src/components/routines/ReportBrowser.tsx
+++ b/frontend/src/components/routines/ReportBrowser.tsx
@@ -12,11 +12,12 @@ import {
   Play,
   PlayCircle,
   Settings2,
-  Square,
   Sun,
   Trash2,
   X,
   Zap,
+  AlertTriangle,
+  Code,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -44,6 +45,7 @@ export function ReportBrowser({
   const [sourceTypeFilter, setSourceTypeFilter] = useState<string>(initialSourceTypeFilter || "all");
   const [isCompact, setIsCompact] = useState(false);
   const [showConfigPanel, setShowConfigPanel] = useState(false);
+  const [showSourceModal, setShowSourceModal] = useState(false);
   const [reportTheme, setReportTheme] = useState<"dark" | "light">("dark");
   const sidebarRef = useRef<HTMLDivElement>(null);
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -101,6 +103,13 @@ export function ReportBrowser({
   });
   const reports = reportsData?.reports ?? [];
 
+  // Source code query (lazy)
+  const { data: sourceData } = useQuery({
+    queryKey: ["routine-source", activeSource],
+    queryFn: () => api.getRoutineSource(activeSource),
+    enabled: showSourceModal && !!activeSource,
+  });
+
   const [selectedReportIdx, setSelectedReportIdx] = useState(0);
   const selectedReport = reports[selectedReportIdx] ?? null;
 
@@ -112,6 +121,12 @@ export function ReportBrowser({
   // Active instances for current source
   const sourceInstances = useMemo(
     () => instances.filter((i) => i.routine_name === activeSource && (i.status === "running" || i.status === "scheduled")),
+    [instances, activeSource],
+  );
+
+  // Latest failed instance for error display
+  const latestFailedInstance = useMemo(
+    () => instances.find((i) => i.routine_name === activeSource && i.status === "failed"),
     [instances, activeSource],
   );
 
@@ -262,14 +277,15 @@ export function ReportBrowser({
       else if (e.key === "ArrowLeft") { goPrevReport(); e.preventDefault(); }
       else if (e.key === "ArrowRight") { goNextReport(); e.preventDefault(); }
       else if (e.key === "Escape") {
-        if (showConfigPanel) setShowConfigPanel(false);
+        if (showSourceModal) setShowSourceModal(false);
+        else if (showConfigPanel) setShowConfigPanel(false);
         else onClose();
         e.preventDefault();
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [goSourceUp, goSourceDown, goPrevReport, goNextReport, onClose, showConfigPanel]);
+  }, [goSourceUp, goSourceDown, goPrevReport, goNextReport, onClose, showConfigPanel, showSourceModal]);
 
   // Scroll active source into view
   useEffect(() => {
@@ -485,6 +501,18 @@ export function ReportBrowser({
                 {activeRoutine?.source.replace("agent:", "")}
               </span>
             )}
+            {selectedReport && (
+              <>
+                <span className="text-[var(--color-text-muted)]/40">|</span>
+                <span className="truncate text-[10px] text-[var(--color-text-muted)]">{selectedReport.title}</span>
+                <span className="text-[10px] text-[var(--color-text-muted)]/60">{new Date(selectedReport.created_at).toLocaleString()}</span>
+                {selectedReport.tags.map((tag) => (
+                  <span key={tag} className="rounded bg-[var(--color-surface-hover)] px-1.5 py-0.5 text-[9px] text-[var(--color-text-muted)]">
+                    #{tag}
+                  </span>
+                ))}
+              </>
+            )}
             {sourceInstances.length > 0 && (
               <div className="flex items-center gap-2">
                 {sourceInstances.map((inst) => (
@@ -503,7 +531,7 @@ export function ReportBrowser({
                       className="ml-0.5 rounded p-0.5 text-[var(--color-red)] hover:bg-[var(--color-red)]/10"
                       title="Stop"
                     >
-                      <Square className="h-2.5 w-2.5" />
+                      <Trash2 className="h-2.5 w-2.5" />
                     </button>
                   </div>
                 ))}
@@ -515,15 +543,24 @@ export function ReportBrowser({
             {activeRoutine && server && (
               <div className="flex items-center gap-1 mr-2">
                 <button
+                  onClick={() => setShowSourceModal(true)}
+                  className="flex items-center gap-1 rounded px-2 py-1 text-[10px] font-semibold text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+                  title="View source code"
+                >
+                  <Code className="h-3.5 w-3.5" />
+                  Source
+                </button>
+                <button
                   onClick={() => setShowConfigPanel(!showConfigPanel)}
-                  className={`rounded p-1.5 transition-colors ${
+                  className={`flex items-center gap-1 rounded px-2 py-1 text-[10px] font-semibold transition-colors ${
                     showConfigPanel
                       ? "bg-[var(--color-primary)]/10 text-[var(--color-primary)]"
                       : "text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
                   }`}
                   title="Configure & Run"
                 >
-                  <Settings2 className="h-4 w-4" />
+                  <Settings2 className="h-3.5 w-3.5" />
+                  Config
                 </button>
                 <button
                   onClick={() => runMutation.mutate()}
@@ -648,19 +685,6 @@ export function ReportBrowser({
           </div>
         </div>
 
-        {/* Report meta bar */}
-        {selectedReport && (
-          <div className="flex items-center gap-3 border-b border-[var(--color-border)]/50 px-4 py-1.5 text-[10px] text-[var(--color-text-muted)]">
-            <span>{selectedReport.title}</span>
-            <span>{new Date(selectedReport.created_at).toLocaleString()}</span>
-            {selectedReport.tags.map((tag) => (
-              <span key={tag} className="rounded bg-[var(--color-surface-hover)] px-1.5 py-0.5 text-[9px]">
-                #{tag}
-              </span>
-            ))}
-          </div>
-        )}
-
         {/* Config panel (collapsible) */}
         {showConfigPanel && activeRoutine && (
           <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3">
@@ -724,33 +748,63 @@ export function ReportBrowser({
               <Loader2 className="h-6 w-6 animate-spin text-[var(--color-text-muted)]" />
             </div>
           ) : !selectedReport ? (
-            // No reports — prompt to run for the first time
+            // No reports — show error if failed, otherwise prompt to run
             <div className="flex h-full flex-col items-center justify-center text-center px-8">
-              <Zap className="mb-3 h-10 w-10 text-[var(--color-text-muted)]/20" />
-              <p className="text-sm font-medium text-[var(--color-text)]">
-                No reports yet
-              </p>
-              <p className="mt-1 text-xs text-[var(--color-text-muted)]">
-                {activeRoutine?.description ?? "Run this routine to generate your first report."}
-              </p>
-              {activeRoutine && server && (
-                <button
-                  onClick={() => runMutation.mutate()}
-                  disabled={runMutation.isPending}
-                  className="mt-4 flex items-center gap-1.5 rounded-lg bg-[var(--color-primary)] px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[var(--color-primary)]/80 disabled:opacity-50"
-                >
-                  {runMutation.isPending ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Play className="h-4 w-4" />
+              {(polledInstance?.status === "failed" || latestFailedInstance) ? (
+                <>
+                  <div className="w-full max-w-lg rounded-lg border border-[var(--color-red)]/30 bg-[var(--color-red)]/5 p-5">
+                    <div className="flex items-center gap-2 mb-3">
+                      <AlertTriangle className="h-5 w-5 text-[var(--color-red)]" />
+                      <span className="text-sm font-semibold text-[var(--color-red)]">Routine Failed</span>
+                    </div>
+                    <pre className="whitespace-pre-wrap break-words text-left font-mono text-xs text-[var(--color-text-muted)] bg-[var(--color-surface)] rounded p-3 max-h-60 overflow-y-auto">
+                      {(polledInstance?.status === "failed" ? polledInstance.error : latestFailedInstance?.error) || "Unknown error"}
+                    </pre>
+                    {activeRoutine && server && (
+                      <button
+                        onClick={() => runMutation.mutate()}
+                        disabled={runMutation.isPending}
+                        className="mt-4 flex items-center gap-1.5 rounded-lg bg-[var(--color-primary)] px-4 py-2 text-xs font-semibold text-white transition-colors hover:bg-[var(--color-primary)]/80 disabled:opacity-50"
+                      >
+                        {runMutation.isPending ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <Play className="h-3.5 w-3.5" />
+                        )}
+                        Retry
+                      </button>
+                    )}
+                  </div>
+                </>
+              ) : (
+                <>
+                  <Zap className="mb-3 h-10 w-10 text-[var(--color-text-muted)]/20" />
+                  <p className="text-sm font-medium text-[var(--color-text)]">
+                    No reports yet
+                  </p>
+                  <p className="mt-1 text-xs text-[var(--color-text-muted)]">
+                    {activeRoutine?.description ?? "Run this routine to generate your first report."}
+                  </p>
+                  {activeRoutine && server && (
+                    <button
+                      onClick={() => runMutation.mutate()}
+                      disabled={runMutation.isPending}
+                      className="mt-4 flex items-center gap-1.5 rounded-lg bg-[var(--color-primary)] px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[var(--color-primary)]/80 disabled:opacity-50"
+                    >
+                      {runMutation.isPending ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Play className="h-4 w-4" />
+                      )}
+                      Run for the first time
+                    </button>
                   )}
-                  Run for the first time
-                </button>
-              )}
-              {runMutation.isError && (
-                <p className="mt-2 text-xs text-[var(--color-red)]">
-                  {(runMutation.error as Error).message}
-                </p>
+                  {runMutation.isError && (
+                    <p className="mt-2 text-xs text-[var(--color-red)]">
+                      {(runMutation.error as Error).message}
+                    </p>
+                  )}
+                </>
               )}
             </div>
           ) : (
@@ -781,6 +835,45 @@ export function ReportBrowser({
           )}
         </div>
       </div>
+
+      {/* Source code modal */}
+      {showSourceModal && (
+        <div className="fixed inset-0 z-[60] flex flex-col bg-[var(--color-bg)]">
+          <div className="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-2">
+            <div className="flex items-center gap-3 min-w-0">
+              <Code className="h-4 w-4 text-[var(--color-text-muted)]" />
+              <span className="text-sm font-semibold text-[var(--color-text)]">
+                {sourceData?.filename ?? activeSource}
+              </span>
+            </div>
+            <button
+              onClick={() => setShowSourceModal(false)}
+              className="rounded p-1.5 text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+              title="Close (Esc)"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="flex-1 overflow-auto bg-[var(--color-surface)]">
+            {sourceData ? (
+              <pre className="p-0 m-0 text-xs leading-relaxed">
+                {sourceData.source.split("\n").map((line, i) => (
+                  <div key={i} className="flex hover:bg-[var(--color-surface-hover)]">
+                    <span className="sticky left-0 w-12 shrink-0 select-none bg-[var(--color-surface)] pr-3 text-right font-mono text-[var(--color-text-muted)]/40 border-r border-[var(--color-border)]/30">
+                      {i + 1}
+                    </span>
+                    <code className="pl-4 font-mono text-[var(--color-text)] whitespace-pre">{line}</code>
+                  </div>
+                ))}
+              </pre>
+            ) : (
+              <div className="flex h-full items-center justify-center">
+                <Loader2 className="h-6 w-6 animate-spin text-[var(--color-text-muted)]" />
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/routines/ReportBrowser.tsx
+++ b/frontend/src/components/routines/ReportBrowser.tsx
@@ -95,11 +95,15 @@ export function ReportBrowser({
   );
   const isAgent = activeRoutine?.source.startsWith("agent:") ?? false;
 
-  // Reports for active source
+  // Reports for active source — poll when a scheduled instance is active
+  const hasScheduledInstance = instances.some(
+    (i) => i.routine_name === activeSource && (i.status === "running" || i.status === "scheduled"),
+  );
   const { data: reportsData, isLoading: loadingReports } = useQuery({
     queryKey: ["routine-reports", activeSource],
     queryFn: () => api.getRoutineReports(activeSource),
     enabled: !!activeSource,
+    refetchInterval: hasScheduledInstance ? 10_000 : false,
   });
   const reports = reportsData?.reports ?? [];
 
@@ -130,22 +134,23 @@ export function ReportBrowser({
     [instances, activeSource],
   );
 
-  // Config state: prefer last-used config from instances, then defaults from routine fields
+  // Config state: merge routine fields with saved localStorage values
   const [configValues, setConfigValues] = useState<Record<string, unknown>>({});
 
   useEffect(() => {
-    const lastInstance = instances.find((i) => i.routine_name === activeSource);
-    if (lastInstance && Object.keys(lastInstance.config || {}).length > 0) {
-      setConfigValues({ ...lastInstance.config });
-    } else if (activeRoutine) {
-      const defaults: Record<string, unknown> = {};
-      for (const [key, field] of Object.entries(activeRoutine.fields)) {
-        defaults[key] = field.default;
-      }
-      setConfigValues(defaults);
+    if (!activeRoutine) return;
+    let saved: Record<string, unknown> | null = null;
+    try {
+      const raw = localStorage.getItem(`routine_config:${activeSource}`);
+      saved = raw ? JSON.parse(raw) : null;
+    } catch { /* ignore */ }
+    const values: Record<string, unknown> = {};
+    for (const [key, field] of Object.entries(activeRoutine.fields)) {
+      values[key] = saved && key in saved ? saved[key] : field.default;
     }
+    setConfigValues(values);
     setShowConfigPanel(false);
-  }, [activeSource, activeRoutine, instances]);
+  }, [activeSource, activeRoutine]);
 
   // Track running instance to poll for completion
   const [pollingInstanceId, setPollingInstanceId] = useState<string | null>(null);
@@ -215,12 +220,14 @@ export function ReportBrowser({
     for (let i = 0; i < toRun.length; i++) {
       setRunAllProgress({ current: i + 1, total: toRun.length });
       const routine = toRun[i];
-      const defaults: Record<string, unknown> = {};
+      let saved: Record<string, unknown> | null = null;
+      try { const raw = localStorage.getItem(`routine_config:${routine.name}`); saved = raw ? JSON.parse(raw) : null; } catch { /* ignore */ }
+      const cfg: Record<string, unknown> = {};
       for (const [key, field] of Object.entries(routine.fields)) {
-        defaults[key] = field.default;
+        cfg[key] = saved && key in saved ? saved[key] : field.default;
       }
       try {
-        await api.runRoutine(server, routine.name, defaults);
+        await api.runRoutine(server, routine.name, cfg);
       } catch {
         // continue with remaining routines
       }
@@ -698,7 +705,13 @@ export function ReportBrowser({
               <RoutineConfigForm
                 fields={activeRoutine.fields}
                 values={configValues}
-                onChange={(key, value) => setConfigValues((prev) => ({ ...prev, [key]: value }))}
+                onChange={(key, value) => {
+                  setConfigValues((prev) => {
+                    const next = { ...prev, [key]: value };
+                    try { localStorage.setItem(`routine_config:${activeSource}`, JSON.stringify(next)); } catch { /* ignore */ }
+                    return next;
+                  });
+                }}
               />
             ) : (
               <p className="text-xs text-[var(--color-text-muted)]">No configurable fields</p>

--- a/frontend/src/components/routines/RoutineConfigForm.tsx
+++ b/frontend/src/components/routines/RoutineConfigForm.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { ChevronDown } from "lucide-react";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import type { RoutineFieldInfo } from "@/lib/api";
 import { api } from "@/lib/api";
@@ -33,9 +33,9 @@ function SelectField({
 
   // Auto-select first option when options load and no value is set
   useEffect(() => {
-    if (options.length > 0 && (!value || value === "")) {
-      onChange(options[0]);
-    }
+    if (options.length === 0) return;
+    if (value && value !== "" && options.includes(String(value))) return;
+    onChange(options[0]);
   }, [options, value, onChange]);
 
   return (
@@ -57,6 +57,38 @@ function SelectField({
       </select>
       <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[var(--color-text-muted)]" />
     </div>
+  );
+}
+
+function NumberField({
+  fieldType,
+  value,
+  onChange,
+}: {
+  fieldType: string;
+  value: unknown;
+  onChange: (v: number) => void;
+}) {
+  const [draft, setDraft] = useState(String(value ?? ""));
+
+  // Sync from parent when value changes externally
+  useEffect(() => {
+    setDraft(String(value ?? ""));
+  }, [value]);
+
+  return (
+    <input
+      type="number"
+      step={fieldType === "float" ? "any" : "1"}
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={() => {
+        const v = fieldType === "int" ? parseInt(draft) : parseFloat(draft);
+        if (!isNaN(v)) onChange(v);
+        else setDraft(String(value ?? ""));
+      }}
+      className="w-full rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)] focus:border-[var(--color-primary)] focus:outline-none"
+    />
   );
 }
 
@@ -87,15 +119,10 @@ export function RoutineConfigForm({ fields, values, onChange }: Props) {
               {values[key] ? "ON" : "OFF"}
             </button>
           ) : field.type === "int" || field.type === "float" ? (
-            <input
-              type="number"
-              step={field.type === "float" ? "any" : "1"}
-              value={String(values[key] ?? field.default ?? "")}
-              onChange={(e) => {
-                const v = field.type === "int" ? parseInt(e.target.value) : parseFloat(e.target.value);
-                if (!isNaN(v)) onChange(key, v);
-              }}
-              className="w-full rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)] focus:border-[var(--color-primary)] focus:outline-none"
+            <NumberField
+              fieldType={field.type}
+              value={values[key] ?? field.default ?? ""}
+              onChange={(v) => onChange(key, v)}
             />
           ) : (
             <input

--- a/frontend/src/components/routines/RoutineDetail.tsx
+++ b/frontend/src/components/routines/RoutineDetail.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Brain, ExternalLink, FileText, Loader2, Play } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { type RoutineInfo, type RoutineInstance, api } from "@/lib/api";
 import { useServer } from "@/hooks/useServer";
@@ -10,6 +10,46 @@ import { RoutineInstances } from "./RoutineInstances";
 import { RoutineReports } from "./RoutineReports";
 import { RoutineResultView } from "./RoutineResultView";
 import { ScheduleDropdown } from "./ScheduleDropdown";
+
+// ── Config persistence helpers ──
+
+const STORAGE_KEY_PREFIX = "routine_config:";
+
+function loadSavedConfig(routineName: string): Record<string, unknown> | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY_PREFIX + routineName);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveConfig(routineName: string, values: Record<string, unknown>) {
+  try {
+    localStorage.setItem(STORAGE_KEY_PREFIX + routineName, JSON.stringify(values));
+  } catch {
+    // storage full or unavailable — ignore
+  }
+}
+
+/**
+ * Build config values for a routine:
+ * 1. Start from the routine's Python Config fields (source of truth for which keys exist)
+ * 2. For each field, check localStorage for a saved value
+ * 3. If saved value exists for a field that still exists, use it; otherwise use the default
+ */
+function buildConfigValues(routine: RoutineInfo): Record<string, unknown> {
+  const saved = loadSavedConfig(routine.name);
+  const values: Record<string, unknown> = {};
+  for (const [key, field] of Object.entries(routine.fields)) {
+    if (saved && key in saved) {
+      values[key] = saved[key];
+    } else {
+      values[key] = field.default;
+    }
+  }
+  return values;
+}
 
 interface RoutineDetailProps {
   routine: RoutineInfo;
@@ -21,20 +61,30 @@ export function RoutineDetail({ routine, instances, onOpenReport }: RoutineDetai
   const { server } = useServer();
   const qc = useQueryClient();
 
-  const [configValues, setConfigValues] = useState<Record<string, unknown>>({});
+  const [configValues, setConfigValues] = useState<Record<string, unknown>>(() =>
+    buildConfigValues(routine),
+  );
   const [activeInstanceId, setActiveInstanceId] = useState<string | null>(null);
   const isPolling = useRef(false);
 
-  // Reset config when routine changes
+  // Rebuild config when routine changes — merge saved values with current fields
   useEffect(() => {
-    const defaults: Record<string, unknown> = {};
-    for (const [key, field] of Object.entries(routine.fields)) {
-      defaults[key] = field.default;
-    }
-    setConfigValues(defaults);
+    setConfigValues(buildConfigValues(routine));
     setActiveInstanceId(null);
     isPolling.current = false;
   }, [routine.name]);
+
+  // Persist config to localStorage whenever it changes
+  const handleConfigChange = useCallback(
+    (key: string, value: unknown) => {
+      setConfigValues((prev) => {
+        const next = { ...prev, [key]: value };
+        saveConfig(routine.name, next);
+        return next;
+      });
+    },
+    [routine.name],
+  );
 
   // Poll active instance
   const { data: activeInstance } = useQuery({
@@ -116,7 +166,7 @@ export function RoutineDetail({ routine, instances, onOpenReport }: RoutineDetai
           <RoutineConfigForm
             fields={routine.fields}
             values={configValues}
-            onChange={(key, value) => setConfigValues((prev) => ({ ...prev, [key]: value }))}
+            onChange={handleConfigChange}
           />
         </div>
       )}

--- a/frontend/src/components/routines/RoutineDetail.tsx
+++ b/frontend/src/components/routines/RoutineDetail.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Brain, ExternalLink, FileText, Loader2, Play } from "lucide-react";
+import { AlertTriangle, Brain, ExternalLink, FileText, Loader2, Play } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { type RoutineInfo, type RoutineInstance, api } from "@/lib/api";
@@ -158,13 +158,27 @@ export function RoutineDetail({ routine, instances, onOpenReport }: RoutineDetai
         </div>
       )}
 
-      {/* Result - show link to report instead of raw text */}
-      {activeInstance && activeInstance.status !== "running" && (activeInstance.result_text || activeInstance.has_result) && (
+      {/* Result - show error or link to report */}
+      {activeInstance && activeInstance.status !== "running" && (activeInstance.result_text || activeInstance.has_result || activeInstance.error) && (
         <div>
           <h3 className="mb-2 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
             Last Result
           </h3>
-          {onOpenReport ? (
+          {activeInstance.status === "failed" || activeInstance.error ? (
+            <div className="rounded-lg border border-[var(--color-red)]/30 bg-[var(--color-red)]/5 px-4 py-3">
+              <div className="flex items-start gap-2">
+                <AlertTriangle className="h-4 w-4 text-[var(--color-red)] shrink-0 mt-0.5" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-xs font-medium text-[var(--color-red)]">
+                    Routine failed
+                  </p>
+                  <pre className="mt-1.5 text-[11px] text-[var(--color-text-muted)] whitespace-pre-wrap break-words font-mono">
+                    {activeInstance.error || activeInstance.result_text}
+                  </pre>
+                </div>
+              </div>
+            </div>
+          ) : onOpenReport ? (
             <button
               onClick={() => onOpenReport(routine.name)}
               className="flex items-center gap-2 rounded-lg border border-[var(--color-primary)]/30 bg-[var(--color-primary)]/5 px-4 py-3 text-left transition-all hover:border-[var(--color-primary)]/50 hover:bg-[var(--color-primary)]/10 w-full"

--- a/frontend/src/components/routines/RoutineDetail.tsx
+++ b/frontend/src/components/routines/RoutineDetail.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, Brain, ExternalLink, FileText, Loader2, Play } from "luc
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { type RoutineInfo, type RoutineInstance, api } from "@/lib/api";
+import { buildConfigValues, formatRoutineName, invalidateRoutineQueries, saveConfig } from "@/lib/routineUtils";
 import { useServer } from "@/hooks/useServer";
 
 import { RoutineConfigForm } from "./RoutineConfigForm";
@@ -10,46 +11,6 @@ import { RoutineInstances } from "./RoutineInstances";
 import { RoutineReports } from "./RoutineReports";
 import { RoutineResultView } from "./RoutineResultView";
 import { ScheduleDropdown } from "./ScheduleDropdown";
-
-// ── Config persistence helpers ──
-
-const STORAGE_KEY_PREFIX = "routine_config:";
-
-function loadSavedConfig(routineName: string): Record<string, unknown> | null {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY_PREFIX + routineName);
-    return raw ? JSON.parse(raw) : null;
-  } catch {
-    return null;
-  }
-}
-
-function saveConfig(routineName: string, values: Record<string, unknown>) {
-  try {
-    localStorage.setItem(STORAGE_KEY_PREFIX + routineName, JSON.stringify(values));
-  } catch {
-    // storage full or unavailable — ignore
-  }
-}
-
-/**
- * Build config values for a routine:
- * 1. Start from the routine's Python Config fields (source of truth for which keys exist)
- * 2. For each field, check localStorage for a saved value
- * 3. If saved value exists for a field that still exists, use it; otherwise use the default
- */
-function buildConfigValues(routine: RoutineInfo): Record<string, unknown> {
-  const saved = loadSavedConfig(routine.name);
-  const values: Record<string, unknown> = {};
-  for (const [key, field] of Object.entries(routine.fields)) {
-    if (saved && key in saved) {
-      values[key] = saved[key];
-    } else {
-      values[key] = field.default;
-    }
-  }
-  return values;
-}
 
 interface RoutineDetailProps {
   routine: RoutineInfo;
@@ -103,8 +64,7 @@ export function RoutineDetail({ routine, instances, onOpenReport }: RoutineDetai
     const status = activeInstance?.status;
     if (prevStatus.current === "running" && status && status !== "running") {
       isPolling.current = false;
-      qc.invalidateQueries({ queryKey: ["routine-instances"] });
-      qc.invalidateQueries({ queryKey: ["routine-reports", routine.name] });
+      invalidateRoutineQueries(qc, routine.name);
     }
     prevStatus.current = status;
   }, [activeInstance?.status, qc, routine.name]);
@@ -114,7 +74,7 @@ export function RoutineDetail({ routine, instances, onOpenReport }: RoutineDetai
     onSuccess: (data) => {
       isPolling.current = true;
       setActiveInstanceId(data.instance_id);
-      qc.invalidateQueries({ queryKey: ["routine-instances"] });
+      invalidateRoutineQueries(qc, routine.name);
     },
   });
 
@@ -122,14 +82,14 @@ export function RoutineDetail({ routine, instances, onOpenReport }: RoutineDetai
     mutationFn: (intervalSec: number) =>
       api.scheduleRoutine(server!, routine.name, configValues, intervalSec),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["routine-instances"] });
+      invalidateRoutineQueries(qc, routine.name);
     },
   });
 
   const stopMutation = useMutation({
     mutationFn: (id: string) => api.stopRoutineInstance(id),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["routine-instances"] });
+      invalidateRoutineQueries(qc, routine.name);
     },
   });
 
@@ -143,7 +103,7 @@ export function RoutineDetail({ routine, instances, onOpenReport }: RoutineDetai
       <div>
         <div className="flex items-center gap-2">
           <h2 className="text-lg font-semibold text-[var(--color-text)]">
-            {formatName(routine.name)}
+            {formatRoutineName(routine.name)}
           </h2>
           {isAgent && (
             <span className="flex items-center gap-1 rounded bg-purple-500/10 px-2 py-0.5 text-[10px] font-bold text-purple-400">
@@ -228,24 +188,24 @@ export function RoutineDetail({ routine, instances, onOpenReport }: RoutineDetai
                 </div>
               </div>
             </div>
-          ) : onOpenReport ? (
-            <button
-              onClick={() => onOpenReport(routine.name)}
-              className="flex items-center gap-2 rounded-lg border border-[var(--color-primary)]/30 bg-[var(--color-primary)]/5 px-4 py-3 text-left transition-all hover:border-[var(--color-primary)]/50 hover:bg-[var(--color-primary)]/10 w-full"
-            >
-              <FileText className="h-5 w-5 text-[var(--color-primary)] shrink-0" />
-              <div className="flex-1 min-w-0">
-                <p className="text-xs font-medium text-[var(--color-text)]">
-                  Report generated successfully
-                </p>
-                <p className="text-[10px] text-[var(--color-text-muted)] mt-0.5 truncate">
-                  {activeInstance.result_text?.split("\n")[0] || "Click to view the full report"}
-                </p>
-              </div>
-              <ExternalLink className="h-4 w-4 text-[var(--color-primary)] shrink-0" />
-            </button>
           ) : (
-            <RoutineResultView instance={activeInstance} />
+            <>
+              <RoutineResultView instance={activeInstance} />
+              {onOpenReport && routine.report_count > 0 && (
+                <button
+                  onClick={() => onOpenReport(routine.name)}
+                  className="flex items-center gap-2 rounded-lg border border-[var(--color-primary)]/30 bg-[var(--color-primary)]/5 px-4 py-3 text-left transition-all hover:border-[var(--color-primary)]/50 hover:bg-[var(--color-primary)]/10 w-full mt-2"
+                >
+                  <FileText className="h-5 w-5 text-[var(--color-primary)] shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-xs font-medium text-[var(--color-text)]">
+                      View reports
+                    </p>
+                  </div>
+                  <ExternalLink className="h-4 w-4 text-[var(--color-primary)] shrink-0" />
+                </button>
+              )}
+            </>
           )}
         </div>
       )}
@@ -258,12 +218,11 @@ export function RoutineDetail({ routine, instances, onOpenReport }: RoutineDetai
       />
 
       {/* Reports section */}
-      <RoutineReports routineName={routine.name} />
+      <RoutineReports
+        routineName={routine.name}
+        hasScheduledInstance={selectedInstances.some(i => i.status === "running" || i.status === "scheduled")}
+      />
     </div>
   );
 }
 
-function formatName(name: string): string {
-  const display = name.includes("/") ? name.split("/")[1] : name;
-  return display.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-}

--- a/frontend/src/components/routines/RoutineInstances.tsx
+++ b/frontend/src/components/routines/RoutineInstances.tsx
@@ -62,9 +62,11 @@ function InstanceCard({
             className={`rounded px-1.5 py-0.5 text-[10px] font-bold uppercase ${
               inst.status === "running" || inst.status === "scheduled"
                 ? "bg-emerald-500/10 text-emerald-400"
-                : inst.status === "completed"
-                  ? "bg-blue-500/10 text-blue-400"
-                  : "bg-[var(--color-surface-hover)] text-[var(--color-text-muted)]"
+                : inst.status === "failed"
+                  ? "bg-red-500/10 text-red-400"
+                  : inst.status === "completed"
+                    ? "bg-blue-500/10 text-blue-400"
+                    : "bg-[var(--color-surface-hover)] text-[var(--color-text-muted)]"
             }`}
           >
             {inst.status}

--- a/frontend/src/components/routines/RoutineInstances.tsx
+++ b/frontend/src/components/routines/RoutineInstances.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronRight, Clock, Trash2 } from "lucide-react";
+import { AlertTriangle, ChevronDown, ChevronRight, Clock, Trash2 } from "lucide-react";
 import { useState } from "react";
 
 import { type RoutineInstance } from "@/lib/api";
@@ -107,6 +107,16 @@ function InstanceCard({
           </button>
         </div>
       </div>
+      {inst.error && (
+        <div className="border-t border-[var(--color-red)]/20 px-3 py-2">
+          <div className="flex items-start gap-1.5">
+            <AlertTriangle className="h-3 w-3 text-[var(--color-red)] shrink-0 mt-0.5" />
+            <pre className="text-[10px] text-[var(--color-red)]/80 whitespace-pre-wrap break-words font-mono leading-relaxed">
+              {inst.error}
+            </pre>
+          </div>
+        </div>
+      )}
       {showConfig && configEntries.length > 0 && (
         <div className="border-t border-[var(--color-border)]/50 px-3 py-2">
           <div className="grid grid-cols-2 gap-x-4 gap-y-1">

--- a/frontend/src/components/routines/RoutineInstances.tsx
+++ b/frontend/src/components/routines/RoutineInstances.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronRight, Clock, Square } from "lucide-react";
+import { ChevronDown, ChevronRight, Clock, Trash2 } from "lucide-react";
 import { useState } from "react";
 
 import { type RoutineInstance } from "@/lib/api";
@@ -103,7 +103,7 @@ function InstanceCard({
             className="rounded p-1 text-[var(--color-red)] hover:bg-[var(--color-red)]/10"
             title="Stop"
           >
-            <Square className="h-3.5 w-3.5" />
+            <Trash2 className="h-3.5 w-3.5" />
           </button>
         </div>
       </div>

--- a/frontend/src/components/routines/RoutineReports.tsx
+++ b/frontend/src/components/routines/RoutineReports.tsx
@@ -5,20 +5,14 @@ import { useSearchParams } from "react-router-dom";
 
 import { ReportViewer } from "@/components/routines/ReportViewer";
 import { type ReportSummary, api } from "@/lib/api";
+import { formatAgo } from "@/lib/routineUtils";
 
 interface RoutineReportsProps {
   routineName: string;
+  hasScheduledInstance?: boolean;
 }
 
-function formatAgo(iso: string): string {
-  const diff = (Date.now() - new Date(iso).getTime()) / 1000;
-  if (diff < 60) return `${Math.floor(diff)}s ago`;
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
-  return `${Math.floor(diff / 86400)}d ago`;
-}
-
-export function RoutineReports({ routineName }: RoutineReportsProps) {
+export function RoutineReports({ routineName, hasScheduledInstance }: RoutineReportsProps) {
   const [viewReport, setViewReport] = useState<ReportSummary | null>(null);
   const [, setSearchParams] = useSearchParams();
 
@@ -26,6 +20,7 @@ export function RoutineReports({ routineName }: RoutineReportsProps) {
     queryKey: ["routine-reports", routineName],
     queryFn: () => api.getRoutineReports(routineName),
     enabled: !!routineName,
+    refetchInterval: hasScheduledInstance ? 10_000 : false,
   });
 
   const reports = data?.reports ?? [];

--- a/frontend/src/components/routines/RoutineReports.tsx
+++ b/frontend/src/components/routines/RoutineReports.tsx
@@ -84,14 +84,6 @@ export function RoutineReports({ routineName }: RoutineReportsProps) {
               <span className="text-[10px] text-[var(--color-text-muted)]">
                 {formatAgo(r.created_at)}
               </span>
-              {r.tags.slice(0, 2).map((tag) => (
-                <span
-                  key={tag}
-                  className="rounded bg-[var(--color-surface-hover)] px-1 py-0.5 text-[9px] text-[var(--color-text-muted)]"
-                >
-                  #{tag}
-                </span>
-              ))}
             </div>
           </button>
         ))}

--- a/frontend/src/components/routines/ScheduleDropdown.tsx
+++ b/frontend/src/components/routines/ScheduleDropdown.tsx
@@ -2,12 +2,12 @@ import { ChevronDown } from "lucide-react";
 import { useState } from "react";
 
 const PRESETS = [
-  { label: "30s", sec: 30 },
   { label: "1m", sec: 60 },
   { label: "5m", sec: 300 },
   { label: "15m", sec: 900 },
   { label: "30m", sec: 1800 },
   { label: "1h", sec: 3600 },
+  { label: "6h", sec: 21600 },
 ];
 
 interface Props {

--- a/frontend/src/components/settings/GatewaySettings.tsx
+++ b/frontend/src/components/settings/GatewaySettings.tsx
@@ -440,9 +440,12 @@ export function GatewaySettings() {
                 <Loader2 className="h-3 w-3 animate-spin" /> Loading logs...
               </div>
             ) : (
-              <pre className="max-h-64 overflow-auto rounded bg-[var(--color-bg)] p-3 text-xs text-[var(--color-text-muted)] font-mono leading-relaxed">
+              <pre className="max-h-64 overflow-auto rounded bg-[var(--color-bg)] p-3 text-xs text-[var(--color-text-muted)] font-mono leading-relaxed whitespace-pre-wrap break-all">
                 {typeof logsData?.logs === "string"
-                  ? logsData.logs || "No logs available"
+                  ? (logsData.logs || "No logs available")
+                      .split("\n")
+                      .map((line) => line.replace(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s*/, ""))
+                      .join("\n")
                   : JSON.stringify(logsData?.logs, null, 2) || "No logs available"}
               </pre>
             )}

--- a/frontend/src/components/trade/TradeBottomPane.tsx
+++ b/frontend/src/components/trade/TradeBottomPane.tsx
@@ -357,7 +357,7 @@ export function TradeBottomPane({
   const totalVolume = executors.reduce((sum, e) => sum + (e.volume || 0), 0);
 
   type SortCol = "status" | "pnl" | "pnl_pct" | "volume" | "age";
-  const [sortCol, setSortCol] = useState<SortCol>("status");
+  const [sortCol, setSortCol] = useState<SortCol>("age");
   const [sortAsc, setSortAsc] = useState(false);
 
   const handleSortClick = useCallback((col: SortCol) => {
@@ -372,13 +372,13 @@ export function TradeBottomPane({
     const arr = [...executors];
     const dir = sortAsc ? 1 : -1;
     arr.sort((a, b) => {
+      // Always pin active executors to the top
+      const aActive = isExecutorActive(a.status) ? 1 : 0;
+      const bActive = isExecutorActive(b.status) ? 1 : 0;
+      if (aActive !== bActive) return bActive - aActive;
+
       switch (sortCol) {
-        case "status": {
-          const aActive = isExecutorActive(a.status) ? 1 : 0;
-          const bActive = isExecutorActive(b.status) ? 1 : 0;
-          if (aActive !== bActive) return (bActive - aActive) * dir;
-          return (b.timestamp - a.timestamp) * dir;
-        }
+        case "status": return (b.timestamp - a.timestamp) * dir;
         case "pnl": return (a.pnl - b.pnl) * dir;
         case "pnl_pct": return ((a.net_pnl_pct || 0) - (b.net_pnl_pct || 0)) * dir;
         case "volume": return (a.volume - b.volume) * dir;

--- a/frontend/src/components/trade/TradeBottomPane.tsx
+++ b/frontend/src/components/trade/TradeBottomPane.tsx
@@ -12,7 +12,7 @@ import {
   formatUsd,
   pnlColor,
   isExecutorActive,
-} from "@/pages/Executors";
+} from "@/lib/formatters";
 
 interface TradeBottomPaneProps {
   executors: ExecutorInfo[];

--- a/frontend/src/components/trade/TradeBottomPane.tsx
+++ b/frontend/src/components/trade/TradeBottomPane.tsx
@@ -1,13 +1,12 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronUp, ChevronDown, Loader2, Square, Trash2, Wallet, Clock } from "lucide-react";
+import { ChevronUp, ChevronDown, Loader2, Square, Trash2, Wallet, Clock, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
 
 import { api, type ExecutorInfo, type ConsolidatedPosition } from "@/lib/api";
 import { useServer } from "@/hooks/useServer";
+import { useRates } from "@/hooks/useRates";
 import {
-  formatPnl,
   formatPct,
-  formatVolume,
   formatAge,
   formatUsd,
   pnlColor,
@@ -188,6 +187,35 @@ function ExecutorTooltip({
   );
 }
 
+function SortTh<T extends string>({
+  col, current, asc, onClick, align, children,
+}: {
+  col: T; current: T; asc: boolean; onClick: (col: T) => void;
+  align?: "right"; children: React.ReactNode;
+}) {
+  const active = current === col;
+  return (
+    <th
+      className={`px-3 py-1.5 font-medium cursor-pointer select-none hover:text-[var(--color-text)] transition-colors ${align === "right" ? "text-right" : ""}`}
+      onClick={() => onClick(col)}
+    >
+      <span className="inline-flex items-center gap-0.5">
+        {align === "right" && (
+          active
+            ? (asc ? <ArrowUp className="h-2.5 w-2.5" /> : <ArrowDown className="h-2.5 w-2.5" />)
+            : <ArrowUpDown className="h-2.5 w-2.5 opacity-30" />
+        )}
+        {children}
+        {align !== "right" && (
+          active
+            ? (asc ? <ArrowUp className="h-2.5 w-2.5" /> : <ArrowDown className="h-2.5 w-2.5" />)
+            : <ArrowUpDown className="h-2.5 w-2.5 opacity-30" />
+        )}
+      </span>
+    </th>
+  );
+}
+
 export function TradeBottomPane({
   executors,
   positions,
@@ -303,11 +331,49 @@ export function TradeBottomPane({
     setHoveredExecutor(null);
   }, []);
 
+  // Currency conversion for the current pair's quote asset
+  const quoteCurrency = pair.split("-")[1] || "USDT";
+  const { formatPnlValue, formatValue } = useRates([quoteCurrency]);
+
+  const fmtPnl = (val: number) => formatPnlValue(val, quoteCurrency);
+  const fmtVol = (val: number) => formatValue(val, quoteCurrency);
+
   const activeExecutors = executors.filter((e) => isExecutorActive(e.status));
   const totalPnl = executors.reduce((sum, e) => sum + (e.pnl || 0), 0);
   const totalVolume = executors.reduce((sum, e) => sum + (e.volume || 0), 0);
 
-  const sortedExecutors = [...executors].sort((a, b) => b.timestamp - a.timestamp);
+  type SortCol = "status" | "pnl" | "pnl_pct" | "volume" | "age";
+  const [sortCol, setSortCol] = useState<SortCol>("status");
+  const [sortAsc, setSortAsc] = useState(false);
+
+  const handleSortClick = useCallback((col: SortCol) => {
+    setSortCol((prev) => {
+      if (prev === col) { setSortAsc((a) => !a); return col; }
+      setSortAsc(false);
+      return col;
+    });
+  }, []);
+
+  const sortedExecutors = useMemo(() => {
+    const arr = [...executors];
+    const dir = sortAsc ? 1 : -1;
+    arr.sort((a, b) => {
+      switch (sortCol) {
+        case "status": {
+          const aActive = isExecutorActive(a.status) ? 1 : 0;
+          const bActive = isExecutorActive(b.status) ? 1 : 0;
+          if (aActive !== bActive) return (bActive - aActive) * dir;
+          return (b.timestamp - a.timestamp) * dir;
+        }
+        case "pnl": return (a.pnl - b.pnl) * dir;
+        case "pnl_pct": return ((a.net_pnl_pct || 0) - (b.net_pnl_pct || 0)) * dir;
+        case "volume": return (a.volume - b.volume) * dir;
+        case "age": return (a.timestamp - b.timestamp) * dir;
+        default: return (b.timestamp - a.timestamp) * dir;
+      }
+    });
+    return arr;
+  }, [executors, sortCol, sortAsc]);
 
   return (
     <div ref={containerRef} className="border-t border-[var(--color-border)] bg-[var(--color-surface)] h-full flex flex-col relative">
@@ -329,9 +395,9 @@ export function TradeBottomPane({
             <>
               <span className="text-[var(--color-border)]">|</span>
               <span style={{ color: pnlColor(totalPnl) }} className="font-mono font-medium">
-                {formatPnl(totalPnl)}
+                {fmtPnl(totalPnl)}
               </span>
-              <span className="font-mono">{formatVolume(totalVolume)} vol</span>
+              <span className="font-mono">{fmtVol(totalVolume)} vol</span>
             </>
           )}
         </div>
@@ -394,19 +460,20 @@ export function TradeBottomPane({
                     <th className="px-3 py-1.5 font-medium">ID</th>
                     <th className="px-3 py-1.5 font-medium">Type</th>
                     <th className="px-3 py-1.5 font-medium">Side</th>
+                    <SortTh col="status" current={sortCol} asc={sortAsc} onClick={handleSortClick}>Status</SortTh>
                     <th className="px-3 py-1.5 font-medium text-right">Entry</th>
                     <th className="px-3 py-1.5 font-medium text-right">Price</th>
-                    <th className="px-3 py-1.5 font-medium text-right">PnL</th>
-                    <th className="px-3 py-1.5 font-medium text-right">PnL%</th>
-                    <th className="px-3 py-1.5 font-medium text-right">Volume</th>
-                    <th className="px-3 py-1.5 font-medium text-right">Age</th>
+                    <SortTh col="pnl" current={sortCol} asc={sortAsc} onClick={handleSortClick} align="right">PnL</SortTh>
+                    <SortTh col="pnl_pct" current={sortCol} asc={sortAsc} onClick={handleSortClick} align="right">PnL%</SortTh>
+                    <SortTh col="volume" current={sortCol} asc={sortAsc} onClick={handleSortClick} align="right">Volume</SortTh>
+                    <SortTh col="age" current={sortCol} asc={sortAsc} onClick={handleSortClick} align="right">Age</SortTh>
                     <th className="w-8" />
                   </tr>
                 </thead>
                 <tbody>
                   {sortedExecutors.length === 0 ? (
                     <tr>
-                      <td colSpan={10} className="px-3 py-3 text-center text-[var(--color-text-muted)]">
+                      <td colSpan={11} className="px-3 py-3 text-center text-[var(--color-text-muted)]">
                         No executors for this pair
                       </td>
                     </tr>
@@ -416,17 +483,20 @@ export function TradeBottomPane({
                       const stopping = stoppingIds.has(ex.id);
                       const side = ex.side?.toUpperCase();
                       const isBuy = side === "BUY" || side === "1";
-                      const borderColor = ex.pnl >= 0 ? "var(--color-green)" : "var(--color-red)";
+                      const borderColor = active ? "var(--color-primary)" : ex.pnl >= 0 ? "var(--color-green)" : "var(--color-red)";
                       const isSelected = selectedExecutorId === ex.id;
                       const entry = getEntryPrice(ex);
                       const exit = getExitPrice(ex);
+                      const closeLabel = ex.close_type ? ex.close_type.replace(/_/g, " ") : "";
                       return (
                         <tr
                           key={ex.id}
                           className={`border-b border-[var(--color-border)]/30 transition-colors ${
                             isSelected
                               ? "bg-[var(--color-primary)]/10 hover:bg-[var(--color-primary)]/15"
-                              : "hover:bg-[var(--color-surface-hover)]/50"
+                              : active
+                                ? "bg-[var(--color-green)]/5 hover:bg-[var(--color-green)]/10"
+                                : "hover:bg-[var(--color-surface-hover)]/50"
                           } ${onExecutorSelect ? "cursor-pointer" : ""}`}
                           style={{
                             borderLeft: isSelected
@@ -453,6 +523,18 @@ export function TradeBottomPane({
                               {side}
                             </span>
                           </td>
+                          <td className="px-3 py-1.5">
+                            {active ? (
+                              <span className="inline-flex items-center gap-1 rounded-full bg-[var(--color-green)]/15 px-1.5 py-0.5 text-[9px] font-bold text-[var(--color-green)]">
+                                <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-green)] animate-pulse" />
+                                ACTIVE
+                              </span>
+                            ) : (
+                              <span className="rounded px-1.5 py-0.5 text-[9px] font-medium bg-[var(--color-text-muted)]/10 text-[var(--color-text-muted)] capitalize">
+                                {closeLabel || ex.status}
+                              </span>
+                            )}
+                          </td>
                           <td className="px-3 py-1.5 text-right font-mono tabular-nums text-[var(--color-text-muted)]">
                             {entry > 0 ? formatPrice(entry) : "—"}
                           </td>
@@ -463,7 +545,7 @@ export function TradeBottomPane({
                             className="px-3 py-1.5 text-right font-mono font-medium tabular-nums"
                             style={{ color: pnlColor(ex.pnl) }}
                           >
-                            {formatPnl(ex.pnl)}
+                            {fmtPnl(ex.pnl)}
                           </td>
                           <td
                             className="px-3 py-1.5 text-right font-mono tabular-nums"
@@ -472,7 +554,7 @@ export function TradeBottomPane({
                             {formatPct(ex.net_pnl_pct)}
                           </td>
                           <td className="px-3 py-1.5 text-right font-mono tabular-nums text-[var(--color-text-muted)]">
-                            {formatVolume(ex.volume)}
+                            {fmtVol(ex.volume)}
                           </td>
                           <td className="px-3 py-1.5 text-right text-[var(--color-text-muted)]">
                             <span className="inline-flex items-center gap-1">
@@ -551,7 +633,7 @@ export function TradeBottomPane({
                               <span className="text-[10px] text-[var(--color-text-muted)]">{pos.leverage}x</span>
                             )}
                             <span className={`font-mono font-medium ${pos.unrealized_pnl >= 0 ? "text-[var(--color-green)]" : "text-[var(--color-red)]"}`}>
-                              {formatPnl(pos.unrealized_pnl)}
+                              {fmtPnl(pos.unrealized_pnl)}
                             </span>
                             <button
                               onClick={() => setConfirmClearPos(pos)}
@@ -570,7 +652,7 @@ export function TradeBottomPane({
                         <div className="mt-1 flex items-center gap-3 text-[10px] text-[var(--color-text-muted)]">
                           <span>
                             Realized: <span className={`font-mono ${pos.realized_pnl >= 0 ? "text-[var(--color-green)]" : "text-[var(--color-red)]"}`}>
-                              {formatPnl(pos.realized_pnl)}
+                              {fmtPnl(pos.realized_pnl)}
                             </span>
                           </span>
                           <span>

--- a/frontend/src/components/trade/TradeBottomPane.tsx
+++ b/frontend/src/components/trade/TradeBottomPane.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { createPortal } from "react-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ChevronUp, ChevronDown, Loader2, Square, Trash2, Wallet, Clock, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
 
@@ -72,11 +73,9 @@ function getExitPrice(ex: ExecutorInfo): number {
 function ExecutorTooltip({
   executor,
   anchorRect,
-  containerRect,
 }: {
   executor: ExecutorInfo;
   anchorRect: DOMRect;
-  containerRect: DOMRect;
 }) {
   const entry = getEntryPrice(executor);
   const exit = getExitPrice(executor);
@@ -84,11 +83,13 @@ function ExecutorTooltip({
 
   const active = isExecutorActive(executor.status);
 
-  // Position tooltip above the row, centered
-  const top = anchorRect.top - containerRect.top - 8;
+  // Position tooltip using viewport-fixed coords (rendered via portal)
+  const tooltipHeight = 180; // approximate max height
+  // If tooltip would go above viewport top, flip it below the row
+  const flipBelow = anchorRect.top - tooltipHeight < 0;
   const left = Math.min(
-    Math.max(anchorRect.left - containerRect.left + anchorRect.width / 2 - 120, 8),
-    containerRect.width - 260,
+    Math.max(anchorRect.left + anchorRect.width / 2 - 120, 8),
+    window.innerWidth - 260,
   );
 
   const slPct = Number(config.stop_loss);
@@ -96,10 +97,14 @@ function ExecutorTooltip({
   const leverage = Number(config.leverage);
   const amount = Number(config.total_amount_quote) || Number(config.amount);
 
-  return (
+  return createPortal(
     <div
-      className="absolute z-50 pointer-events-none"
-      style={{ top, left, transform: "translateY(-100%)" }}
+      className="fixed z-[9999] pointer-events-none"
+      style={{
+        top: flipBelow ? anchorRect.bottom + 8 : anchorRect.top - 8,
+        left,
+        transform: flipBelow ? undefined : "translateY(-100%)",
+      }}
     >
       <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)]/95 backdrop-blur-sm shadow-xl p-3 w-[250px] text-[11px]">
         {/* Header */}
@@ -179,11 +184,19 @@ function ExecutorTooltip({
         </div>
 
         {/* Arrow */}
-        <div className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-full">
-          <div className="w-0 h-0 border-l-[6px] border-r-[6px] border-t-[6px] border-l-transparent border-r-transparent border-t-[var(--color-border)]" />
-        </div>
+        {!flipBelow && (
+          <div className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-full">
+            <div className="w-0 h-0 border-l-[6px] border-r-[6px] border-t-[6px] border-l-transparent border-r-transparent border-t-[var(--color-border)]" />
+          </div>
+        )}
+        {flipBelow && (
+          <div className="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-full">
+            <div className="w-0 h-0 border-l-[6px] border-r-[6px] border-b-[6px] border-l-transparent border-r-transparent border-b-[var(--color-border)]" />
+          </div>
+        )}
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 
@@ -333,7 +346,8 @@ export function TradeBottomPane({
 
   // Currency conversion for the current pair's quote asset
   const quoteCurrency = pair.split("-")[1] || "USDT";
-  const { formatPnlValue, formatValue } = useRates([quoteCurrency]);
+  const quoteCurrencies = useMemo(() => [quoteCurrency], [quoteCurrency]);
+  const { formatPnlValue, formatValue } = useRates(quoteCurrencies);
 
   const fmtPnl = (val: number) => formatPnlValue(val, quoteCurrency);
   const fmtVol = (val: number) => formatValue(val, quoteCurrency);
@@ -673,11 +687,10 @@ export function TradeBottomPane({
       )}
 
       {/* Hover tooltip */}
-      {hoveredExecutor && containerRef.current && (
+      {hoveredExecutor && (
         <ExecutorTooltip
           executor={hoveredExecutor.executor}
           anchorRect={hoveredExecutor.rect}
-          containerRect={containerRef.current.getBoundingClientRect()}
         />
       )}
 

--- a/frontend/src/hooks/useChatSocket.ts
+++ b/frontend/src/hooks/useChatSocket.ts
@@ -31,7 +31,7 @@ export interface ChatSlot {
 
 let msgIdCounter = 0;
 function nextMsgId(): string {
-  return `msg_${++msgIdCounter}`;
+  return `msg_${Date.now()}_${++msgIdCounter}`;
 }
 
 // ── localStorage persistence for chat messages ──

--- a/frontend/src/hooks/useChatSocket.ts
+++ b/frontend/src/hooks/useChatSocket.ts
@@ -21,6 +21,7 @@ export interface SlotInfo {
   agent_key: string;
   mode: string;
   is_busy?: boolean;
+  server_name?: string;
 }
 
 export interface ChatSlot {
@@ -31,6 +32,37 @@ export interface ChatSlot {
 let msgIdCounter = 0;
 function nextMsgId(): string {
   return `msg_${++msgIdCounter}`;
+}
+
+// ── localStorage persistence for chat messages ──
+const STORAGE_KEY = "condor_chat_messages";
+
+function saveSlotMessages(slots: ChatSlot[]) {
+  try {
+    const data: Record<string, ChatMessage[]> = {};
+    for (const s of slots) {
+      if (s.messages.length > 0) {
+        data[s.info.slot_id] = s.messages;
+      }
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch { /* quota exceeded or private mode */ }
+}
+
+function loadSlotMessages(): Record<string, ChatMessage[]> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch { /* corrupted */ }
+  return {};
+}
+
+function clearStoredSlot(slotId: string) {
+  try {
+    const data = loadSlotMessages();
+    delete data[slotId];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch { /* ignore */ }
 }
 
 export function useChatSocket() {
@@ -104,12 +136,15 @@ export function useChatSocket() {
         case "sessions_list": {
           const sessions = data.sessions as SlotInfo[];
           if (sessions.length > 0) {
+            const stored = loadSlotMessages();
             setSlots((prev) => {
-              // Merge: keep existing messages for known slots, add new ones
+              // Merge: keep existing messages for known slots, restore from localStorage, or start empty
               const existing = new Map(prev.map((s) => [s.info.slot_id, s]));
               const merged = sessions.map((info) => {
                 const ex = existing.get(info.slot_id);
-                return ex ? { ...ex, info } : { info, messages: [] };
+                if (ex) return { ...ex, info };
+                const restored = stored[info.slot_id];
+                return { info, messages: restored || [] };
               });
               return merged;
             });
@@ -126,6 +161,7 @@ export function useChatSocket() {
             slot_id: data.slot_id as string,
             agent_key: data.agent_key as string,
             mode: data.mode as string,
+            server_name: (data.server_name as string) || undefined,
           };
           setSlots((prev) => [...prev, { info: newSlot, messages: [] }]);
           setActiveSlotId(newSlot.slot_id);
@@ -134,6 +170,7 @@ export function useChatSocket() {
 
         case "session_destroyed": {
           const destroyedId = data.slot_id as string;
+          clearStoredSlot(destroyedId);
           setSlots((prev) => prev.filter((s) => s.info.slot_id !== destroyedId));
           setActiveSlotId((prev) => {
             if (prev === destroyedId) return null;
@@ -334,8 +371,8 @@ export function useChatSocket() {
   );
 
   const startSession = useCallback(
-    (agentKey: string, mode: string) => {
-      send({ action: "start_session", agent_key: agentKey, mode });
+    (agentKey: string, mode: string, serverName?: string) => {
+      send({ action: "start_session", agent_key: agentKey, mode, server_name: serverName });
     },
     [send],
   );
@@ -343,7 +380,15 @@ export function useChatSocket() {
   const destroySession = useCallback(
     (slotId: string) => {
       currentAssistantMsg.current[slotId] = null;
+      clearStoredSlot(slotId);
       send({ action: "destroy_session", slot_id: slotId });
+    },
+    [send],
+  );
+
+  const abortPrompt = useCallback(
+    (slotId: string) => {
+      send({ action: "abort_prompt", slot_id: slotId });
     },
     [send],
   );
@@ -363,6 +408,11 @@ export function useChatSocket() {
     };
   }, []);
 
+  // Persist messages to localStorage on every change
+  useEffect(() => {
+    saveSlotMessages(slots);
+  }, [slots]);
+
   const activeSlot = slots.find((s) => s.info.slot_id === activeSlotId) || null;
   const isStreaming = streamingSlotId !== null;
 
@@ -380,6 +430,7 @@ export function useChatSocket() {
     sendMessage,
     startSession,
     destroySession,
+    abortPrompt,
     resolvePermission,
   };
 }

--- a/frontend/src/hooks/useChatSocket.ts
+++ b/frontend/src/hooks/useChatSocket.ts
@@ -274,9 +274,32 @@ export function useChatSocket() {
           setStreamingSlotId(null);
           break;
 
-        case "error":
+        case "error": {
+          const errSlotId = slotId || null;
+          // Reset current assistant message so next response creates a new bubble
+          if (errSlotId) {
+            currentAssistantMsg.current[errSlotId] = null;
+          }
+          // Show error as a system message in the chat
+          const errMsg = (data.message as string) || "Unknown error";
+          if (errSlotId) {
+            setSlots((prev) =>
+              prev.map((s) => {
+                if (s.info.slot_id !== errSlotId) return s;
+                const id = nextMsgId();
+                return {
+                  ...s,
+                  messages: [
+                    ...s.messages,
+                    { id, role: "assistant" as const, text: `⚠️ ${errMsg}`, toolCalls: [] },
+                  ],
+                };
+              }),
+            );
+          }
           setStreamingSlotId(null);
           break;
+        }
 
         case "heartbeat":
           break;

--- a/frontend/src/hooks/useChatSocket.ts
+++ b/frontend/src/hooks/useChatSocket.ts
@@ -306,6 +306,29 @@ export function useChatSocket() {
 
         case "prompt_done":
           if (slotId) {
+            // Mark any in-flight tool calls as completed so the spinner stops
+            setSlots((prev) =>
+              prev.map((s) => {
+                if (s.info.slot_id !== slotId) return s;
+                const curId = currentAssistantMsg.current[slotId];
+                if (!curId) return s;
+                return {
+                  ...s,
+                  messages: s.messages.map((m) =>
+                    m.id === curId && m.toolCalls.some((tc) => tc.status !== "completed" && tc.status !== "failed")
+                      ? {
+                          ...m,
+                          toolCalls: m.toolCalls.map((tc) =>
+                            tc.status === "completed" || tc.status === "failed"
+                              ? tc
+                              : { ...tc, status: "completed" },
+                          ),
+                        }
+                      : m,
+                  ),
+                };
+              }),
+            );
             currentAssistantMsg.current[slotId] = null;
           }
           setStreamingSlotId(null);
@@ -389,6 +412,31 @@ export function useChatSocket() {
   const abortPrompt = useCallback(
     (slotId: string) => {
       send({ action: "abort_prompt", slot_id: slotId });
+      // Immediately reset streaming state so the UI doesn't get stuck
+      // if the backend's prompt_done event is lost or delayed
+      setStreamingSlotId(null);
+      currentAssistantMsg.current[slotId] = null;
+      // Mark any in-flight tool calls as completed
+      setSlots((prev) =>
+        prev.map((s) => {
+          if (s.info.slot_id !== slotId) return s;
+          return {
+            ...s,
+            messages: s.messages.map((m) =>
+              m.toolCalls.some((tc) => tc.status !== "completed" && tc.status !== "failed")
+                ? {
+                    ...m,
+                    toolCalls: m.toolCalls.map((tc) =>
+                      tc.status === "completed" || tc.status === "failed"
+                        ? tc
+                        : { ...tc, status: "completed" },
+                    ),
+                  }
+                : m,
+            ),
+          };
+        }),
+      );
     },
     [send],
   );

--- a/frontend/src/hooks/useChatSocket.ts
+++ b/frontend/src/hooks/useChatSocket.ts
@@ -75,6 +75,9 @@ export function useChatSocket() {
   const [isConnected, setIsConnected] = useState(false);
   const [slots, setSlots] = useState<ChatSlot[]>([]);
   const [activeSlotId, setActiveSlotId] = useState<string | null>(null);
+  // Track whether we've received the initial sessions_list from the backend.
+  // Prevents the empty initial slots from overwriting localStorage.
+  const hydrated = useRef(false);
   const [streamingSlotId, setStreamingSlotId] = useState<string | null>(null);
   const [permissionRequest, setPermissionRequest] = useState<{
     request_id: string;
@@ -135,6 +138,7 @@ export function useChatSocket() {
       switch (event) {
         case "sessions_list": {
           const sessions = data.sessions as SlotInfo[];
+          hydrated.current = true;
           if (sessions.length > 0) {
             const stored = loadSlotMessages();
             setSlots((prev) => {
@@ -456,9 +460,12 @@ export function useChatSocket() {
     };
   }, []);
 
-  // Persist messages to localStorage on every change
+  // Persist messages to localStorage on every change (but only after initial hydration
+  // to avoid the empty initial state wiping saved messages before WS reconnects)
   useEffect(() => {
-    saveSlotMessages(slots);
+    if (hydrated.current) {
+      saveSlotMessages(slots);
+    }
   }, [slots]);
 
   const activeSlot = slots.find((s) => s.info.slot_id === activeSlotId) || null;

--- a/frontend/src/hooks/useDisplayCurrency.ts
+++ b/frontend/src/hooks/useDisplayCurrency.ts
@@ -1,0 +1,53 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+export type DisplayCurrency = "USDT" | "USD" | "USDC" | "BTC" | "ETH" | "BRL" | "EUR";
+
+export const CURRENCY_OPTIONS: DisplayCurrency[] = ["USDT", "USD", "USDC", "BTC", "ETH", "BRL", "EUR"];
+
+export const CURRENCY_SYMBOLS: Record<DisplayCurrency, string> = {
+  USDT: "$",
+  USD: "$",
+  USDC: "$",
+  BTC: "\u20BF",
+  ETH: "\u039E",
+  BRL: "R$",
+  EUR: "\u20AC",
+};
+
+const STORAGE_KEY = "condor_display_currency";
+
+function getStoredCurrency(): DisplayCurrency {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored && CURRENCY_OPTIONS.includes(stored as DisplayCurrency)) {
+    return stored as DisplayCurrency;
+  }
+  return "USDT";
+}
+
+let currentCurrency: DisplayCurrency = getStoredCurrency();
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot(): DisplayCurrency {
+  return currentCurrency;
+}
+
+export function useDisplayCurrency() {
+  const currency = useSyncExternalStore(subscribe, getSnapshot);
+
+  const setCurrency = useCallback((c: DisplayCurrency) => {
+    currentCurrency = c;
+    localStorage.setItem(STORAGE_KEY, c);
+    listeners.forEach((l) => l());
+  }, []);
+
+  return {
+    currency,
+    setCurrency,
+    currencySymbol: CURRENCY_SYMBOLS[currency],
+  };
+}

--- a/frontend/src/hooks/useDisplayCurrency.ts
+++ b/frontend/src/hooks/useDisplayCurrency.ts
@@ -1,15 +1,12 @@
 import { useCallback, useSyncExternalStore } from "react";
 
-export type DisplayCurrency = "USDT" | "USD" | "USDC" | "BTC" | "ETH" | "BRL" | "EUR";
+export type DisplayCurrency = "USDT" | "BTC" | "BRL" | "EUR";
 
-export const CURRENCY_OPTIONS: DisplayCurrency[] = ["USDT", "USD", "USDC", "BTC", "ETH", "BRL", "EUR"];
+export const CURRENCY_OPTIONS: DisplayCurrency[] = ["USDT", "BTC", "BRL", "EUR"];
 
 export const CURRENCY_SYMBOLS: Record<DisplayCurrency, string> = {
   USDT: "$",
-  USD: "$",
-  USDC: "$",
   BTC: "\u20BF",
-  ETH: "\u039E",
   BRL: "R$",
   EUR: "\u20AC",
 };

--- a/frontend/src/hooks/useMainControllerData.ts
+++ b/frontend/src/hooks/useMainControllerData.ts
@@ -16,24 +16,20 @@ export function useMainControllerData(
   connector: string,
   pair: string,
 ) {
-  // Fetch executors via REST on mount (survives refresh), WS updates keep it fresh
+  // Fetch executors filtered server-side by controller_id + trading_pair
   const { data: cachedExecutors } = useQuery<ExecutorInfo[]>({
-    queryKey: ["executors", server, ""],
-    queryFn: () => api.getExecutors(server!),
-    enabled: !!server,
+    queryKey: ["executors", server, "main", pair],
+    queryFn: () => api.getExecutors(server!, { controller_id: "main", trading_pair: pair }),
+    enabled: !!server && !!pair,
     staleTime: 30_000, // REST fetch valid for 30s, WS pushes override instantly
     refetchOnWindowFocus: false,
   });
 
+  // connector is not a server-side filter — filter client-side (lightweight)
   const filteredExecutors = useMemo(() => {
     if (!cachedExecutors) return [];
-    return cachedExecutors.filter(
-      (ex) =>
-        ex.controller_id === "main" &&
-        ex.connector === connector &&
-        ex.trading_pair === pair,
-    );
-  }, [cachedExecutors, connector, pair]);
+    return cachedExecutors.filter((ex) => ex.connector === connector);
+  }, [cachedExecutors, connector]);
 
   // Stable reference: only update when executor data actually changes
   const prevFingerprintRef = useRef("");

--- a/frontend/src/hooks/useMainControllerData.ts
+++ b/frontend/src/hooks/useMainControllerData.ts
@@ -68,7 +68,8 @@ export function useMainControllerData(
     ];
     return all.filter(
       (p) =>
-        p.controller_id === "main" &&
+        // Show positions from main controller or untagged (executor-level positions)
+        (!p.controller_id || p.controller_id === "main") &&
         p.connector_name === connector &&
         p.trading_pair === pair,
     );

--- a/frontend/src/hooks/useRates.ts
+++ b/frontend/src/hooks/useRates.ts
@@ -32,7 +32,7 @@ export function useRates(quoteCurrencies: string[]) {
   }, [quoteCurrencies, currency]);
 
   const { data: rates, isLoading } = useQuery({
-    queryKey: ["rates", server, currency, needed],
+    queryKey: ["rates", server, currency, needed.join(",")],
     queryFn: async () => {
       const results: Record<string, number | null> = {};
       // Stablecoin-to-stablecoin: use 1:1 rate (no API call needed)

--- a/frontend/src/hooks/useRates.ts
+++ b/frontend/src/hooks/useRates.ts
@@ -1,0 +1,109 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import { api } from "@/lib/api";
+import { formatCurrency, formatCurrencyPnl, formatCurrencyVolume } from "@/lib/formatters";
+import { useDisplayCurrency, CURRENCY_SYMBOLS, type DisplayCurrency } from "./useDisplayCurrency";
+import { useServer } from "./useServer";
+
+// USD-pegged stablecoins — treat conversions between these as 1:1
+const STABLECOINS = new Set(["USDT", "USDC", "FDUSD", "BUSD", "DAI", "TUSD", "USD"]);
+
+export function useRates(quoteCurrencies: string[]) {
+  const { currency, currencySymbol } = useDisplayCurrency();
+  const { server } = useServer();
+
+  // Dedupe and filter out currencies that match the display currency
+  // Also skip stablecoin-to-stablecoin pairs (rate is ~1.0)
+  const { needed, stablePairs } = useMemo(() => {
+    const set = new Set<string>();
+    const stable: string[] = [];
+    const isCurrencyStable = STABLECOINS.has(currency);
+    for (const q of quoteCurrencies) {
+      const norm = q.toUpperCase();
+      if (norm === currency) continue;
+      if (isCurrencyStable && STABLECOINS.has(norm)) {
+        stable.push(norm);
+      } else {
+        set.add(norm);
+      }
+    }
+    return { needed: Array.from(set).sort(), stablePairs: stable };
+  }, [quoteCurrencies, currency]);
+
+  const { data: rates, isLoading } = useQuery({
+    queryKey: ["rates", server, currency, needed],
+    queryFn: async () => {
+      const results: Record<string, number | null> = {};
+      // Stablecoin-to-stablecoin: use 1:1 rate (no API call needed)
+      for (const q of stablePairs) {
+        results[q] = 1.0;
+      }
+      if (needed.length > 0) {
+        const pairs = needed.map((quote) => `${currency}-${quote}`);
+        try {
+          const resp = await api.getRateOracleRates(server!, pairs);
+          const rateMap = resp.rates ?? {};
+          for (const quote of needed) {
+            const pair = `${currency}-${quote}`;
+            const rate = rateMap[pair];
+            results[quote] = rate != null ? rate : null;
+          }
+        } catch {
+          for (const quote of needed) {
+            results[quote] = null;
+          }
+        }
+      }
+      return results;
+    },
+    enabled: !!server && (needed.length > 0 || stablePairs.length > 0),
+    staleTime: 60_000,
+    refetchInterval: 60_000,
+  });
+
+  const convert = useMemo(() => {
+    return (value: number, quoteCurrency: string): { value: number; converted: boolean } => {
+      const norm = quoteCurrency.toUpperCase();
+      if (norm === currency) return { value, converted: true };
+      const rate = rates?.[norm];
+      if (rate != null && rate > 0) return { value: value / rate, converted: true };
+      return { value, converted: false };
+    };
+  }, [rates, currency]);
+
+  const formatValue = useMemo(() => {
+    return (val: number, quoteCurrency: string): string => {
+      const { value, converted } = convert(val, quoteCurrency);
+      const sym = converted ? currencySymbol : CURRENCY_SYMBOLS[quoteCurrency.toUpperCase() as DisplayCurrency] || "$";
+      return formatCurrencyVolume(value, sym) + (converted ? "" : " \u26A0");
+    };
+  }, [convert, currencySymbol]);
+
+  const formatPnlValue = useMemo(() => {
+    return (val: number, quoteCurrency: string): string => {
+      const { value, converted } = convert(val, quoteCurrency);
+      const sym = converted ? currencySymbol : CURRENCY_SYMBOLS[quoteCurrency.toUpperCase() as DisplayCurrency] || "$";
+      return formatCurrencyPnl(value, sym) + (converted ? "" : " \u26A0");
+    };
+  }, [convert, currencySymbol]);
+
+  const formatValueDetailed = useMemo(() => {
+    return (val: number, quoteCurrency: string): string => {
+      const { value, converted } = convert(val, quoteCurrency);
+      const sym = converted ? currencySymbol : CURRENCY_SYMBOLS[quoteCurrency.toUpperCase() as DisplayCurrency] || "$";
+      return formatCurrency(value, sym) + (converted ? "" : " \u26A0");
+    };
+  }, [convert, currencySymbol]);
+
+  return {
+    rates: rates ?? {},
+    convert,
+    formatValue,
+    formatPnlValue,
+    formatValueDetailed,
+    isLoading,
+    currency,
+    currencySymbol,
+  };
+}

--- a/frontend/src/hooks/useRates.ts
+++ b/frontend/src/hooks/useRates.ts
@@ -60,6 +60,7 @@ export function useRates(quoteCurrencies: string[]) {
     enabled: !!server && (needed.length > 0 || stablePairs.length > 0),
     staleTime: 60_000,
     refetchInterval: 60_000,
+    placeholderData: (prev: Record<string, number | null> | undefined) => prev,
   });
 
   const convert = useMemo(() => {

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,7 +1,8 @@
 import { useCallback, useSyncExternalStore } from "react";
 
-export type Theme = "dark" | "light";
+export type Theme = "dark" | "light" | "colorblind";
 
+const THEMES: Theme[] = ["dark", "light", "colorblind"];
 const STORAGE_KEY = "condor_theme";
 
 function getSystemTheme(): Theme {
@@ -9,8 +10,8 @@ function getSystemTheme(): Theme {
 }
 
 function getStoredTheme(): Theme {
-  const stored = localStorage.getItem(STORAGE_KEY);
-  if (stored === "dark" || stored === "light") return stored;
+  const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+  if (stored && THEMES.includes(stored)) return stored;
   return getSystemTheme();
 }
 
@@ -45,7 +46,8 @@ export function useTheme() {
   }, []);
 
   const toggleTheme = useCallback(() => {
-    setTheme(currentTheme === "dark" ? "light" : "dark");
+    const idx = THEMES.indexOf(currentTheme);
+    setTheme(THEMES[(idx + 1) % THEMES.length]);
   }, [setTheme]);
 
   return { theme, setTheme, toggleTheme };

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -96,6 +96,24 @@ export function useCondorWebSocket(
         });
       } else if (prefix === "executors") {
         queryClient.setQueryData(["executors", server, ""], data);
+        // Also update any filtered executor queries (e.g. ["executors", server, "main", pair])
+        const allExecs = data as { controller_id?: string; trading_pair?: string }[];
+        if (Array.isArray(allExecs)) {
+          const cache = queryClient.getQueryCache().findAll({ queryKey: ["executors", server] });
+          for (const entry of cache) {
+            const key = entry.queryKey as string[];
+            // Skip the unfiltered key (already set above)
+            if (key.length <= 3 && key[2] === "") continue;
+            // key format: ["executors", server, controllerId, pair]
+            if (key.length === 4) {
+              const [, , cid, tp] = key;
+              const filtered = allExecs.filter(
+                (ex) => (!cid || ex.controller_id === cid) && (!tp || ex.trading_pair === tp),
+              );
+              queryClient.setQueryData(key, filtered);
+            }
+          }
+        }
         const execs = data as unknown[];
         if (Array.isArray(execs)) {
           queryClient.setQueryData(

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -2,7 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 
 import { useAuth } from "@/lib/auth";
-import type { BotsPageResponse, ControllerInfo } from "@/lib/api";
+import type { BotsPageResponse, ControllerInfo, ControllerPerformanceHistoryResponse, ControllerPerformanceSnapshot } from "@/lib/api";
 import { candleStore } from "@/lib/candle-store";
 import { CondorWebSocket } from "@/lib/websocket";
 
@@ -129,6 +129,58 @@ export function useCondorWebSocket(
               return { ...old, pages: [nextFirst, ...old.pages.slice(1)] };
             },
           );
+        }
+      } else if (prefix === "controller_perf") {
+        // Update the "all controllers" sparkline cache
+        const incoming = data as { snapshots?: ControllerPerformanceSnapshot[] };
+        if (incoming?.snapshots) {
+          queryClient.setQueryData(
+            ["controller-perf-history-all", server],
+            (old: ControllerPerformanceHistoryResponse | undefined) => {
+              if (!old) return old;
+              // Append new snapshots and deduplicate by controller_id+timestamp
+              const existing = old.snapshots ?? [];
+              const merged = [...existing];
+              const seen = new Set(existing.map((s) => `${s.controller_id}:${s.timestamp}`));
+              for (const snap of incoming.snapshots!) {
+                const key = `${snap.controller_id}:${snap.timestamp}`;
+                if (!seen.has(key)) {
+                  merged.push(snap);
+                  seen.add(key);
+                }
+              }
+              return { ...old, snapshots: merged };
+            },
+          );
+
+          // Also update per-controller history caches
+          const byController = new Map<string, ControllerPerformanceSnapshot[]>();
+          for (const snap of incoming.snapshots) {
+            const cid = snap.controller_id || snap.controller_name;
+            if (!cid) continue;
+            const arr = byController.get(cid) ?? [];
+            arr.push(snap);
+            byController.set(cid, arr);
+          }
+          for (const [cid, snaps] of byController) {
+            queryClient.setQueryData(
+              ["controller-perf-history", server, cid],
+              (old: ControllerPerformanceHistoryResponse | undefined) => {
+                if (!old) return old;
+                const existing = old.snapshots ?? [];
+                const merged = [...existing];
+                const seen = new Set(existing.map((s) => `${s.controller_id}:${s.timestamp}`));
+                for (const snap of snaps) {
+                  const key = `${snap.controller_id}:${snap.timestamp}`;
+                  if (!seen.has(key)) {
+                    merged.push(snap);
+                    seen.add(key);
+                  }
+                }
+                return { ...old, snapshots: merged };
+              },
+            );
+          }
         }
       } else if (prefix === "orderbook") {
         const parts = channel.split(":");

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -67,16 +67,19 @@ export function useCondorWebSocket(
           if (!incoming?.controllers) return old ?? data;
           if (!old?.controllers?.length) return incoming;
 
+          // Key by controller_id (stable) — controller_name may differ between REST and WS
           const oldMap = new Map<string, ControllerInfo>();
           for (const c of old.controllers) {
-            oldMap.set(`${c.bot_name}-${c.controller_name}`, c);
+            const key = `${c.bot_name}-${c.controller_id || c.controller_name}`;
+            oldMap.set(key, c);
           }
           const oldBotMap = new Map(old.bots.map((b) => [b.bot_name, b]));
 
           return {
             ...incoming,
             controllers: incoming.controllers.map((c) => {
-              const prev = oldMap.get(`${c.bot_name}-${c.controller_name}`);
+              const key = `${c.bot_name}-${c.controller_id || c.controller_name}`;
+              const prev = oldMap.get(key);
               if (!prev) return c;
               return {
                 ...c,

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -216,9 +216,14 @@ export function useCondorWebSocket(
   // ── Effect 2: Diff channels — subscribe/unsubscribe without reconnecting ──
   useEffect(() => {
     const ws = wsRef.current;
-    if (!ws) return;
+    if (!ws || !server) return;
 
-    const newSet = new Set(nonCandleChannels(channels));
+    // Bare channel names (e.g. "bots") need server prefix ("bots:local")
+    // to match the backend broadcast channel format.
+    const resolved = nonCandleChannels(channels).map((ch) =>
+      ch.includes(":") ? ch : `${ch}:${server}`,
+    );
+    const newSet = new Set(resolved);
     const oldSet = prevChannelsRef.current;
 
     // Subscribe new channels
@@ -231,7 +236,7 @@ export function useCondorWebSocket(
     }
 
     prevChannelsRef.current = newSet;
-  }, [channels.join(",")]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [channels.join(","), server]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return { wsRef, wsVersion };
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -51,6 +51,31 @@
   color-scheme: light;
 }
 
+/* ── Color-blind Mode: Blue/Orange (deuteranopia/protanopia safe) ── */
+[data-theme="colorblind"] {
+  --color-bg: #0a0e1a;
+  --color-surface: #111729;
+  --color-surface-hover: #1a2138;
+  --color-border: #1e2a45;
+  --color-text: #e8e6e3;
+  --color-text-muted: #7b8ba4;
+  --color-accent: #56b4e9;
+  --color-primary: #56b4e9;
+  --color-primary-hover: #7ec8f0;
+  --color-green: #0072b2;
+  --color-red: #e69f00;
+  --color-yellow: #f0e442;
+
+  /* Chart-specific */
+  --chart-bg: #111729;
+  --chart-grid: #1e2a45;
+  --chart-text: #7b8ba4;
+  --chart-up: #0072b2;
+  --chart-down: #e69f00;
+
+  color-scheme: dark;
+}
+
 body {
   margin: 0;
   background-color: var(--color-bg);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -120,6 +120,52 @@ export interface BotsPageResponse {
   error_hint?: string;
 }
 
+export interface BotRunInfo {
+  bot_name: string;
+  account_name: string;
+  strategy_type: string;
+  strategy_name: string;
+  run_status: string;
+  deployment_status: string;
+  created_at: string | null;
+  stopped_at: string | null;
+  realized_pnl_quote: number;
+  unrealized_pnl_quote: number;
+  global_pnl_quote: number;
+  volume_traded: number;
+  num_controllers: number;
+}
+
+export interface BotRunsResponse {
+  runs: BotRunInfo[];
+  total: number;
+}
+
+export interface ControllerPerformanceSnapshot {
+  timestamp: string;
+  bot_name: string;
+  controller_id: string;
+  controller_name: string;
+  connector: string;
+  trading_pair: string;
+  realized_pnl_quote: number;
+  unrealized_pnl_quote: number;
+  global_pnl_quote: number;
+  global_pnl_pct: number;
+  volume_traded: number;
+  close_type_counts: Record<string, number>;
+  positions_summary: Record<string, unknown>[];
+  custom_info: Record<string, unknown>;
+}
+
+export interface ControllerPerformanceHistoryResponse {
+  snapshots: ControllerPerformanceSnapshot[];
+  next_cursor: string | null;
+  interval: string;
+  server_online?: boolean;
+  error_hint?: string;
+}
+
 export interface ExecutorInfo {
   id: string;
   type: string;
@@ -673,6 +719,59 @@ export const api = {
       `/api/v1/servers/${server}/bots/${encodeURIComponent(botName)}/controllers/start`,
       { method: "POST", body: JSON.stringify({ controller_names: controllerNames }) },
     ),
+
+  getControllerPerformanceHistory: (
+    server: string,
+    params: {
+      bot_name?: string;
+      controller_id?: string;
+      start_time?: string;
+      end_time?: string;
+      interval?: string;
+      limit?: number;
+      cursor?: string;
+    } = {},
+  ) => {
+    const qs = new URLSearchParams();
+    if (params.bot_name) qs.set("bot_name", params.bot_name);
+    if (params.controller_id) qs.set("controller_id", params.controller_id);
+    if (params.start_time) qs.set("start_time", params.start_time);
+    if (params.end_time) qs.set("end_time", params.end_time);
+    if (params.interval) qs.set("interval", params.interval);
+    if (params.limit) qs.set("limit", String(params.limit));
+    if (params.cursor) qs.set("cursor", params.cursor);
+    const q = qs.toString();
+    return apiFetch<ControllerPerformanceHistoryResponse>(
+      `/api/v1/servers/${server}/controller-performance/history${q ? `?${q}` : ""}`,
+    );
+  },
+
+  getBotRuns: (
+    server: string,
+    params: {
+      bot_name?: string;
+      run_status?: string;
+      deployment_status?: string;
+      limit?: number;
+      offset?: number;
+    } = {},
+  ) => {
+    const qs = new URLSearchParams();
+    if (params.bot_name) qs.set("bot_name", params.bot_name);
+    if (params.run_status) qs.set("run_status", params.run_status);
+    if (params.deployment_status) qs.set("deployment_status", params.deployment_status);
+    if (params.limit) qs.set("limit", String(params.limit));
+    if (params.offset) qs.set("offset", String(params.offset));
+    const q = qs.toString();
+    return apiFetch<BotRunsResponse>(
+      `/api/v1/servers/${server}/bot-runs${q ? `?${q}` : ""}`,
+    );
+  },
+
+  deleteBotRun: (server: string, botName: string) =>
+    apiFetch<{ deleted: boolean }>(`/api/v1/servers/${server}/bot-runs/${botName}`, {
+      method: "DELETE",
+    }),
 
   getExecutors: (
     server: string,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -994,6 +994,11 @@ export const api = {
       method: "POST",
     }),
 
+  getRoutineSource: (name: string) =>
+    apiFetch<{ filename: string; source: string }>(
+      `/api/v1/routines/${encodeURIComponent(name)}/source`,
+    ),
+
   getRoutineReports: (name: string) =>
     apiFetch<ReportsListResponse>(
       `/api/v1/routines/${encodeURIComponent(name)}/reports`,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -579,8 +579,10 @@ export const api = {
       `/api/v1/servers/${name}/status`,
     ),
 
-  getPortfolio: (server: string) =>
-    apiFetch<PortfolioResponse>(`/api/v1/servers/${server}/portfolio`),
+  getPortfolio: (server: string, refresh = false) =>
+    apiFetch<PortfolioResponse>(
+      `/api/v1/servers/${server}/portfolio${refresh ? "?refresh=true" : ""}`,
+    ),
 
   getPortfolioHistory: (server: string, range = "1D", breakdown = false) =>
     apiFetch<PortfolioHistoryResponse>(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -422,6 +422,7 @@ export interface RoutineInstance {
   table_data?: Record<string, unknown>[] | null;
   table_columns?: string[] | null;
   sections?: Record<string, unknown>[] | null;
+  error?: string | null;
 }
 
 // ── Archived Bots ──
@@ -748,6 +749,12 @@ export const api = {
   getPrice: (server: string, connector: string, pair: string) =>
     apiFetch<MarketPrice>(
       `/api/v1/servers/${server}/market/prices?connector=${connector}&trading_pair=${pair}`,
+    ),
+
+  getRateOracleRates: (server: string, tradingPairs: string[]) =>
+    apiFetch<{ rates: Record<string, number> }>(
+      `/api/v1/servers/${server}/rate-oracle/rates`,
+      { method: "POST", body: JSON.stringify({ trading_pairs: tradingPairs }) },
     ),
 
   getTradingRules: (server: string, connector: string) =>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -536,6 +536,26 @@ export interface VoiceSettingsResponse {
   available_languages: Record<string, string>;
 }
 
+// ── Chat ──
+
+export interface ChatAgentOption {
+  key: string;
+  label: string;
+}
+
+export interface ChatModeOption {
+  key: string;
+  label: string;
+  description: string;
+}
+
+export interface ChatOptionsResponse {
+  agents: ChatAgentOption[];
+  modes: ChatModeOption[];
+  default_agent: string;
+  default_mode: string;
+}
+
 // ── Backtesting ──
 
 export interface BacktestTask {
@@ -1080,4 +1100,9 @@ export const api = {
       method: "PUT",
       body: JSON.stringify(data),
     }),
+
+  // ── Chat ──
+
+  getChatOptions: () =>
+    apiFetch<ChatOptionsResponse>("/api/v1/chat/options"),
 };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -657,6 +657,12 @@ export const api = {
       body: JSON.stringify(data),
     }),
 
+  updateBotControllerConfig: (server: string, botName: string, configId: string, data: Record<string, unknown>) =>
+    apiFetch<{ updated: boolean }>(`/api/v1/servers/${server}/bots/${encodeURIComponent(botName)}/controllers/${encodeURIComponent(configId)}/config`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
+
   updateConfigYaml: (server: string, configId: string, yamlContent: string) =>
     apiFetch<{ updated: boolean }>(`/api/v1/servers/${server}/controllers/configs/${configId}`, {
       method: "PUT",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -122,6 +122,7 @@ export interface BotsPageResponse {
 
 export interface BotRunInfo {
   bot_name: string;
+  bot_run_id: number | null;
   account_name: string;
   strategy_type: string;
   strategy_name: string;
@@ -774,8 +775,8 @@ export const api = {
     );
   },
 
-  deleteBotRun: (server: string, botName: string) =>
-    apiFetch<{ deleted: boolean }>(`/api/v1/servers/${server}/bot-runs/${botName}`, {
+  deleteBotRun: (server: string, botRunId: number) =>
+    apiFetch<{ deleted: boolean }>(`/api/v1/servers/${server}/bot-runs/${botRunId}`, {
       method: "DELETE",
     }),
 

--- a/frontend/src/lib/executor-overlays.ts
+++ b/frontend/src/lib/executor-overlays.ts
@@ -1,5 +1,5 @@
 import type { ExecutorInfo } from "./api";
-import { getThemeColors, pnlColor, sideColor } from "./theme-colors";
+import { getThemeColors, pnlHexColor, sideColor } from "./theme-colors";
 
 // ── Overlay Model ──
 
@@ -169,7 +169,7 @@ function computePositionOverlay(executor: ExecutorInfo): ExecutorOverlay {
     lines.push({
       price: closePrice,
       label: "Close",
-      color: pnlColor(pnlPositive ? 1 : -1),
+      color: pnlHexColor(pnlPositive ? 1 : -1),
       style: "dashed",
     });
   }
@@ -184,7 +184,7 @@ function computePositionOverlay(executor: ExecutorInfo): ExecutorOverlay {
       entryPrice: entry,
       exitTime: exitT,
       exitPrice: exitP,
-      color: pnlColor(executor.pnl),
+      color: pnlHexColor(executor.pnl),
     };
   }
 
@@ -259,7 +259,7 @@ function computeGridOverlay(executor: ExecutorInfo): ExecutorOverlay {
       startPrice,
       endPrice,
       limitPrice: limitPrice > 0 ? limitPrice : undefined,
-      color: pnlColor(profitable ? 1 : -1),
+      color: pnlHexColor(profitable ? 1 : -1),
     };
   }
 
@@ -357,7 +357,7 @@ function computeOrderOverlay(executor: ExecutorInfo): ExecutorOverlay {
         price: fillPrice,
         position: side === "buy" ? "aboveBar" : "belowBar",
         shape: side === "buy" ? "arrowDown" : "arrowUp",
-        color: pnlColor(executor.pnl),
+        color: pnlHexColor(executor.pnl),
         text: closeTypeLabel(executor.close_type),
       });
     }
@@ -369,7 +369,7 @@ function computeOrderOverlay(executor: ExecutorInfo): ExecutorOverlay {
         entryPrice: orderPrice,
         exitTime: executor.close_timestamp,
         exitPrice: fillPrice,
-        color: pnlColor(executor.pnl),
+        color: pnlHexColor(executor.pnl),
       };
     }
   }
@@ -415,7 +415,7 @@ function computeGenericOverlay(executor: ExecutorInfo): ExecutorOverlay {
   }
   if (closePrice > 0 && closePrice !== entryPrice) {
     const pnlPositive = side === "buy" ? closePrice > entryPrice : closePrice < entryPrice;
-    lines.push({ price: closePrice, label: "Close", color: pnlColor(pnlPositive ? 1 : -1), style: "dashed" });
+    lines.push({ price: closePrice, label: "Close", color: pnlHexColor(pnlPositive ? 1 : -1), style: "dashed" });
   }
 
   // Segment
@@ -428,7 +428,7 @@ function computeGenericOverlay(executor: ExecutorInfo): ExecutorOverlay {
       entryPrice: entryPrice,
       exitTime: exitT,
       exitPrice: exitP,
-      color: pnlColor(executor.pnl),
+      color: pnlHexColor(executor.pnl),
     };
   }
 
@@ -494,7 +494,7 @@ export function computeExecutorOverlay(executor: ExecutorInfo): ExecutorOverlay 
 
 /** PnL-based color: green for profit, red for loss */
 export function getExecutorColor(_index: number, pnl?: number): string {
-  return pnlColor(pnl ?? 0);
+  return pnlHexColor(pnl ?? 0);
 }
 
 export function computeMultiOverlays(executors: ExecutorInfo[]): ExecutorOverlay[] {

--- a/frontend/src/lib/executor-overlays.ts
+++ b/frontend/src/lib/executor-overlays.ts
@@ -1,4 +1,5 @@
 import type { ExecutorInfo } from "./api";
+import { getThemeColors, pnlColor, sideColor } from "./theme-colors";
 
 // ── Overlay Model ──
 
@@ -81,10 +82,6 @@ function closeTypeLabel(closeType: string): string {
   return ct ? ct.replace(/_/g, " ") : "closed";
 }
 
-function pnlColor(pnl: number): string {
-  return pnl >= 0 ? "#22c55e" : "#ef4444";
-}
-
 function isActiveStatus(status: string): boolean {
   const s = status?.toLowerCase() ?? "";
   return s === "running" || s === "active_position" || s === "active";
@@ -125,7 +122,7 @@ function computePositionOverlay(executor: ExecutorInfo): ExecutorOverlay {
     lines.push({
       price: slPrice,
       label: `SL (${(slPct * 100).toFixed(1)}%)`,
-      color: "#ef4444",
+      color: getThemeColors().red,
       style: "dashed",
     });
   }
@@ -137,7 +134,7 @@ function computePositionOverlay(executor: ExecutorInfo): ExecutorOverlay {
     lines.push({
       price: tpPrice,
       label: `TP (${(tpPct * 100).toFixed(1)}%)`,
-      color: "#22c55e",
+      color: getThemeColors().green,
       style: "dashed",
     });
   }
@@ -172,7 +169,7 @@ function computePositionOverlay(executor: ExecutorInfo): ExecutorOverlay {
     lines.push({
       price: closePrice,
       label: "Close",
-      color: pnlPositive ? "#22c55e" : "#ef4444",
+      color: pnlColor(pnlPositive ? 1 : -1),
       style: "dashed",
     });
   }
@@ -198,7 +195,7 @@ function computePositionOverlay(executor: ExecutorInfo): ExecutorOverlay {
       price: entry,
       position: side === "buy" ? "belowBar" : "aboveBar",
       shape: side === "buy" ? "arrowUp" : "arrowDown",
-      color: side === "buy" ? "#22c55e" : "#ef4444",
+      color: sideColor(side),
       text: side === "buy" ? "BUY" : "SELL",
     });
   }
@@ -262,7 +259,7 @@ function computeGridOverlay(executor: ExecutorInfo): ExecutorOverlay {
       startPrice,
       endPrice,
       limitPrice: limitPrice > 0 ? limitPrice : undefined,
-      color: profitable ? "#22c55e" : "#ef4444",
+      color: pnlColor(profitable ? 1 : -1),
     };
   }
 
@@ -327,14 +324,14 @@ function computeOrderOverlay(executor: ExecutorInfo): ExecutorOverlay {
       entryPrice: orderPrice,
       exitTime: Math.floor(Date.now() / 1000),
       exitPrice: orderPrice,
-      color: side === "buy" ? "#22c55e" : "#ef4444",
+      color: sideColor(side),
     };
 
     if (orderPrice > 0) {
       lines.push({
         price: orderPrice,
         label: descriptiveLabel,
-        color: side === "buy" ? "#22c55e" : "#ef4444",
+        color: sideColor(side),
         style: isChaser ? "dotted" : "solid",
         lineWidth: 2,
       });
@@ -349,7 +346,7 @@ function computeOrderOverlay(executor: ExecutorInfo): ExecutorOverlay {
       price: orderPrice,
       position: side === "buy" ? "belowBar" : "aboveBar",
       shape: side === "buy" ? "arrowUp" : "arrowDown",
-      color: side === "buy" ? "#22c55e" : "#ef4444",
+      color: sideColor(side),
       text: side === "buy" ? "BUY" : "SELL",
     });
 
@@ -418,7 +415,7 @@ function computeGenericOverlay(executor: ExecutorInfo): ExecutorOverlay {
   }
   if (closePrice > 0 && closePrice !== entryPrice) {
     const pnlPositive = side === "buy" ? closePrice > entryPrice : closePrice < entryPrice;
-    lines.push({ price: closePrice, label: "Close", color: pnlPositive ? "#22c55e" : "#ef4444", style: "dashed" });
+    lines.push({ price: closePrice, label: "Close", color: pnlColor(pnlPositive ? 1 : -1), style: "dashed" });
   }
 
   // Segment
@@ -441,7 +438,7 @@ function computeGenericOverlay(executor: ExecutorInfo): ExecutorOverlay {
       price: entryPrice,
       position: side === "buy" ? "belowBar" : "aboveBar",
       shape: side === "buy" ? "arrowUp" : "arrowDown",
-      color: side === "buy" ? "#22c55e" : "#ef4444",
+      color: sideColor(side),
       text: side.toUpperCase(),
     });
   }
@@ -497,7 +494,7 @@ export function computeExecutorOverlay(executor: ExecutorInfo): ExecutorOverlay 
 
 /** PnL-based color: green for profit, red for loss */
 export function getExecutorColor(_index: number, pnl?: number): string {
-  return (pnl ?? 0) >= 0 ? "#22c55e" : "#ef4444";
+  return pnlColor(pnl ?? 0);
 }
 
 export function computeMultiOverlays(executors: ExecutorInfo[]): ExecutorOverlay[] {

--- a/frontend/src/lib/formatters.ts
+++ b/frontend/src/lib/formatters.ts
@@ -10,6 +10,8 @@ export function formatCurrency(val: number, symbol = "$") {
       minimumFractionDigits: 2,
     });
   }
+  // Adaptive precision for small values (e.g. BTC)
+  if (Math.abs(val) < 0.01 && val !== 0) return symbol + val.toPrecision(4);
   return symbol + val.toFixed(2);
 }
 

--- a/frontend/src/lib/formatters.ts
+++ b/frontend/src/lib/formatters.ts
@@ -1,0 +1,76 @@
+// ── Centralized Formatters ──
+
+export function formatCurrency(val: number, symbol = "$") {
+  if (Math.abs(val) >= 1_000_000) return symbol + (val / 1_000_000).toFixed(2) + "M";
+  if (Math.abs(val) >= 10_000) return symbol + (val / 1_000).toFixed(1) + "K";
+  if (symbol === "$") {
+    return val.toLocaleString("en-US", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 2,
+    });
+  }
+  return symbol + val.toFixed(2);
+}
+
+export function formatCurrencyVolume(val: number, symbol = "$") {
+  if (Math.abs(val) >= 1_000_000) return symbol + (val / 1_000_000).toFixed(1) + "M";
+  if (Math.abs(val) >= 1_000) return symbol + (val / 1_000).toFixed(1) + "K";
+  return symbol + val.toFixed(0);
+}
+
+export function formatCurrencyPnl(val: number, symbol = "$") {
+  const prefix = val >= 0 ? "+" : "";
+  return prefix + formatCurrency(val, symbol);
+}
+
+export function pnlColor(val: number) {
+  return val >= 0 ? "var(--color-green)" : "var(--color-red)";
+}
+
+// Backward-compatible aliases (default to $)
+export function formatUsd(val: number) {
+  return formatCurrency(val);
+}
+
+export function formatVolume(val: number) {
+  return formatCurrencyVolume(val);
+}
+
+export function formatPnl(val: number) {
+  return formatCurrencyPnl(val);
+}
+
+export function formatAge(timestamp: number): string {
+  if (!timestamp) return "\u2014";
+  try {
+    const now = Date.now();
+    const diffMs = now - timestamp * 1000;
+    if (diffMs < 0) return "\u2014";
+    const days = Math.floor(diffMs / 86400000);
+    const hours = Math.floor((diffMs % 86400000) / 3600000);
+    if (days > 0) return `${days}d ${hours}h`;
+    const mins = Math.floor((diffMs % 3600000) / 60000);
+    if (hours > 0) return `${hours}h ${mins}m`;
+    if (mins > 0) return `${mins}m`;
+    return "<1m";
+  } catch {
+    return "\u2014";
+  }
+}
+
+export function formatPrice(val: number): string {
+  if (!val) return "\u2014";
+  if (val >= 1000) return val.toLocaleString("en-US", { maximumFractionDigits: 2 });
+  if (val >= 1) return val.toFixed(4);
+  return val.toPrecision(4);
+}
+
+export function formatPct(val: number): string {
+  if (!val) return "\u2014";
+  return (val >= 0 ? "+" : "") + (val * 100).toFixed(2) + "%";
+}
+
+export function isExecutorActive(status: string) {
+  return status === "active" || status === "running";
+}

--- a/frontend/src/lib/formatters.ts
+++ b/frontend/src/lib/formatters.ts
@@ -18,7 +18,7 @@ export function formatCurrency(val: number, symbol = "$") {
 export function formatCurrencyVolume(val: number, symbol = "$") {
   if (Math.abs(val) >= 1_000_000) return symbol + (val / 1_000_000).toFixed(1) + "M";
   if (Math.abs(val) >= 1_000) return symbol + (val / 1_000).toFixed(1) + "K";
-  return symbol + val.toFixed(0);
+  return symbol + val.toFixed(Math.abs(val) < 100 ? 2 : 0);
 }
 
 export function formatCurrencyPnl(val: number, symbol = "$") {

--- a/frontend/src/lib/routineUtils.ts
+++ b/frontend/src/lib/routineUtils.ts
@@ -1,0 +1,75 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { RoutineInfo } from "@/lib/api";
+
+// ── Config persistence ──
+
+export const ROUTINE_CONFIG_KEY_PREFIX = "routine_config:";
+
+export function loadSavedConfig(
+  routineName: string,
+): Record<string, unknown> | null {
+  try {
+    const raw = localStorage.getItem(ROUTINE_CONFIG_KEY_PREFIX + routineName);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveConfig(
+  routineName: string,
+  values: Record<string, unknown>,
+): void {
+  try {
+    localStorage.setItem(
+      ROUTINE_CONFIG_KEY_PREFIX + routineName,
+      JSON.stringify(values),
+    );
+  } catch {
+    // storage full or unavailable
+  }
+}
+
+export function buildConfigValues(
+  routine: RoutineInfo,
+): Record<string, unknown> {
+  const saved = loadSavedConfig(routine.name);
+  const values: Record<string, unknown> = {};
+  for (const [key, field] of Object.entries(routine.fields)) {
+    if (saved && key in saved) {
+      values[key] = saved[key];
+    } else {
+      values[key] = field.default;
+    }
+  }
+  return values;
+}
+
+// ── Formatters ──
+
+export function formatRoutineName(name: string): string {
+  const display = name.includes("/") ? name.split("/").pop()! : name;
+  return display.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function formatAgo(iso: string): string {
+  const diff = (Date.now() - new Date(iso).getTime()) / 1000;
+  if (diff < 60) return `${Math.floor(diff)}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+// ── Query invalidation ──
+
+export function invalidateRoutineQueries(
+  qc: QueryClient,
+  routineName?: string,
+): void {
+  qc.invalidateQueries({ queryKey: ["routine-instances"] });
+  qc.invalidateQueries({ queryKey: ["reports-grouped"] });
+  qc.invalidateQueries({ queryKey: ["routines"] });
+  if (routineName) {
+    qc.invalidateQueries({ queryKey: ["routine-reports", routineName] });
+  }
+}

--- a/frontend/src/lib/theme-colors.ts
+++ b/frontend/src/lib/theme-colors.ts
@@ -1,0 +1,23 @@
+/** Read chart colors from CSS variables (respects dark/light/colorblind theme). */
+export function getThemeColors() {
+  const style = getComputedStyle(document.documentElement);
+  return {
+    up: style.getPropertyValue("--chart-up").trim() || "#22c55e",
+    down: style.getPropertyValue("--chart-down").trim() || "#ef4444",
+    green: style.getPropertyValue("--color-green").trim() || "#22c55e",
+    red: style.getPropertyValue("--color-red").trim() || "#ef4444",
+    yellow: style.getPropertyValue("--color-yellow").trim() || "#eab308",
+  };
+}
+
+/** Return the up or down color based on a numeric value. */
+export function pnlColor(value: number): string {
+  const { up, down } = getThemeColors();
+  return value >= 0 ? up : down;
+}
+
+/** Return the up or down color based on buy/sell side. */
+export function sideColor(side: string): string {
+  const { up, down } = getThemeColors();
+  return side === "buy" ? up : down;
+}

--- a/frontend/src/lib/theme-colors.ts
+++ b/frontend/src/lib/theme-colors.ts
@@ -10,8 +10,8 @@ export function getThemeColors() {
   };
 }
 
-/** Return the up or down color based on a numeric value. */
-export function pnlColor(value: number): string {
+/** Return the up or down hex color based on a numeric value (for canvas/charts). */
+export function pnlHexColor(value: number): string {
   const { up, down } = getThemeColors();
   return value >= 0 ? up : down;
 }

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -1,5 +1,5 @@
-import { useQuery } from "@tanstack/react-query";
-import { ArrowLeft, FileText, ScrollText, X, Zap } from "lucide-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft, FileText, ScrollText, Trash2, X, Zap } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 
@@ -23,10 +23,20 @@ export function AgentDetail() {
   const navigate = useNavigate();
   const location = useLocation();
 
+  const queryClient = useQueryClient();
   const [reviewerSessionNum, setReviewerSessionNum] = useState<number | null>(null);
   const [reviewerKind, setReviewerKind] = useState<"session" | "experiment">("session");
   const [showStrategyModal, setShowStrategyModal] = useState(false);
   const [showRoutinesBrowser, setShowRoutinesBrowser] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const deleteMutation = useMutation({
+    mutationFn: () => api.deleteAgent(slug!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agents"] });
+      navigate("/agents");
+    },
+  });
 
   // Check location.state for agent-switching (SessionReviewer up/down nav)
   useEffect(() => {
@@ -164,6 +174,15 @@ export function AgentDetail() {
               <ScrollText className="h-3.5 w-3.5" />
               <span className="hidden sm:inline">Routines</span>
             </button>
+            <button
+              onClick={() => setShowDeleteConfirm(true)}
+              disabled={agent.status === "running"}
+              className="flex items-center gap-1.5 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-1.5 text-xs font-semibold text-red-400 transition-all hover:bg-red-500/20 disabled:cursor-not-allowed disabled:opacity-30"
+              title={agent.status === "running" ? "Stop agent before deleting" : "Delete agent"}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">Delete</span>
+            </button>
             <AgentControls
               slug={slug!}
               status={agent.status}
@@ -289,6 +308,39 @@ export function AgentDetail() {
           instances={routineInstances}
           onClose={() => setShowRoutinesBrowser(false)}
         />
+      )}
+
+      {/* Delete Confirmation Dialog */}
+      {showDeleteConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={() => setShowDeleteConfirm(false)}>
+          <div
+            className="w-full max-w-sm rounded-xl border border-[var(--color-border)] bg-[var(--color-bg)] p-6 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="mb-2 text-lg font-semibold text-[var(--color-text)]">Delete Agent</h2>
+            <p className="mb-6 text-sm text-[var(--color-text-muted)]">
+              Delete <strong className="text-[var(--color-text)]">{agent.name}</strong>? This cannot be undone.
+            </p>
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={() => setShowDeleteConfirm(false)}
+                className="rounded-lg px-4 py-2 text-sm text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => deleteMutation.mutate()}
+                disabled={deleteMutation.isPending}
+                className="rounded-lg bg-red-500 px-4 py-2 text-sm font-medium text-white transition-opacity hover:bg-red-600 disabled:opacity-40"
+              >
+                {deleteMutation.isPending ? "Deleting..." : "Delete"}
+              </button>
+            </div>
+            {deleteMutation.isError && (
+              <p className="mt-3 text-xs text-red-400">Failed to delete agent. It may be running.</p>
+            )}
+          </div>
+        </div>
       )}
 
       {/* Session Reviewer Overlay */}

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -5,6 +5,7 @@ import {
   CircleDot,
   Pause,
   Plus,
+  Trash2,
   Zap,
 } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -29,7 +30,7 @@ function StatusBadge({ status }: { status: string }) {
   );
 }
 
-function AgentCard({ agent, onClick }: { agent: AgentSummary; onClick: () => void }) {
+function AgentCard({ agent, onClick, onDelete }: { agent: AgentSummary; onClick: () => void; onDelete: () => void }) {
   const totalPnl = agent.total_pnl ?? 0;
   const totalPnlColor = totalPnl >= 0 ? "text-[var(--color-green)]" : "text-[var(--color-red)]";
   const dayPnl = agent.daily_pnl ?? 0;
@@ -57,7 +58,22 @@ function AgentCard({ agent, onClick }: { agent: AgentSummary; onClick: () => voi
               <h3 className="text-sm font-semibold text-[var(--color-text)]">{agent.name}</h3>
             </div>
           </div>
-          <StatusBadge status={agent.status} />
+          <div className="flex items-center gap-2">
+            <StatusBadge status={agent.status} />
+            {!isLive && (
+              <div
+                className="opacity-0 transition-opacity group-hover:opacity-100"
+                onClick={(e) => { e.stopPropagation(); onDelete(); }}
+                onKeyDown={(e) => { if (e.key === "Enter") { e.stopPropagation(); onDelete(); } }}
+                role="button"
+                tabIndex={0}
+              >
+                <span className="flex h-7 w-7 items-center justify-center rounded-md border border-red-500/30 bg-red-500/10 text-red-400 transition-colors hover:bg-red-500/20">
+                  <Trash2 className="h-3.5 w-3.5" />
+                </span>
+              </div>
+            )}
+          </div>
         </div>
 
         {agent.description && (
@@ -273,9 +289,61 @@ function ActiveSessionsTable({ sessions }: { sessions: ActiveSession[] }) {
   );
 }
 
+function DeleteAgentDialog({
+  agent,
+  onClose,
+}: {
+  agent: AgentSummary | null;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const deleteMutation = useMutation({
+    mutationFn: () => api.deleteAgent(agent!.slug),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agents"] });
+      onClose();
+    },
+  });
+
+  if (!agent) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={onClose}>
+      <div
+        className="w-full max-w-sm rounded-xl border border-[var(--color-border)] bg-[var(--color-bg)] p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="mb-2 text-lg font-semibold text-[var(--color-text)]">Delete Agent</h2>
+        <p className="mb-6 text-sm text-[var(--color-text-muted)]">
+          Delete <strong className="text-[var(--color-text)]">{agent.name}</strong>? This cannot be undone.
+        </p>
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            className="rounded-lg px-4 py-2 text-sm text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => deleteMutation.mutate()}
+            disabled={deleteMutation.isPending}
+            className="rounded-lg bg-red-500 px-4 py-2 text-sm font-medium text-white transition-opacity hover:bg-red-600 disabled:opacity-40"
+          >
+            {deleteMutation.isPending ? "Deleting..." : "Delete"}
+          </button>
+        </div>
+        {deleteMutation.isError && (
+          <p className="mt-3 text-xs text-red-400">Failed to delete agent. It may be running.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function Agents() {
   const navigate = useNavigate();
   const [showCreate, setShowCreate] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<AgentSummary | null>(null);
 
   const { data: agents = [], isLoading } = useQuery({
     queryKey: ["agents"],
@@ -393,6 +461,7 @@ export function Agents() {
                     key={agent.slug}
                     agent={agent}
                     onClick={() => navigate(`/agents/${agent.slug}`)}
+                    onDelete={() => setDeleteTarget(agent)}
                   />
                 ))}
               </div>
@@ -414,6 +483,7 @@ export function Agents() {
                     key={agent.slug}
                     agent={agent}
                     onClick={() => navigate(`/agents/${agent.slug}`)}
+                    onDelete={() => setDeleteTarget(agent)}
                   />
                 ))}
               </div>
@@ -423,6 +493,7 @@ export function Agents() {
       )}
 
       <CreateAgentDialog open={showCreate} onClose={() => setShowCreate(false)} />
+      <DeleteAgentDialog agent={deleteTarget} onClose={() => setDeleteTarget(null)} />
     </div>
   );
 }

--- a/frontend/src/pages/Bots.tsx
+++ b/frontend/src/pages/Bots.tsx
@@ -1,9 +1,12 @@
-import { Archive, Bot, FlaskConical, Loader2, TerminalSquare } from "lucide-react";
+import { Archive, Bot, FlaskConical, History, Loader2, TerminalSquare } from "lucide-react";
 import { lazy, Suspense, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 
 const ActiveBotsTab = lazy(() =>
   import("@/pages/tabs/ActiveBotsTab").then((m) => ({ default: m.ActiveBotsTab })),
+);
+const BotRunsTab = lazy(() =>
+  import("@/pages/tabs/BotRunsTab").then((m) => ({ default: m.BotRunsTab })),
 );
 const ArchivedBotsTab = lazy(() =>
   import("@/pages/tabs/ArchivedBotsTab").then((m) => ({ default: m.ArchivedBotsTab })),
@@ -17,6 +20,7 @@ const EditorTab = lazy(() =>
 
 const TABS = [
   { key: "active", label: "Active", icon: Bot },
+  { key: "runs", label: "Runs", icon: History },
   { key: "editor", label: "Editor", icon: TerminalSquare },
   { key: "backtest", label: "Backtest", icon: FlaskConical },
   { key: "archived", label: "Archived", icon: Archive },
@@ -71,6 +75,11 @@ export function Bots() {
         {visitedRef.current.has("active") && (
           <div style={{ display: currentTab === "active" ? undefined : "none" }}>
             <ActiveBotsTab />
+          </div>
+        )}
+        {visitedRef.current.has("runs") && (
+          <div style={{ display: currentTab === "runs" ? undefined : "none" }}>
+            <BotRunsTab />
           </div>
         )}
         {visitedRef.current.has("archived") && (

--- a/frontend/src/pages/CreateExecutor.tsx
+++ b/frontend/src/pages/CreateExecutor.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import {
@@ -6,12 +6,14 @@ import {
   ArrowUpDown,
   BarChart3,
   CheckCircle,
+  Copy,
   Grid3X3,
   Layers,
   Loader2,
   Rocket,
   Settings2,
   TrendingUp,
+  X,
 } from "lucide-react";
 
 import { ExchangeSelector } from "@/components/market/ExchangeSelector";
@@ -172,6 +174,7 @@ const TYPE_LABELS: Record<ExecutorType, string> = {
 export function CreateExecutor() {
   const { server } = useServer();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
 
   // Executor type from URL param or default to grid
@@ -218,7 +221,7 @@ export function CreateExecutor() {
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const [successId, setSuccessId] = useState<string | null>(null);
+  const [successInfo, setSuccessInfo] = useState<{ id: string; type: ExecutorType; connector: string; pair: string } | null>(null);
   const [rightPanel, setRightPanel] = useState<"config" | "depth">("config");
   const [rightPanelWidth, setRightPanelWidth] = useState(288);
   const [bottomPaneHeight, setBottomPaneHeight] = useState(200);
@@ -456,10 +459,13 @@ export function CreateExecutor() {
         case "order": orderConfig.save(); break;
         case "dca": dcaConfig.save(); break;
       }
-      setSuccessId(data.executor_id);
-      // Auto-dismiss success toast after 2.5s — stay on this page
-      // so the new executor appears in the bottom pane via WS
-      setTimeout(() => setSuccessId(null), 2500);
+      // Show success modal
+      setSuccessInfo({ id: data.executor_id, type: executorType, connector, pair });
+      // Invalidate executor queries so the new one appears immediately
+      queryClient.invalidateQueries({ queryKey: ["executors", server, "main", pair] });
+      queryClient.invalidateQueries({ queryKey: ["consolidated-positions", server] });
+      // Auto-select the new executor in the bottom pane
+      setSelectedExecutorId(data.executor_id);
     },
   });
 
@@ -705,13 +711,68 @@ export function CreateExecutor() {
         </div>
       </div>
 
-      {/* Success toast */}
-      {successId && (
-        <div className="absolute bottom-16 left-1/2 z-50 -translate-x-1/2">
-          <div className="flex items-center gap-2 rounded-lg border border-[var(--color-green)]/30 bg-[var(--color-surface)] px-4 py-2.5 shadow-2xl shadow-black/40">
-            <CheckCircle className="h-4 w-4 text-[var(--color-green)]" />
-            <span className="text-xs font-medium text-[var(--color-text)]">{TYPE_LABELS[executorType]} Created</span>
-            <span className="font-mono text-[10px] text-[var(--color-text-muted)]">{successId.slice(0, 8)}</span>
+      {/* Success modal */}
+      {successInfo && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+          <div className="relative w-[360px] rounded-xl border border-[var(--color-green)]/30 bg-[var(--color-surface)] p-6 shadow-2xl shadow-black/40 animate-in fade-in zoom-in-95 duration-200">
+            {/* Close button */}
+            <button
+              onClick={() => setSuccessInfo(null)}
+              className="absolute right-3 top-3 rounded p-1 text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+            >
+              <X className="h-4 w-4" />
+            </button>
+
+            {/* Icon */}
+            <div className="mb-4 flex justify-center">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--color-green)]/15">
+                <CheckCircle className="h-6 w-6 text-[var(--color-green)]" />
+              </div>
+            </div>
+
+            {/* Title */}
+            <h3 className="mb-1 text-center text-sm font-semibold text-[var(--color-text)]">
+              {TYPE_LABELS[successInfo.type]} Created
+            </h3>
+            <p className="mb-4 text-center text-[11px] text-[var(--color-text-muted)]">
+              Successfully deployed on {successInfo.connector}
+            </p>
+
+            {/* Details */}
+            <div className="mb-4 space-y-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] p-3">
+              <div className="flex items-center justify-between text-[11px]">
+                <span className="text-[var(--color-text-muted)]">Executor ID</span>
+                <div className="flex items-center gap-1.5">
+                  <span className="font-mono text-[var(--color-text)]">{successInfo.id.slice(0, 12)}…</span>
+                  <button
+                    onClick={() => navigator.clipboard.writeText(successInfo.id)}
+                    className="rounded p-0.5 text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+                    title="Copy full ID"
+                  >
+                    <Copy className="h-3 w-3" />
+                  </button>
+                </div>
+              </div>
+              <div className="flex items-center justify-between text-[11px]">
+                <span className="text-[var(--color-text-muted)]">Pair</span>
+                <span className="font-mono text-[var(--color-text)]">{successInfo.pair}</span>
+              </div>
+              <div className="flex items-center justify-between text-[11px]">
+                <span className="text-[var(--color-text-muted)]">Status</span>
+                <span className="inline-flex items-center gap-1 rounded-full bg-[var(--color-green)]/15 px-1.5 py-0.5 text-[9px] font-bold text-[var(--color-green)]">
+                  <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-green)] animate-pulse" />
+                  ACTIVE
+                </span>
+              </div>
+            </div>
+
+            {/* Action */}
+            <button
+              onClick={() => setSuccessInfo(null)}
+              className="w-full rounded-lg bg-[var(--color-primary)] px-4 py-2 text-xs font-semibold text-white transition-colors hover:brightness-110"
+            >
+              Continue Trading
+            </button>
           </div>
         </div>
       )}

--- a/frontend/src/pages/CreateExecutor.tsx
+++ b/frontend/src/pages/CreateExecutor.tsx
@@ -27,7 +27,9 @@ import { TradeBottomPane } from "@/components/trade/TradeBottomPane";
 import { useServer } from "@/hooks/useServer";
 import { useCondorWebSocket } from "@/hooks/useWebSocket";
 import { useMainControllerData } from "@/hooks/useMainControllerData";
+import { useRates } from "@/hooks/useRates";
 import { api } from "@/lib/api";
+import { candleStore } from "@/lib/candle-store";
 import type { ExecutorType } from "@/components/executor/types";
 import {
   type GridState,
@@ -274,6 +276,19 @@ export function CreateExecutor() {
     useMainControllerData(server, connector, pair);
 
   const rulesData = useTradingRules(server ?? "", connector);
+
+  // Currency conversion for chart tooltip values
+  const quoteCurrency = pair.split("-")[1] || "USDT";
+  const { formatPnlValue, formatValue } = useRates([quoteCurrency]);
+  const convertPnl = useCallback((val: number) => formatPnlValue(val, quoteCurrency), [formatPnlValue, quoteCurrency]);
+  const convertValue = useCallback((val: number) => formatValue(val, quoteCurrency), [formatValue, quoteCurrency]);
+
+  // Load candles for an executor that's outside the current range
+  const handleRequestCandleRange = useCallback((startTime: number) => {
+    if (!server) return;
+    const newLookback = Math.ceil(Date.now() / 1000 - startTime) + 3600; // +1h padding
+    gridDispatch({ type: "SET_FIELD", field: "lookbackSeconds", value: newLookback });
+  }, [server]);
 
   // Persist last-used connector/pair to localStorage & clear executor selection
   useEffect(() => {
@@ -550,6 +565,9 @@ export function CreateExecutor() {
               executorOverlays={mainOverlays}
               positions={mainPositions}
               selectedExecutorId={selectedExecutorId}
+              convertValue={convertValue}
+              convertPnl={convertPnl}
+              onExecutorDeselect={() => setSelectedExecutorId(null)}
             />
           </div>
           {/* Horizontal resize handle */}
@@ -568,7 +586,20 @@ export function CreateExecutor() {
               pair={pair}
               isSpot={isSpot}
               selectedExecutorId={selectedExecutorId}
-              onExecutorSelect={(ex) => setSelectedExecutorId(ex?.id ?? null)}
+              onExecutorSelect={(ex) => {
+                setSelectedExecutorId(ex?.id ?? null);
+                // If this executor is older than current candle range, expand lookback
+                if (ex && ex.timestamp > 0) {
+                  const key = `candles:${server}:${connector}:${pair}:${gridState.interval}`;
+                  const candles = candleStore.getCandles(key);
+                  if (candles.length > 0) {
+                    const minTime = candles[0].timestamp;
+                    if (ex.timestamp < minTime) {
+                      handleRequestCandleRange(ex.timestamp);
+                    }
+                  }
+                }
+              }}
             />
           </div>
         </div>

--- a/frontend/src/pages/CreateExecutor.tsx
+++ b/frontend/src/pages/CreateExecutor.tsx
@@ -634,7 +634,7 @@ export function CreateExecutor() {
               {/* Config Panel */}
               <div className="flex-1 overflow-y-auto">
                 {executorType === "grid" && (
-                  <GridConfigPanel state={gridState} dispatch={gridDispatch} currentPrice={currentPrice} isSpot={isSpot} />
+                  <GridConfigPanel state={gridState} dispatch={gridDispatch} currentPrice={currentPrice} isSpot={isSpot} quoteCurrency={pair?.split("-")[1] || "USDT"} />
                 )}
                 {executorType === "position" && (
                   <PositionConfigPanel state={positionConfig.state} dispatch={positionConfig.dispatch} currentPrice={currentPrice} isSpot={isSpot} pair={pair} />

--- a/frontend/src/pages/CreateGridExecutor.tsx
+++ b/frontend/src/pages/CreateGridExecutor.tsx
@@ -402,7 +402,7 @@ export function CreateGridExecutor() {
             </h3>
           </div>
           <div className="flex-1 overflow-y-auto">
-            <GridConfigPanel state={state} dispatch={dispatch} currentPrice={currentPrice} isSpot={isSpot} />
+            <GridConfigPanel state={state} dispatch={dispatch} currentPrice={currentPrice} isSpot={isSpot} quoteCurrency={state.pair.split("-")[1] || "USDT"} />
           </div>
         </div>
       </div>

--- a/frontend/src/pages/Executors.tsx
+++ b/frontend/src/pages/Executors.tsx
@@ -39,21 +39,6 @@ import {
   formatCurrencyVolume,
 } from "@/lib/formatters";
 
-// Re-export formatters for backward compatibility (TradeBottomPane, AgentSessionContent)
-export {
-  formatUsd,
-  formatVolume,
-  formatPnl,
-  pnlColor,
-  formatAge,
-  formatPrice,
-  formatPct,
-  isExecutorActive,
-  formatCurrency,
-  formatCurrencyPnl,
-  formatCurrencyVolume,
-} from "@/lib/formatters";
-
 // ── Multi-select dropdown ──
 
 function MultiSelect({

--- a/frontend/src/pages/Executors.tsx
+++ b/frontend/src/pages/Executors.tsx
@@ -448,12 +448,18 @@ export function DetailPanel({
   onClose,
   onStop,
   stopping,
+  rateFormatPnl,
+  rateFormatValue,
+  rateFormatDetailed,
 }: {
   executor: ExecutorInfo;
   server: string;
   onClose: () => void;
   onStop: (id: string) => void;
   stopping: boolean;
+  rateFormatPnl?: (val: number, quote: string) => string;
+  rateFormatValue?: (val: number, quote: string) => string;
+  rateFormatDetailed?: (val: number, quote: string) => string;
 }) {
   const navigate = useNavigate();
   const [panelWidth, setPanelWidth] = useState(480);
@@ -500,6 +506,11 @@ export function DetailPanel({
     }
     return typeof raw === "object" ? (raw as Record<string, unknown>) : {};
   })();
+
+  const quote = executor.trading_pair?.split("-")[1] || "USDT";
+  const fmtPnl = rateFormatPnl ? (v: number) => rateFormatPnl(v, quote) : formatPnl;
+  const fmtVal = rateFormatValue ? (v: number) => rateFormatValue(v, quote) : formatUsd;
+  const fmtDet = rateFormatDetailed ? (v: number) => rateFormatDetailed(v, quote) : formatUsd;
 
   return (
       <div
@@ -620,7 +631,7 @@ export function DetailPanel({
               <div>
                 <div className="text-[var(--color-text-muted)] text-xs mb-0.5">Net PnL</div>
                 <div className="font-medium tabular-nums" style={{ color: pnlColor(executor.pnl) }}>
-                  {formatPnl(executor.pnl)}
+                  {fmtPnl(executor.pnl)}
                 </div>
               </div>
               <div>
@@ -634,12 +645,12 @@ export function DetailPanel({
               </div>
               <div>
                 <div className="text-[var(--color-text-muted)] text-xs mb-0.5">Volume</div>
-                <div className="font-medium tabular-nums">{formatVolume(executor.volume)}</div>
+                <div className="font-medium tabular-nums">{fmtVal(executor.volume)}</div>
               </div>
               <div>
                 <div className="text-[var(--color-text-muted)] text-xs mb-0.5">Fees</div>
                 <div className="font-medium tabular-nums">
-                  {executor.cum_fees_quote ? formatUsd(executor.cum_fees_quote) : "\u2014"}
+                  {executor.cum_fees_quote ? fmtDet(executor.cum_fees_quote) : "\u2014"}
                 </div>
               </div>
             </div>
@@ -677,7 +688,7 @@ export function DetailPanel({
                 {config.total_amount_quote != null && (
                   <div>
                     <div className="text-[var(--color-text-muted)] text-xs mb-0.5">Amount</div>
-                    <div className="font-medium tabular-nums">{formatUsd(Number(config.total_amount_quote))}</div>
+                    <div className="font-medium tabular-nums">{fmtDet(Number(config.total_amount_quote))}</div>
                   </div>
                 )}
               </div>
@@ -718,7 +729,7 @@ export function DetailPanel({
                 {config.total_amount_quote != null && (
                   <div>
                     <div className="text-[var(--color-text-muted)] text-xs mb-0.5">Amount</div>
-                    <div className="font-medium tabular-nums">{formatUsd(Number(config.total_amount_quote))}</div>
+                    <div className="font-medium tabular-nums">{fmtDet(Number(config.total_amount_quote))}</div>
                   </div>
                 )}
                 {tripleBarrier.take_profit != null && (
@@ -979,8 +990,8 @@ export function Executors() {
     trading_pair: "",
     controller_ids: [] as string[],
   });
-  const [maxPages, setMaxPages] = useState<number>(40); // 40 * 50 = 2000 cap by default
-  const PAGE_SIZE = 50;
+  const PAGE_SIZE = 500;
+  const [maxPages, setMaxPages] = useState<number>(4); // 4 * 500 = 2000 cap by default
   const [historyCollapsed, setHistoryCollapsed] = useState(false);
   const [sortKey, setSortKey] = useState<SortKey>("timestamp");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
@@ -1220,7 +1231,7 @@ export function Executors() {
         </span>
         {reachedCap && (
           <button
-            onClick={() => setMaxPages((p) => p + 40)}
+            onClick={() => setMaxPages((p) => p + 4)}
             className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-xs font-medium hover:bg-[var(--color-surface-hover)] transition-colors"
           >
             Load more
@@ -1426,6 +1437,9 @@ export function Executors() {
           onClose={() => setSelectedExecutor(null)}
           onStop={handleStopOne}
           stopping={stoppingIds.has(selectedExecutor.id)}
+          rateFormatPnl={formatPnlValue}
+          rateFormatValue={formatValue}
+          rateFormatDetailed={formatValueDetailed}
         />
       )}
 

--- a/frontend/src/pages/Executors.tsx
+++ b/frontend/src/pages/Executors.tsx
@@ -21,70 +21,38 @@ import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } fro
 import { useNavigate } from "react-router-dom";
 
 import { ExecutorChart } from "@/components/charts/ExecutorChart";
+import { useRates } from "@/hooks/useRates";
 import { useCondorWebSocket } from "@/hooks/useWebSocket";
 import { useServer } from "@/hooks/useServer";
 import { api, type ExecutorInfo } from "@/lib/api";
+import {
+  formatUsd,
+  formatVolume,
+  formatPnl,
+  pnlColor,
+  formatAge,
+  formatPrice,
+  formatPct,
+  isExecutorActive,
+  formatCurrency,
+  formatCurrencyPnl,
+  formatCurrencyVolume,
+} from "@/lib/formatters";
 
-// ── Formatters ──
-
-export function formatUsd(val: number) {
-  if (Math.abs(val) >= 1_000_000) return "$" + (val / 1_000_000).toFixed(2) + "M";
-  if (Math.abs(val) >= 10_000) return "$" + (val / 1_000).toFixed(1) + "K";
-  return val.toLocaleString("en-US", {
-    style: "currency",
-    currency: "USD",
-    minimumFractionDigits: 2,
-  });
-}
-
-export function formatVolume(val: number) {
-  if (Math.abs(val) >= 1_000_000) return "$" + (val / 1_000_000).toFixed(1) + "M";
-  if (Math.abs(val) >= 1_000) return "$" + (val / 1_000).toFixed(1) + "K";
-  return "$" + val.toFixed(0);
-}
-
-export function formatPnl(val: number) {
-  const prefix = val >= 0 ? "+" : "";
-  return prefix + formatUsd(val);
-}
-
-export function pnlColor(val: number) {
-  return val >= 0 ? "var(--color-green)" : "var(--color-red)";
-}
-
-export function formatAge(timestamp: number): string {
-  if (!timestamp) return "\u2014";
-  try {
-    const now = Date.now();
-    const diffMs = now - timestamp * 1000;
-    if (diffMs < 0) return "\u2014";
-    const days = Math.floor(diffMs / 86400000);
-    const hours = Math.floor((diffMs % 86400000) / 3600000);
-    if (days > 0) return `${days}d ${hours}h`;
-    const mins = Math.floor((diffMs % 3600000) / 60000);
-    if (hours > 0) return `${hours}h ${mins}m`;
-    if (mins > 0) return `${mins}m`;
-    return "<1m";
-  } catch {
-    return "\u2014";
-  }
-}
-
-export function formatPrice(val: number): string {
-  if (!val) return "\u2014";
-  if (val >= 1000) return val.toLocaleString("en-US", { maximumFractionDigits: 2 });
-  if (val >= 1) return val.toFixed(4);
-  return val.toPrecision(4);
-}
-
-export function formatPct(val: number): string {
-  if (!val) return "\u2014";
-  return (val >= 0 ? "+" : "") + (val * 100).toFixed(2) + "%";
-}
-
-export function isExecutorActive(status: string) {
-  return status === "active" || status === "running";
-}
+// Re-export formatters for backward compatibility (TradeBottomPane, AgentSessionContent)
+export {
+  formatUsd,
+  formatVolume,
+  formatPnl,
+  pnlColor,
+  formatAge,
+  formatPrice,
+  formatPct,
+  isExecutorActive,
+  formatCurrency,
+  formatCurrencyPnl,
+  formatCurrencyVolume,
+} from "@/lib/formatters";
 
 // ── Multi-select dropdown ──
 
@@ -337,6 +305,9 @@ export function ExecutorTable({
   selectedExecutorId,
   onStop,
   stoppingIds,
+  rateFormatPnl,
+  rateFormatValue,
+  rateFormatDetailed,
 }: {
   executors: ExecutorInfo[];
   sortKey: SortKey;
@@ -350,11 +321,18 @@ export function ExecutorTable({
   selectedExecutorId: string | null;
   onStop: (id: string) => void;
   stoppingIds: Set<string>;
+  rateFormatPnl?: (val: number, quote: string) => string;
+  rateFormatValue?: (val: number, quote: string) => string;
+  rateFormatDetailed?: (val: number, quote: string) => string;
 }) {
   const sorted = useMemo(
     () => [...executors].sort((a, b) => compareExecutors(a, b, sortKey, sortDir)),
     [executors, sortKey, sortDir],
   );
+
+  const fmtPnl = rateFormatPnl ?? ((val: number) => formatPnl(val));
+  const fmtVol = rateFormatValue ?? ((val: number) => formatVolume(val));
+  const fmtDet = rateFormatDetailed ?? ((val: number) => formatUsd(val));
 
   return (
     <div className="overflow-hidden rounded-lg border border-[var(--color-border)]">
@@ -390,6 +368,7 @@ export function ExecutorTable({
               const isChecked = selectedIds.has(ex.id);
               const side = ex.side.toUpperCase();
               const pnlBorder = ex.pnl >= 0 ? "var(--color-green)" : "var(--color-red)";
+              const quote = ex.trading_pair?.split("-")[1] || "USDT";
               return (
                 <tr
                   key={ex.id}
@@ -431,7 +410,7 @@ export function ExecutorTable({
                     className="px-4 py-2.5 text-sm text-right tabular-nums font-medium"
                     style={{ color: pnlColor(ex.pnl) }}
                   >
-                    {formatPnl(ex.pnl)}
+                    {fmtPnl(ex.pnl, quote)}
                   </td>
                   <td
                     className="px-4 py-2.5 text-sm text-right tabular-nums"
@@ -440,10 +419,10 @@ export function ExecutorTable({
                     {formatPct(ex.net_pnl_pct)}
                   </td>
                   <td className="px-4 py-2.5 text-sm text-right tabular-nums text-[var(--color-text-muted)]">
-                    {formatVolume(ex.volume)}
+                    {fmtVol(ex.volume, quote)}
                   </td>
                   <td className="px-4 py-2.5 text-sm text-right tabular-nums text-[var(--color-text-muted)]">
-                    {ex.cum_fees_quote ? formatUsd(ex.cum_fees_quote) : "\u2014"}
+                    {ex.cum_fees_quote ? fmtDet(ex.cum_fees_quote, quote) : "\u2014"}
                   </td>
                   <td className="px-4 py-2.5 text-sm text-[var(--color-text-muted)]">
                     {ex.close_type || "\u2014"}
@@ -1108,6 +1087,13 @@ export function Executors() {
   );
   const reachedCap = loadedPages >= maxPages && hasNextPage;
 
+  // Currency conversion
+  const quoteCurrencies = useMemo(
+    () => executors.map((ex) => ex.trading_pair?.split("-")[1] || "USDT"),
+    [executors],
+  );
+  const { convert, formatPnlValue, formatValue, formatValueDetailed, currencySymbol } = useRates(quoteCurrencies);
+
   const executorTypes = useMemo(() => {
     const types = new Set(executors.map((ex) => ex.type));
     return Array.from(types).sort();
@@ -1147,8 +1133,8 @@ export function Executors() {
   );
 
   // Aggregate stats (archived only for win rate), filtered by kpiPeriod
-  const activePnl = useMemo(() => activeExecutors.reduce((s, ex) => s + ex.pnl, 0), [activeExecutors]);
-  const activeVolume = useMemo(() => activeExecutors.reduce((s, ex) => s + ex.volume, 0), [activeExecutors]);
+  const activePnl = useMemo(() => activeExecutors.reduce((s, ex) => s + convert(ex.pnl, ex.trading_pair?.split("-")[1] || "USDT").value, 0), [activeExecutors, convert]);
+  const activeVolume = useMemo(() => activeExecutors.reduce((s, ex) => s + convert(ex.volume, ex.trading_pair?.split("-")[1] || "USDT").value, 0), [activeExecutors, convert]);
 
   const periodFilteredArchived = useMemo(() => {
     const now = Date.now() / 1000;
@@ -1159,9 +1145,9 @@ export function Executors() {
     return archivedExecutors.filter((ex) => ex.timestamp >= cutoff);
   }, [archivedExecutors, kpiPeriod]);
 
-  const archivedPnl = useMemo(() => periodFilteredArchived.reduce((s, ex) => s + ex.pnl, 0), [periodFilteredArchived]);
-  const archivedVolume = useMemo(() => periodFilteredArchived.reduce((s, ex) => s + ex.volume, 0), [periodFilteredArchived]);
-  const archivedFees = useMemo(() => periodFilteredArchived.reduce((s, ex) => s + ex.cum_fees_quote, 0), [periodFilteredArchived]);
+  const archivedPnl = useMemo(() => periodFilteredArchived.reduce((s, ex) => s + convert(ex.pnl, ex.trading_pair?.split("-")[1] || "USDT").value, 0), [periodFilteredArchived, convert]);
+  const archivedVolume = useMemo(() => periodFilteredArchived.reduce((s, ex) => s + convert(ex.volume, ex.trading_pair?.split("-")[1] || "USDT").value, 0), [periodFilteredArchived, convert]);
+  const archivedFees = useMemo(() => periodFilteredArchived.reduce((s, ex) => s + convert(ex.cum_fees_quote, ex.trading_pair?.split("-")[1] || "USDT").value, 0), [periodFilteredArchived, convert]);
   const winRate = useMemo(() => {
     if (periodFilteredArchived.length === 0) return 0;
     return periodFilteredArchived.filter((ex) => ex.pnl > 0).length / periodFilteredArchived.length;
@@ -1303,7 +1289,7 @@ export function Executors() {
                   <span className="text-xs text-[var(--color-text-muted)] uppercase tracking-wider">Total PnL</span>
                 </div>
                 <p className="text-xl font-bold tabular-nums" style={{ color: pnlColor(archivedPnl) }}>
-                  {formatPnl(archivedPnl)}
+                  {formatCurrencyPnl(archivedPnl, currencySymbol)}
                 </p>
               </div>
               <div className="flex-1 px-4 py-3">
@@ -1320,14 +1306,14 @@ export function Executors() {
                   <Volume2 className="h-3.5 w-3.5 text-[var(--color-text-muted)]" />
                   <span className="text-xs text-[var(--color-text-muted)] uppercase tracking-wider">Total Volume</span>
                 </div>
-                <p className="text-xl font-bold tabular-nums">{formatVolume(archivedVolume)}</p>
+                <p className="text-xl font-bold tabular-nums">{formatCurrencyVolume(archivedVolume, currencySymbol)}</p>
               </div>
               <div className="flex-1 px-4 py-3">
                 <div className="flex items-center gap-2 mb-1">
                   <Layers className="h-3.5 w-3.5 text-[var(--color-text-muted)]" />
                   <span className="text-xs text-[var(--color-text-muted)] uppercase tracking-wider">Total Fees</span>
                 </div>
-                <p className="text-xl font-bold tabular-nums">{archivedFees > 0 ? formatUsd(archivedFees) : "\u2014"}</p>
+                <p className="text-xl font-bold tabular-nums">{archivedFees > 0 ? formatCurrency(archivedFees, currencySymbol) : "\u2014"}</p>
               </div>
               <div className="flex items-center px-3 shrink-0">
                 <div className="flex gap-0.5 rounded-md border border-[var(--color-border)] p-0.5 bg-[var(--color-bg)]">
@@ -1360,12 +1346,12 @@ export function Executors() {
                   </h3>
                   {activePnl !== 0 && (
                     <span className="text-sm font-medium tabular-nums" style={{ color: pnlColor(activePnl) }}>
-                      {formatPnl(activePnl)}
+                      {formatCurrencyPnl(activePnl, currencySymbol)}
                     </span>
                   )}
                   {activeVolume > 0 && (
                     <span className="text-xs text-[var(--color-text-muted)] tabular-nums">
-                      {formatVolume(activeVolume)} vol
+                      {formatCurrencyVolume(activeVolume, currencySymbol)} vol
                     </span>
                   )}
                 </div>
@@ -1383,6 +1369,9 @@ export function Executors() {
                 selectedExecutorId={selectedExecutor?.id ?? null}
                 onStop={handleStopOne}
                 stoppingIds={stoppingIds}
+                rateFormatPnl={formatPnlValue}
+                rateFormatValue={formatValue}
+                rateFormatDetailed={formatValueDetailed}
               />
             </div>
           )}
@@ -1408,7 +1397,7 @@ export function Executors() {
                   History ({archivedExecutors.length})
                 </h3>
                 <span className="text-sm font-medium tabular-nums" style={{ color: pnlColor(archivedPnl) }}>
-                  {formatPnl(archivedPnl)}
+                  {formatCurrencyPnl(archivedPnl, currencySymbol)}
                 </span>
                 {winRate > 0 && (
                   <span className="text-xs text-[var(--color-text-muted)]">
@@ -1431,6 +1420,9 @@ export function Executors() {
                   selectedExecutorId={selectedExecutor?.id ?? null}
                   onStop={handleStopOne}
                   stoppingIds={stoppingIds}
+                  rateFormatPnl={formatPnlValue}
+                  rateFormatValue={formatValue}
+                  rateFormatDetailed={formatValueDetailed}
                 />
               )}
             </div>

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -730,6 +730,7 @@ function PortfolioEvolution({ server, range }: { server: string; range: string }
 export function Portfolio() {
   const { server } = useServer();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [period, setPeriod] = useState<string>("1W");
 
   const { data, isLoading, error, isPlaceholderData } = useQuery({
@@ -739,6 +740,20 @@ export function Portfolio() {
     refetchInterval: 15000,
     placeholderData: keepPreviousData,
   });
+
+  // One-time background refresh on mount / server change
+  useEffect(() => {
+    if (!server) return;
+    const timer = setTimeout(() => {
+      api
+        .getPortfolio(server, true)
+        .then((fresh) => {
+          queryClient.setQueryData(["portfolio", server], fresh);
+        })
+        .catch(() => {}); // silent fail, cached data still shown
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [server, queryClient]);
 
   const { data: bots } = useQuery({
     queryKey: ["bots", server],

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -14,15 +14,18 @@ import {
 import { useState, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { useRates } from "@/hooks/useRates";
 import { useServer } from "@/hooks/useServer";
 import {
   api,
   type AgentSummary,
   type BalanceItem,
   type ConnectorBalance,
+  type ExecutorInfo,
   type PortfolioHistoryPoint,
   type PortfolioHistoryResponse,
 } from "@/lib/api";
+import { formatCurrencyPnl, formatCurrencyVolume } from "@/lib/formatters";
 
 // ── Formatters ──
 
@@ -80,7 +83,11 @@ function isExecutorActive(status: string) {
   return status === "active" || status === "running";
 }
 
-function computeExecutorStats(executors: import("@/lib/api").ExecutorInfo[], period: string) {
+function computeExecutorStats(
+  executors: ExecutorInfo[],
+  period: string,
+  convert: (value: number, quote: string) => { value: number; converted: boolean },
+) {
   const now = Date.now() / 1000;
   const cutoff =
     period === "1D" ? now - 86400 :
@@ -88,10 +95,14 @@ function computeExecutorStats(executors: import("@/lib/api").ExecutorInfo[], per
     now - 30 * 86400;
 
   const filtered = executors.filter((e) => e.timestamp >= cutoff);
-  const pnl = filtered.reduce((s, e) => s + e.pnl, 0);
-  const volume = filtered.reduce((s, e) => s + e.volume, 0);
-  const count = filtered.length;
-  return { pnl, volume, count };
+  let pnl = 0;
+  let volume = 0;
+  for (const e of filtered) {
+    const quote = e.trading_pair?.split("-")[1] || "USDT";
+    pnl += convert(e.pnl, quote).value;
+    volume += convert(e.volume, quote).value;
+  }
+  return { pnl, volume, count: filtered.length };
 }
 
 // ── Unified Dashboard Strip ──
@@ -101,11 +112,13 @@ function KpiCell({
   mainValue,
   pnl,
   details,
+  currencySymbol,
 }: {
   label: string;
   mainValue: string | number;
   pnl?: number;
   details: string;
+  currencySymbol?: string;
 }) {
   return (
     <div className="flex-1 px-5 py-3 min-w-0">
@@ -116,7 +129,7 @@ function KpiCell({
           <span className="inline-flex items-center gap-0.5 text-sm tabular-nums font-semibold"
             style={{ color: pnl >= 0 ? "var(--color-green)" : "var(--color-red)" }}>
             {pnl >= 0 ? <ArrowUpRight className="h-3.5 w-3.5" /> : <ArrowDownRight className="h-3.5 w-3.5" />}
-            {formatPnl(pnl)}
+            {currencySymbol ? formatCurrencyPnl(pnl, currencySymbol) : formatPnl(pnl)}
           </span>
         )}
       </div>
@@ -140,6 +153,8 @@ function DashboardStrip({
   period,
   onPeriodChange,
   onNavigate,
+  convert,
+  currencySymbol,
 }: {
   totalUsd: number;
   totalTokens: number;
@@ -150,13 +165,15 @@ function DashboardStrip({
   botPnl: number;
   botVolume: number;
   activeExecutorCount: number;
-  allExecutors: import("@/lib/api").ExecutorInfo[];
+  allExecutors: ExecutorInfo[];
   agents: AgentSummary[];
   period: string;
   onPeriodChange: (p: string) => void;
   onNavigate: (path: string) => void;
+  convert: (value: number, quote: string) => { value: number; converted: boolean };
+  currencySymbol: string;
 }) {
-  const execStats = useMemo(() => computeExecutorStats(allExecutors, period), [allExecutors, period]);
+  const execStats = useMemo(() => computeExecutorStats(allExecutors, period, convert), [allExecutors, period, convert]);
 
   const activeAgents = agents.filter((a) => a.status === "running" || a.status === "active");
   const agentPnl = agents.reduce((s, a) => s + a.daily_pnl, 0);
@@ -178,14 +195,16 @@ function DashboardStrip({
           label="Bots"
           mainValue={botCount}
           pnl={botPnl}
-          details={`${controllerCount} controller${controllerCount !== 1 ? "s" : ""} · vol ${formatUsd(botVolume)}`}
+          details={`${controllerCount} controller${controllerCount !== 1 ? "s" : ""} · vol ${formatCurrencyVolume(botVolume, currencySymbol)}`}
+          currencySymbol={currencySymbol}
         />
 
         <KpiCell
           label="Executors"
           mainValue={`${activeExecutorCount} active`}
           pnl={execStats.pnl}
-          details={`${execStats.count} in ${period} · vol ${formatUsd(execStats.volume)}`}
+          details={`${execStats.count} in ${period} · vol ${formatCurrencyVolume(execStats.volume, currencySymbol)}`}
+          currencySymbol={currencySymbol}
         />
 
         <KpiCell
@@ -747,6 +766,21 @@ export function Portfolio() {
     refetchInterval: 60000,
   });
 
+  // Currency conversion for bots + executors (must be before early returns)
+  const controllers = bots?.controllers ?? [];
+  const executorsList = allExecutors ?? [];
+  const quoteCurrencies = useMemo(() => {
+    const quotes = new Set<string>();
+    for (const c of controllers) {
+      quotes.add(c.trading_pair?.split("-")[1] || "USDT");
+    }
+    for (const e of executorsList) {
+      quotes.add(e.trading_pair?.split("-")[1] || "USDT");
+    }
+    return Array.from(quotes);
+  }, [controllers, executorsList]);
+  const { convert, currencySymbol } = useRates(quoteCurrencies);
+
   if (!server) {
     return (
       <div className="flex items-center justify-center min-h-[60vh]">
@@ -815,10 +849,17 @@ export function Portfolio() {
   // Compute aggregate stats
   const totalTokens = connectors.reduce((s, c) => s + c.balances.length, 0);
   const botsList = bots?.bots ?? [];
-  const controllerCount = bots?.controllers?.length ?? 0;
-  const botPnl = bots?.total_pnl ?? 0;
-  const botVolume = bots?.total_volume ?? 0;
-  const activeExecutorCount = (allExecutors ?? []).filter((e) => isExecutorActive(e.status)).length;
+  const controllerCount = controllers.length;
+  const activeExecutorCount = executorsList.filter((e) => isExecutorActive(e.status)).length;
+
+  // Convert bot PnL and volume per-controller
+  let botPnl = 0;
+  let botVolume = 0;
+  for (const ctrl of controllers) {
+    const quote = ctrl.trading_pair?.split("-")[1] || "USDT";
+    botPnl += convert(ctrl.global_pnl_quote, quote).value;
+    botVolume += convert(ctrl.volume_traded, quote).value;
+  }
 
   // Flatten all tokens for top holdings
   const allTokens = connectors.flatMap((c) =>
@@ -840,11 +881,13 @@ export function Portfolio() {
         botPnl={botPnl}
         botVolume={botVolume}
         activeExecutorCount={activeExecutorCount}
-        allExecutors={allExecutors ?? []}
+        allExecutors={executorsList}
         agents={agents ?? []}
         period={period}
         onPeriodChange={setPeriod}
         onNavigate={navigate}
+        convert={convert}
+        currencySymbol={currencySymbol}
       />
 
       {/* Portfolio Evolution + Top Holdings side by side */}

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -11,7 +11,7 @@ import {
   ArrowUpRight,
   ArrowDownRight,
 } from "lucide-react";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useRates } from "@/hooks/useRates";
@@ -25,28 +25,10 @@ import {
   type PortfolioHistoryPoint,
   type PortfolioHistoryResponse,
 } from "@/lib/api";
-import { formatCurrencyPnl, formatCurrencyVolume } from "@/lib/formatters";
+import { formatCurrency, formatCurrencyPnl, formatCurrencyVolume } from "@/lib/formatters";
 import { getThemeColors } from "@/lib/theme-colors";
 
 // ── Formatters ──
-
-function formatUsd(val: number) {
-  if (Math.abs(val) >= 1_000_000) return "$" + (val / 1_000_000).toFixed(2) + "M";
-  if (Math.abs(val) >= 10_000) return "$" + (val / 1_000).toFixed(1) + "K";
-  return val.toLocaleString("en-US", {
-    style: "currency",
-    currency: "USD",
-    minimumFractionDigits: 2,
-  });
-}
-
-function formatPrice(val: number) {
-  if (val === 0) return "-";
-  if (val >= 1000) return "$" + val.toLocaleString("en-US", { maximumFractionDigits: 0 });
-  if (val >= 1) return "$" + val.toFixed(2);
-  if (val >= 0.01) return "$" + val.toFixed(4);
-  return "$" + val.toExponential(2);
-}
 
 function formatAmount(val: number) {
   if (val === 0) return "0";
@@ -56,9 +38,12 @@ function formatAmount(val: number) {
   return val.toLocaleString("en-US", { maximumFractionDigits: 4 });
 }
 
-function formatPnl(val: number) {
-  const prefix = val >= 0 ? "+" : "";
-  return prefix + formatUsd(val);
+function formatTokenPrice(val: number, symbol = "$") {
+  if (val === 0) return "-";
+  if (val >= 1000) return symbol + val.toLocaleString("en-US", { maximumFractionDigits: 0 });
+  if (val >= 1) return symbol + val.toFixed(2);
+  if (val >= 0.01) return symbol + val.toFixed(4);
+  return symbol + val.toExponential(2);
 }
 
 // ── Chart Colors ──
@@ -133,7 +118,7 @@ function KpiCell({
           <span className="inline-flex items-center gap-0.5 text-sm tabular-nums font-semibold"
             style={{ color: pnl >= 0 ? "var(--color-green)" : "var(--color-red)" }}>
             {pnl >= 0 ? <ArrowUpRight className="h-3.5 w-3.5" /> : <ArrowDownRight className="h-3.5 w-3.5" />}
-            {currencySymbol ? formatCurrencyPnl(pnl, currencySymbol) : formatPnl(pnl)}
+            {formatCurrencyPnl(pnl, currencySymbol || "$")}
           </span>
         )}
       </div>
@@ -158,6 +143,7 @@ function DashboardStrip({
   onPeriodChange,
   onNavigate,
   convert,
+  convertFromUsd,
   currencySymbol,
 }: {
   totalUsd: number;
@@ -175,6 +161,7 @@ function DashboardStrip({
   onPeriodChange: (p: string) => void;
   onNavigate: (path: string) => void;
   convert: (value: number, quote: string) => { value: number; converted: boolean };
+  convertFromUsd: (val: number) => number;
   currencySymbol: string;
 }) {
   const execStats = useMemo(() => computeExecutorStats(allExecutors, period, convert), [allExecutors, period, convert]);
@@ -190,9 +177,10 @@ function DashboardStrip({
       <div className="flex items-stretch divide-x divide-[var(--color-border)]">
         <KpiCell
           label="Portfolio"
-          mainValue={formatUsd(totalUsd)}
-          pnl={portfolioPnl ?? undefined}
+          mainValue={formatCurrency(convertFromUsd(totalUsd), currencySymbol)}
+          pnl={portfolioPnl != null ? convertFromUsd(portfolioPnl) : undefined}
           details={`${totalTokens} assets · ${connectorCount} connector${connectorCount !== 1 ? "s" : ""}`}
+          currencySymbol={currencySymbol}
         />
 
         <KpiCell
@@ -214,8 +202,9 @@ function DashboardStrip({
         <KpiCell
           label="Agents"
           mainValue={activeAgents.length}
-          pnl={agentPnl}
+          pnl={convertFromUsd(agentPnl)}
           details={`${agents.length} total · ${agentSessions} session${agentSessions !== 1 ? "s" : ""}`}
+          currencySymbol={currencySymbol}
         />
 
         {/* ── Period + Quick Links ── */}
@@ -320,7 +309,17 @@ function AllocationBar({ pct }: { pct: number }) {
 
 // ── Table Rows ──
 
-function TokenRow({ b, totalPortfolio }: { b: BalanceItem; totalPortfolio: number }) {
+function TokenRow({
+  b,
+  totalPortfolio,
+  convertFromUsd,
+  currencySymbol,
+}: {
+  b: BalanceItem;
+  totalPortfolio: number;
+  convertFromUsd: (val: number) => number;
+  currencySymbol: string;
+}) {
   const price = b.total > 0 ? b.usd_value / b.total : 0;
   const pct = totalPortfolio > 0 ? (b.usd_value / totalPortfolio) * 100 : 0;
 
@@ -331,10 +330,10 @@ function TokenRow({ b, totalPortfolio }: { b: BalanceItem; totalPortfolio: numbe
       </td>
       <td className="px-4 py-2 text-right text-sm tabular-nums">{formatAmount(b.total)}</td>
       <td className="px-4 py-2 text-right text-sm tabular-nums text-[var(--color-text-muted)]">
-        {formatPrice(price)}
+        {formatTokenPrice(convertFromUsd(price), currencySymbol)}
       </td>
       <td className="px-4 py-2 text-right text-sm tabular-nums font-medium">
-        {formatUsd(b.usd_value)}
+        {formatCurrency(convertFromUsd(b.usd_value), currencySymbol)}
       </td>
       <td className="px-4 py-2">
         <AllocationBar pct={pct} />
@@ -346,9 +345,13 @@ function TokenRow({ b, totalPortfolio }: { b: BalanceItem; totalPortfolio: numbe
 function ConnectorRow({
   connector,
   totalPortfolio,
+  convertFromUsd,
+  currencySymbol,
 }: {
   connector: ConnectorBalance;
   totalPortfolio: number;
+  convertFromUsd: (val: number) => number;
+  currencySymbol: string;
 }) {
   const [expanded, setExpanded] = useState(true);
   const Chevron = expanded ? ChevronDown : ChevronRight;
@@ -372,7 +375,7 @@ function ConnectorRow({
         <td className="px-4 py-3" />
         <td className="px-4 py-3" />
         <td className="px-4 py-3 text-right font-semibold tabular-nums">
-          {formatUsd(connector.total_usd)}
+          {formatCurrency(convertFromUsd(connector.total_usd), currencySymbol)}
         </td>
         <td className="px-4 py-3">
           <span className="text-sm tabular-nums text-[var(--color-text-muted)]">
@@ -382,7 +385,7 @@ function ConnectorRow({
       </tr>
       {expanded &&
         connector.balances.map((b) => (
-          <TokenRow key={b.token} b={b} totalPortfolio={totalPortfolio} />
+          <TokenRow key={b.token} b={b} totalPortfolio={totalPortfolio} convertFromUsd={convertFromUsd} currencySymbol={currencySymbol} />
         ))}
     </>
   );
@@ -404,7 +407,7 @@ function formatTooltipDate(ts: number, range: string) {
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
 }
 
-function PortfolioEvolution({ server, range }: { server: string; range: string }) {
+function PortfolioEvolution({ server, range, convertFromUsd, currencySymbol }: { server: string; range: string; convertFromUsd: (val: number) => number; currencySymbol: string }) {
   const [stacked, setStacked] = useState(false);
   const [hover, setHover] = useState<{ x: number; point: PortfolioHistoryPoint } | null>(null);
   const queryClient = useQueryClient();
@@ -435,8 +438,20 @@ function PortfolioEvolution({ server, range }: { server: string; range: string }
   });
 
   const activeData: PortfolioHistoryResponse | undefined = stacked && breakdownData ? breakdownData : data;
-  const points = activeData?.points ?? [];
+  const rawPoints = activeData?.points ?? [];
   const topTokens = activeData?.top_tokens ?? [];
+
+  // Convert all values from USDT to display currency
+  const points = useMemo(() =>
+    rawPoints.map(p => ({
+      ...p,
+      total_usd: convertFromUsd(p.total_usd),
+      tokens: p.tokens ? Object.fromEntries(
+        Object.entries(p.tokens).map(([k, v]) => [k, convertFromUsd(v)])
+      ) : undefined,
+    })),
+    [rawPoints, convertFromUsd]
+  );
 
   const W = 800;
   const H = 250;
@@ -603,7 +618,7 @@ function PortfolioEvolution({ server, range }: { server: string; range: string }
                   fill="var(--color-text-muted)"
                   fontSize="10"
                 >
-                  {formatUsd(val)}
+                  {formatCurrency(val, currencySymbol)}
                 </text>
               </g>
             ))}
@@ -681,14 +696,14 @@ function PortfolioEvolution({ server, range }: { server: string; range: string }
                             {entry.token}
                           </text>
                           <text x={tooltipW - 8} y="7" fill="var(--color-text-muted)" fontSize="9" textAnchor="end">
-                            {formatUsd(entry.value)}
+                            {formatCurrency(entry.value, currencySymbol)}
                           </text>
                         </g>
                       ))}
                     </>
                   ) : (
                     <text x="8" y="32" fill="var(--color-text)" fontSize="12" fontWeight="bold">
-                      {formatUsd(hover.point.total_usd)}
+                      {formatCurrency(hover.point.total_usd, currencySymbol)}
                     </text>
                   )}
                 </g>
@@ -789,7 +804,7 @@ export function Portfolio() {
   const controllers = bots?.controllers ?? [];
   const executorsList = allExecutors ?? [];
   const quoteCurrencies = useMemo(() => {
-    const quotes = new Set<string>();
+    const quotes = new Set<string>(["USDT"]);
     for (const c of controllers) {
       quotes.add(c.trading_pair?.split("-")[1] || "USDT");
     }
@@ -799,6 +814,12 @@ export function Portfolio() {
     return Array.from(quotes);
   }, [controllers, executorsList]);
   const { convert, currencySymbol } = useRates(quoteCurrencies);
+
+  // Convert a USDT-denominated value to the display currency
+  const convertFromUsd = useCallback(
+    (val: number) => convert(val, "USDT").value,
+    [convert]
+  );
 
   if (!server) {
     return (
@@ -906,13 +927,14 @@ export function Portfolio() {
         onPeriodChange={setPeriod}
         onNavigate={navigate}
         convert={convert}
+        convertFromUsd={convertFromUsd}
         currencySymbol={currencySymbol}
       />
 
       {/* Portfolio Evolution + Top Holdings side by side */}
       <div className="flex flex-col lg:flex-row gap-4">
         <div className={connectors.length > 0 && topTokens.length > 0 ? "lg:flex-[2] min-w-0" : "w-full"}>
-          <PortfolioEvolution server={server!} range={period} />
+          <PortfolioEvolution server={server!} range={period} convertFromUsd={convertFromUsd} currencySymbol={currencySymbol} />
         </div>
         {connectors.length > 0 && topTokens.length > 0 && (
           <div className="lg:flex-1 min-w-0">
@@ -951,7 +973,7 @@ export function Portfolio() {
             </thead>
             <tbody>
               {connectors.map((c) => (
-                <ConnectorRow key={c.connector} connector={c} totalPortfolio={totalUsd} />
+                <ConnectorRow key={c.connector} connector={c} totalPortfolio={totalUsd} convertFromUsd={convertFromUsd} currencySymbol={currencySymbol} />
               ))}
             </tbody>
           </table>

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -26,6 +26,7 @@ import {
   type PortfolioHistoryResponse,
 } from "@/lib/api";
 import { formatCurrencyPnl, formatCurrencyVolume } from "@/lib/formatters";
+import { getThemeColors } from "@/lib/theme-colors";
 
 // ── Formatters ──
 
@@ -62,18 +63,21 @@ function formatPnl(val: number) {
 
 // ── Chart Colors ──
 
-const CHART_COLORS = [
-  "#d4a845", // gold
-  "#22c55e", // green
-  "#6366f1", // indigo
-  "#ef4444", // red
-  "#06b6d4", // cyan
-  "#8b5cf6", // violet
-  "#ec4899", // pink
-  "#14b8a6", // teal
-  "#f97316", // orange
-  "#a78bfa", // light violet
-];
+function getChartColors() {
+  const tc = getThemeColors();
+  return [
+    "#d4a845", // gold
+    tc.green,   // green (theme-aware)
+    "#6366f1", // indigo
+    tc.red,     // red (theme-aware)
+    "#06b6d4", // cyan
+    "#8b5cf6", // violet
+    "#ec4899", // pink
+    "#14b8a6", // teal
+    "#f97316", // orange
+    "#a78bfa", // light violet
+  ];
+}
 
 // ── KPI helpers ──
 
@@ -271,7 +275,7 @@ function TokenBarChart({
               <div className="flex items-center gap-1.5 w-16 justify-end shrink-0">
                 <div
                   className="h-2.5 w-2.5 rounded-sm shrink-0"
-                  style={{ backgroundColor: CHART_COLORS[i % CHART_COLORS.length] }}
+                  style={{ backgroundColor: getChartColors()[i % getChartColors().length] }}
                 />
                 <span className="text-xs font-medium truncate">{t.token}</span>
               </div>
@@ -280,7 +284,7 @@ function TokenBarChart({
                   className="h-full rounded transition-all duration-500"
                   style={{
                     width: `${Math.max(barPct, 2)}%`,
-                    backgroundColor: CHART_COLORS[i % CHART_COLORS.length],
+                    backgroundColor: getChartColors()[i % getChartColors().length],
                     opacity: 0.8,
                   }}
                 />
@@ -459,7 +463,7 @@ function PortfolioEvolution({ server, range }: { server: string; range: string }
     const tokenOrder = topTokens;
     for (let ti = 0; ti < tokenOrder.length; ti++) {
       const token = tokenOrder[ti];
-      const color = CHART_COLORS[ti % CHART_COLORS.length];
+      const color = getChartColors()[ti % getChartColors().length];
 
       // Upper line (cumulative up to and including this token)
       const upperPoints = points.map((p) => {
@@ -529,7 +533,7 @@ function PortfolioEvolution({ server, range }: { server: string; range: string }
   // Tooltip dimensions for stacked mode
   const hoverTokens = hover?.point.tokens ?? {};
   const hoverTokenEntries = stacked && topTokens.length > 0
-    ? topTokens.filter((t) => (hoverTokens[t] ?? 0) > 0).map((t) => ({ token: t, value: hoverTokens[t] ?? 0, color: CHART_COLORS[topTokens.indexOf(t) % CHART_COLORS.length] }))
+    ? topTokens.filter((t) => (hoverTokens[t] ?? 0) > 0).map((t) => ({ token: t, value: hoverTokens[t] ?? 0, color: getChartColors()[topTokens.indexOf(t) % getChartColors().length] }))
     : [];
   const tooltipH = stacked && hoverTokenEntries.length > 0 ? 28 + hoverTokenEntries.length * 16 : 40;
   const tooltipW = stacked && hoverTokenEntries.length > 0 ? 150 : 108;
@@ -708,7 +712,7 @@ function PortfolioEvolution({ server, range }: { server: string; range: string }
                 <div key={token} className="flex items-center gap-1.5">
                   <div
                     className="h-2.5 w-2.5 rounded-sm"
-                    style={{ backgroundColor: CHART_COLORS[i % CHART_COLORS.length] }}
+                    style={{ backgroundColor: getChartColors()[i % getChartColors().length] }}
                   />
                   <span className="text-xs text-[var(--color-text-muted)]">{token}</span>
                 </div>

--- a/frontend/src/pages/tabs/ActiveBotsTab.tsx
+++ b/frontend/src/pages/tabs/ActiveBotsTab.tsx
@@ -17,11 +17,12 @@ import { useMemo, useState } from "react";
 
 import { ControllerBrowser } from "@/components/bots/ControllerBrowser";
 import { DeployBotDialog } from "@/components/bots/DeployBotDialog";
+import { PnlSparkline } from "@/components/bots/PnlSparkline";
 
 import { useRates } from "@/hooks/useRates";
 import { useServer } from "@/hooks/useServer";
 import { useCondorWebSocket } from "@/hooks/useWebSocket";
-import { api, type BotLogEntry, type BotSummary, type ControllerInfo } from "@/lib/api";
+import { api, type BotLogEntry, type BotSummary, type ControllerInfo, type ControllerPerformanceSnapshot } from "@/lib/api";
 import { formatCurrencyVolume, pnlColor } from "@/lib/formatters";
 
 function formatUptime(deployedAt: string | null): string {
@@ -247,6 +248,7 @@ function ControllerRow({
   onSelect,
   formatPnlValue,
   formatValue,
+  sparklineValues,
 }: {
   ctrl: ControllerInfo;
   server: string;
@@ -254,6 +256,7 @@ function ControllerRow({
   onSelect: () => void;
   formatPnlValue: (val: number, quote: string) => string;
   formatValue: (val: number, quote: string) => string;
+  sparklineValues?: number[];
 }) {
   const queryClient = useQueryClient();
   const isKilled = ctrl.config?.manual_kill_switch === true;
@@ -261,8 +264,8 @@ function ControllerRow({
   const toggleMutation = useMutation({
     mutationFn: () =>
       isKilled
-        ? api.startControllers(server, ctrl.bot_name, [ctrl.controller_name])
-        : api.stopControllers(server, ctrl.bot_name, [ctrl.controller_name]),
+        ? api.startControllers(server, ctrl.bot_name, [ctrl.controller_id])
+        : api.stopControllers(server, ctrl.bot_name, [ctrl.controller_id]),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["bots", server] });
     },
@@ -310,6 +313,15 @@ function ControllerRow({
               style={{ color: pnlColor(ctrl.global_pnl_quote) }}
             >
               {formatPnlValue(ctrl.global_pnl_quote, quote)}
+            </td>
+            <td className="px-2 py-2.5">
+              <div className="flex justify-center">
+                {sparklineValues && sparklineValues.length >= 2 ? (
+                  <PnlSparkline values={sparklineValues} />
+                ) : (
+                  <span className="text-[10px] text-[var(--color-text-muted)]">—</span>
+                )}
+              </div>
             </td>
             <td className="px-4 py-2.5 text-sm text-right tabular-nums text-[var(--color-text-muted)]">
               {formatValue(ctrl.volume_traded, quote)}
@@ -472,7 +484,7 @@ function BotsSection({ bots, server }: { bots: BotSummary[]; server: string }) {
 
 // ── Main Page ──
 
-const BOTS_WS_CHANNELS = ["bots"];
+const BOTS_WS_CHANNELS = ["bots", "controller_perf"];
 
 export function ActiveBotsTab() {
   const { server } = useServer();
@@ -491,6 +503,41 @@ export function ActiveBotsTab() {
     refetchInterval: 30000, // Slower polling since WS handles real-time updates
   });
 
+  // Fetch performance history for sparklines (all controllers at once)
+  const { data: perfHistory } = useQuery({
+    queryKey: ["controller-perf-history-all", server],
+    queryFn: () =>
+      api.getControllerPerformanceHistory(server!, {
+        interval: "5m",
+        limit: 1000,
+      }),
+    enabled: !!server && (data?.controllers?.length ?? 0) > 0,
+    refetchInterval: 120_000,
+    staleTime: 60_000,
+  });
+
+  // Build a map: controller_id -> sorted pnl values for sparklines
+  const sparklineMap = useMemo(() => {
+    const map: Record<string, number[]> = {};
+    if (!perfHistory?.snapshots) return map;
+    // Group by controller_id
+    const grouped: Record<string, ControllerPerformanceSnapshot[]> = {};
+    for (const snap of perfHistory.snapshots) {
+      const key = snap.controller_id || snap.controller_name;
+      if (!key) continue;
+      (grouped[key] ??= []).push(snap);
+    }
+    for (const [key, snaps] of Object.entries(grouped)) {
+      const sorted = snaps.sort((a, b) => {
+        const ta = Date.parse(a.timestamp) || 0;
+        const tb = Date.parse(b.timestamp) || 0;
+        return ta - tb;
+      });
+      map[key] = sorted.map((s) => s.global_pnl_quote);
+    }
+    return map;
+  }, [perfHistory]);
+
   const handleSort = (key: SortKey) => {
     if (key === sortKey) {
       setSortDir((d) => (d === "asc" ? "desc" : "asc"));
@@ -504,17 +551,6 @@ export function ActiveBotsTab() {
   const bots = data?.bots ?? [];
 
   // Aggregate logs per bot for the overlay
-  const allLogsByBot = useMemo(() => {
-    const map: Record<string, BotLogEntry[]> = {};
-    for (const bot of bots) {
-      map[bot.bot_name] = [
-        ...(bot.error_logs || []).map((l) => ({ ...l, log_category: "error" as const })),
-        ...(bot.general_logs || []).map((l) => ({ ...l, log_category: "general" as const })),
-      ].sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
-    }
-    return map;
-  }, [bots]);
-
   const sortedControllers = useMemo(
     () => [...controllers].sort((a, b) => compareControllers(a, b, sortKey, sortDir)),
     [controllers, sortKey, sortDir],
@@ -610,6 +646,9 @@ export function ActiveBotsTab() {
                       <SortHeader label="Realized" sortKey="realized_pnl_quote" currentKey={sortKey} currentDir={sortDir} onSort={handleSort} align="right" />
                       <SortHeader label="Unrealized" sortKey="unrealized_pnl_quote" currentKey={sortKey} currentDir={sortDir} onSort={handleSort} align="right" />
                       <SortHeader label="Total PnL" sortKey="global_pnl_quote" currentKey={sortKey} currentDir={sortDir} onSort={handleSort} align="right" />
+                      <th className="px-2 py-3 text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)] text-center">
+                        Trend
+                      </th>
                       <SortHeader label="Volume" sortKey="volume_traded" currentKey={sortKey} currentDir={sortDir} onSort={handleSort} align="right" />
                       <SortHeader label="Age" sortKey="deployed_at" currentKey={sortKey} currentDir={sortDir} onSort={handleSort} align="right" />
                       <SortHeader label="Status" sortKey="status" currentKey={sortKey} currentDir={sortDir} onSort={handleSort} align="center" />
@@ -619,17 +658,21 @@ export function ActiveBotsTab() {
                     </tr>
                   </thead>
                   <tbody>
-                    {sortedControllers.map((ctrl) => (
-                      <ControllerRow
-                        key={`${ctrl.bot_name}-${ctrl.controller_name}`}
-                        ctrl={ctrl}
-                        server={server!}
-                        isSelected={selectedKey === `${ctrl.bot_name}-${ctrl.controller_name}`}
-                        onSelect={() => setSelectedKey(`${ctrl.bot_name}-${ctrl.controller_name}`)}
-                        formatPnlValue={formatPnlValue}
-                        formatValue={formatValue}
-                      />
-                    ))}
+                    {sortedControllers.map((ctrl) => {
+                      const cid = ctrl.controller_id || ctrl.controller_name;
+                      return (
+                        <ControllerRow
+                          key={`${ctrl.bot_name}-${ctrl.controller_name}`}
+                          ctrl={ctrl}
+                          server={server!}
+                          isSelected={selectedKey === `${ctrl.bot_name}-${ctrl.controller_name}`}
+                          onSelect={() => setSelectedKey(`${ctrl.bot_name}-${ctrl.controller_name}`)}
+                          formatPnlValue={formatPnlValue}
+                          formatValue={formatValue}
+                          sparklineValues={sparklineMap[cid]}
+                        />
+                      );
+                    })}
                   </tbody>
                 </table>
               </div>
@@ -647,7 +690,6 @@ export function ActiveBotsTab() {
           controllers={sortedControllers}
           server={server}
           initialControllerKey={selectedKey}
-          allLogs={allLogsByBot}
           onClose={() => setSelectedKey(null)}
         />
       )}

--- a/frontend/src/pages/tabs/ActiveBotsTab.tsx
+++ b/frontend/src/pages/tabs/ActiveBotsTab.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { useMemo, useState } from "react";
 
+import { AggregatedPnlChart } from "@/components/bots/AggregatedPnlChart";
 import { ControllerBrowser } from "@/components/bots/ControllerBrowser";
 import { DeployBotDialog } from "@/components/bots/DeployBotDialog";
 import { PnlSparkline } from "@/components/bots/PnlSparkline";
@@ -118,13 +119,18 @@ function StatCard({
 // ── Status Dot ──
 
 function StatusDot({ status }: { status: string }) {
+  const isStopping = status === "stopping";
   const color =
     status === "running"
       ? "text-[var(--color-green)]"
       : status === "stopped" || status === "error"
         ? "text-[var(--color-red)]"
         : "text-[var(--color-yellow)]";
-  return <Circle className={`h-2 w-2 fill-current ${color}`} />;
+  return isStopping ? (
+    <span className="h-2.5 w-2.5 animate-spin rounded-full border-[1.5px] border-[var(--color-yellow)] border-t-transparent" />
+  ) : (
+    <Circle className={`h-2 w-2 fill-current ${color}`} />
+  );
 }
 
 // ── Sortable Header ──
@@ -260,6 +266,7 @@ function ControllerRow({
 }) {
   const queryClient = useQueryClient();
   const isKilled = ctrl.config?.manual_kill_switch === true;
+  const isStopping = ctrl.status === "stopping";
 
   const toggleMutation = useMutation({
     mutationFn: () =>
@@ -341,15 +348,17 @@ function ControllerRow({
         <div className="flex items-center justify-center" onClick={(e) => e.stopPropagation()}>
           <button
             onClick={() => toggleMutation.mutate()}
-            disabled={toggleMutation.isPending}
+            disabled={toggleMutation.isPending || isStopping}
             className={`flex items-center gap-1 rounded px-2 py-1 text-xs font-medium transition-colors disabled:opacity-50 ${
-              isKilled
-                ? "text-[var(--color-green)] hover:bg-[var(--color-green)]/10"
-                : "text-[var(--color-yellow)] hover:bg-[var(--color-yellow)]/10"
+              isStopping
+                ? "text-[var(--color-yellow)]"
+                : isKilled
+                  ? "text-[var(--color-green)] hover:bg-[var(--color-green)]/10"
+                  : "text-[var(--color-yellow)] hover:bg-[var(--color-yellow)]/10"
             }`}
-            title={isKilled ? "Start controller" : "Pause controller"}
+            title={isStopping ? "Stopping..." : isKilled ? "Start controller" : "Pause controller"}
           >
-            {toggleMutation.isPending ? (
+            {toggleMutation.isPending || isStopping ? (
               <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
             ) : isKilled ? (
               <Play className="h-3.5 w-3.5" />
@@ -369,6 +378,7 @@ function BotRow({ bot, server }: { bot: BotSummary; server: string }) {
   const [showLogs, setShowLogs] = useState(false);
   const [confirmStop, setConfirmStop] = useState(false);
   const queryClient = useQueryClient();
+  const isStopping = bot.status === "stopping";
 
   const stopMutation = useMutation({
     mutationFn: () => api.stopBot(server, bot.bot_name),
@@ -416,7 +426,12 @@ function BotRow({ bot, server }: { bot: BotSummary; server: string }) {
         <span className="ml-auto text-[var(--color-text-muted)] tabular-nums">
           {formatUptime(bot.deployed_at)}
         </span>
-        {confirmStop ? (
+        {isStopping ? (
+            <div className="flex items-center gap-1.5 text-[var(--color-yellow)]" onClick={(e) => e.stopPropagation()}>
+              <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+              <span className="text-xs font-medium">Stopping</span>
+            </div>
+          ) : confirmStop ? (
             <div className="flex items-center gap-1.5" onClick={(e) => e.stopPropagation()}>
               <button
                 onClick={() => stopMutation.mutate()}
@@ -547,8 +562,18 @@ export function ActiveBotsTab() {
     }
   };
 
-  const controllers = data?.controllers ?? [];
   const bots = data?.bots ?? [];
+
+  // Deduplicate controllers by bot_name + controller_id (WS updates can cause duplicates)
+  const controllers = useMemo(() => {
+    const raw = data?.controllers ?? [];
+    const seen = new Map<string, ControllerInfo>();
+    for (const ctrl of raw) {
+      const key = `${ctrl.bot_name}:${ctrl.controller_id || ctrl.controller_name}`;
+      seen.set(key, ctrl); // last wins (most recent data)
+    }
+    return Array.from(seen.values());
+  }, [data?.controllers]);
 
   // Aggregate logs per bot for the overlay
   const sortedControllers = useMemo(
@@ -576,7 +601,7 @@ export function ActiveBotsTab() {
 
   const serverOnline = data?.server_online !== false;
   const errorHint = data?.error_hint;
-  const activeBots = bots.filter((b) => b.status === "running").length;
+  const activeBots = bots.filter((b) => b.status === "running" || b.status === "stopping").length;
 
   // Compute totals with currency conversion
   let totalPnl = 0;
@@ -625,6 +650,14 @@ export function ActiveBotsTab() {
           Deploy Bot
         </button>
       </div>
+
+      {/* Aggregated PnL chart */}
+      {perfHistory?.snapshots && perfHistory.snapshots.length > 0 && (
+        <AggregatedPnlChart
+          snapshots={perfHistory.snapshots}
+          currencySymbol={currencySymbol}
+        />
+      )}
 
       {isEmpty ? (
         <div className="flex flex-col items-center gap-2 py-16 text-[var(--color-text-muted)]">

--- a/frontend/src/pages/tabs/ActiveBotsTab.tsx
+++ b/frontend/src/pages/tabs/ActiveBotsTab.tsx
@@ -13,7 +13,7 @@ import {
   TrendingUp,
   Volume2,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { AggregatedPnlChart } from "@/components/bots/AggregatedPnlChart";
 import { ControllerBrowser } from "@/components/bots/ControllerBrowser";
@@ -255,6 +255,7 @@ function ControllerRow({
   formatPnlValue,
   formatValue,
   sparklineValues,
+  isBotStopping,
 }: {
   ctrl: ControllerInfo;
   server: string;
@@ -263,10 +264,11 @@ function ControllerRow({
   formatPnlValue: (val: number, quote: string) => string;
   formatValue: (val: number, quote: string) => string;
   sparklineValues?: number[];
+  isBotStopping?: boolean;
 }) {
   const queryClient = useQueryClient();
   const isKilled = ctrl.config?.manual_kill_switch === true;
-  const isStopping = ctrl.status === "stopping";
+  const isStopping = ctrl.status === "stopping" || (isBotStopping && !isKilled);
 
   const toggleMutation = useMutation({
     mutationFn: () =>
@@ -341,7 +343,7 @@ function ControllerRow({
       </td>
       <td className="px-4 py-2.5">
         <div className="flex items-center gap-1.5 justify-center">
-          <StatusDot status={isKilled ? "stopped" : ctrl.status} />
+          <StatusDot status={isKilled ? "stopped" : isStopping ? "stopping" : ctrl.status} />
         </div>
       </td>
       <td className="px-4 py-2.5">
@@ -374,17 +376,23 @@ function ControllerRow({
 
 // ── Bots Collapsible Section ──
 
-function BotRow({ bot, server }: { bot: BotSummary; server: string }) {
+function BotRow({ bot, server, onStopInitiated, onStopSettled }: { bot: BotSummary; server: string; onStopInitiated?: (botName: string) => void; onStopSettled?: (botName: string) => void }) {
   const [showLogs, setShowLogs] = useState(false);
   const [confirmStop, setConfirmStop] = useState(false);
   const queryClient = useQueryClient();
   const isStopping = bot.status === "stopping";
 
   const stopMutation = useMutation({
-    mutationFn: () => api.stopBot(server, bot.bot_name),
+    mutationFn: () => {
+      onStopInitiated?.(bot.bot_name);
+      return api.stopBot(server, bot.bot_name);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["bots", server] });
       setConfirmStop(false);
+    },
+    onSettled: () => {
+      onStopSettled?.(bot.bot_name);
     },
   });
 
@@ -472,7 +480,7 @@ function BotRow({ bot, server }: { bot: BotSummary; server: string }) {
   );
 }
 
-function BotsSection({ bots, server }: { bots: BotSummary[]; server: string }) {
+function BotsSection({ bots, server, onStopInitiated, onStopSettled }: { bots: BotSummary[]; server: string; onStopInitiated?: (botName: string) => void; onStopSettled?: (botName: string) => void }) {
   const [expanded, setExpanded] = useState(true);
   const Chevron = expanded ? ChevronDown : ChevronRight;
 
@@ -489,7 +497,7 @@ function BotsSection({ bots, server }: { bots: BotSummary[]; server: string }) {
       {expanded && (
         <div className="border-t border-[var(--color-border)] divide-y divide-[var(--color-border)]/30">
           {bots.map((bot) => (
-            <BotRow key={bot.bot_name} bot={bot} server={server} />
+            <BotRow key={bot.bot_name} bot={bot} server={server} onStopInitiated={onStopInitiated} onStopSettled={onStopSettled} />
           ))}
         </div>
       )}
@@ -507,6 +515,18 @@ export function ActiveBotsTab() {
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [showDeploy, setShowDeploy] = useState(false);
+  const [pendingStopBots, setPendingStopBots] = useState<Set<string>>(new Set());
+
+  const onStopInitiated = useCallback((botName: string) => {
+    setPendingStopBots((prev) => new Set(prev).add(botName));
+  }, []);
+  const onStopSettled = useCallback((botName: string) => {
+    setPendingStopBots((prev) => {
+      const next = new Set(prev);
+      next.delete(botName);
+      return next;
+    });
+  }, []);
 
   // Subscribe to real-time bots updates via WS
   useCondorWebSocket(BOTS_WS_CHANNELS, server);
@@ -518,26 +538,98 @@ export function ActiveBotsTab() {
     refetchInterval: 30000, // Slower polling since WS handles real-time updates
   });
 
+  // Compute earliest deploy time from active bots for filtering perf history
+  const earliestDeploy = useMemo(() => {
+    if (!data?.bots?.length) return undefined;
+    let earliest: number | undefined;
+    for (const bot of data.bots) {
+      if (bot.deployed_at) {
+        const ms = Date.parse(bot.deployed_at);
+        if (!isNaN(ms) && (earliest === undefined || ms < earliest)) earliest = ms;
+      }
+    }
+    return earliest ? new Date(earliest).toISOString() : undefined;
+  }, [data?.bots]);
+
   // Fetch performance history for sparklines (all controllers at once)
   const { data: perfHistory } = useQuery({
-    queryKey: ["controller-perf-history-all", server],
+    queryKey: ["controller-perf-history-all", server, earliestDeploy],
     queryFn: () =>
       api.getControllerPerformanceHistory(server!, {
         interval: "5m",
         limit: 1000,
+        start_time: earliestDeploy,
       }),
     enabled: !!server && (data?.controllers?.length ?? 0) > 0,
     refetchInterval: 120_000,
     staleTime: 60_000,
   });
 
+  const handleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("desc");
+    }
+  };
+
+  const bots = data?.bots ?? [];
+
+  // Track which bots are stopping (server-side status + optimistic pending mutations)
+  const stoppingBotNames = useMemo(() => {
+    const names = new Set(pendingStopBots);
+    for (const bot of bots) {
+      if (bot.status === "stopping") names.add(bot.bot_name);
+    }
+    return names;
+  }, [bots, pendingStopBots]);
+
+  // Deduplicate controllers by bot_name + controller_id (WS updates can cause duplicates)
+  const controllers = useMemo(() => {
+    const raw = data?.controllers ?? [];
+    const seen = new Map<string, ControllerInfo>();
+    for (const ctrl of raw) {
+      const key = `${ctrl.bot_name}:${ctrl.controller_id || ctrl.controller_name}`;
+      seen.set(key, ctrl); // last wins (most recent data)
+    }
+    return Array.from(seen.values());
+  }, [data?.controllers]);
+
+  const sortedControllers = useMemo(
+    () => [...controllers].sort((a, b) => compareControllers(a, b, sortKey, sortDir)),
+    [controllers, sortKey, sortDir],
+  );
+
+  // Filter performance snapshots to only active controllers and current run
+  const activeSnapshots = useMemo(() => {
+    if (!perfHistory?.snapshots || controllers.length === 0) return [];
+
+    // Build set of active controller IDs and their deploy times
+    const activeControllers = new Map<string, number>(); // id -> deployedAt ms
+    for (const ctrl of controllers) {
+      const cid = ctrl.controller_id || ctrl.controller_name;
+      const deployMs = ctrl.deployed_at ? Date.parse(ctrl.deployed_at) : 0;
+      activeControllers.set(cid, deployMs);
+    }
+
+    return perfHistory.snapshots.filter((snap) => {
+      const key = snap.controller_id || snap.controller_name;
+      if (!key || !activeControllers.has(key)) return false;
+      const deployMs = activeControllers.get(key)!;
+      if (!deployMs) return true; // no deploy time known, keep it
+      const snapMs = Date.parse(snap.timestamp) || 0;
+      return snapMs >= deployMs;
+    });
+  }, [perfHistory, controllers]);
+
   // Build a map: controller_id -> sorted pnl values for sparklines
   const sparklineMap = useMemo(() => {
     const map: Record<string, number[]> = {};
-    if (!perfHistory?.snapshots) return map;
+    if (activeSnapshots.length === 0) return map;
     // Group by controller_id
     const grouped: Record<string, ControllerPerformanceSnapshot[]> = {};
-    for (const snap of perfHistory.snapshots) {
+    for (const snap of activeSnapshots) {
       const key = snap.controller_id || snap.controller_name;
       if (!key) continue;
       (grouped[key] ??= []).push(snap);
@@ -551,35 +643,7 @@ export function ActiveBotsTab() {
       map[key] = sorted.map((s) => s.global_pnl_quote);
     }
     return map;
-  }, [perfHistory]);
-
-  const handleSort = (key: SortKey) => {
-    if (key === sortKey) {
-      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
-    } else {
-      setSortKey(key);
-      setSortDir("desc");
-    }
-  };
-
-  const bots = data?.bots ?? [];
-
-  // Deduplicate controllers by bot_name + controller_id (WS updates can cause duplicates)
-  const controllers = useMemo(() => {
-    const raw = data?.controllers ?? [];
-    const seen = new Map<string, ControllerInfo>();
-    for (const ctrl of raw) {
-      const key = `${ctrl.bot_name}:${ctrl.controller_id || ctrl.controller_name}`;
-      seen.set(key, ctrl); // last wins (most recent data)
-    }
-    return Array.from(seen.values());
-  }, [data?.controllers]);
-
-  // Aggregate logs per bot for the overlay
-  const sortedControllers = useMemo(
-    () => [...controllers].sort((a, b) => compareControllers(a, b, sortKey, sortDir)),
-    [controllers, sortKey, sortDir],
-  );
+  }, [activeSnapshots]);
 
   // Currency conversion
   const quoteCurrencies = useMemo(
@@ -652,9 +716,10 @@ export function ActiveBotsTab() {
       </div>
 
       {/* Aggregated PnL chart */}
-      {perfHistory?.snapshots && perfHistory.snapshots.length > 0 && (
+      {activeSnapshots.length > 0 && (
         <AggregatedPnlChart
-          snapshots={perfHistory.snapshots}
+          snapshots={activeSnapshots}
+          controllers={controllers}
           currencySymbol={currencySymbol}
         />
       )}
@@ -703,6 +768,7 @@ export function ActiveBotsTab() {
                           formatPnlValue={formatPnlValue}
                           formatValue={formatValue}
                           sparklineValues={sparklineMap[cid]}
+                          isBotStopping={stoppingBotNames.has(ctrl.bot_name)}
                         />
                       );
                     })}
@@ -713,7 +779,7 @@ export function ActiveBotsTab() {
           )}
 
           {/* Bots collapsible section */}
-          {bots.length > 0 && <BotsSection bots={bots} server={server} />}
+          {bots.length > 0 && <BotsSection bots={bots} server={server} onStopInitiated={onStopInitiated} onStopSettled={onStopSettled} />}
         </>
       )}
 

--- a/frontend/src/pages/tabs/ActiveBotsTab.tsx
+++ b/frontend/src/pages/tabs/ActiveBotsTab.tsx
@@ -18,36 +18,11 @@ import { useMemo, useState } from "react";
 import { ControllerBrowser } from "@/components/bots/ControllerBrowser";
 import { DeployBotDialog } from "@/components/bots/DeployBotDialog";
 
+import { useRates } from "@/hooks/useRates";
 import { useServer } from "@/hooks/useServer";
 import { useCondorWebSocket } from "@/hooks/useWebSocket";
 import { api, type BotLogEntry, type BotSummary, type ControllerInfo } from "@/lib/api";
-
-// ── Formatters ──
-
-function formatUsd(val: number) {
-  if (Math.abs(val) >= 1_000_000) return "$" + (val / 1_000_000).toFixed(2) + "M";
-  if (Math.abs(val) >= 10_000) return "$" + (val / 1_000).toFixed(1) + "K";
-  return val.toLocaleString("en-US", {
-    style: "currency",
-    currency: "USD",
-    minimumFractionDigits: 2,
-  });
-}
-
-function formatVolume(val: number) {
-  if (Math.abs(val) >= 1_000_000) return "$" + (val / 1_000_000).toFixed(1) + "M";
-  if (Math.abs(val) >= 1_000) return "$" + (val / 1_000).toFixed(1) + "K";
-  return "$" + val.toFixed(0);
-}
-
-function formatPnl(val: number) {
-  const prefix = val >= 0 ? "+" : "";
-  return prefix + formatUsd(val);
-}
-
-function pnlColor(val: number) {
-  return val >= 0 ? "var(--color-green)" : "var(--color-red)";
-}
+import { formatCurrencyVolume, pnlColor } from "@/lib/formatters";
 
 function formatUptime(deployedAt: string | null): string {
   if (!deployedAt) return "—";
@@ -270,11 +245,15 @@ function ControllerRow({
   server,
   isSelected,
   onSelect,
+  formatPnlValue,
+  formatValue,
 }: {
   ctrl: ControllerInfo;
   server: string;
   isSelected: boolean;
   onSelect: () => void;
+  formatPnlValue: (val: number, quote: string) => string;
+  formatValue: (val: number, quote: string) => string;
 }) {
   const queryClient = useQueryClient();
   const isKilled = ctrl.config?.manual_kill_switch === true;
@@ -310,27 +289,34 @@ function ControllerRow({
         {ctrl.connector || "—"}
       </td>
       <td className="px-4 py-2.5 text-sm">{ctrl.trading_pair || "—"}</td>
-      <td
-        className="px-4 py-2.5 text-sm text-right tabular-nums font-medium"
-        style={{ color: pnlColor(ctrl.realized_pnl_quote) }}
-      >
-        {formatPnl(ctrl.realized_pnl_quote)}
-      </td>
-      <td
-        className="px-4 py-2.5 text-sm text-right tabular-nums font-medium"
-        style={{ color: pnlColor(ctrl.unrealized_pnl_quote) }}
-      >
-        {formatPnl(ctrl.unrealized_pnl_quote)}
-      </td>
-      <td
-        className="px-4 py-2.5 text-sm text-right tabular-nums font-medium"
-        style={{ color: pnlColor(ctrl.global_pnl_quote) }}
-      >
-        {formatPnl(ctrl.global_pnl_quote)}
-      </td>
-      <td className="px-4 py-2.5 text-sm text-right tabular-nums text-[var(--color-text-muted)]">
-        {formatVolume(ctrl.volume_traded)}
-      </td>
+      {(() => {
+        const quote = ctrl.trading_pair?.split("-")[1] || "USDT";
+        return (
+          <>
+            <td
+              className="px-4 py-2.5 text-sm text-right tabular-nums font-medium"
+              style={{ color: pnlColor(ctrl.realized_pnl_quote) }}
+            >
+              {formatPnlValue(ctrl.realized_pnl_quote, quote)}
+            </td>
+            <td
+              className="px-4 py-2.5 text-sm text-right tabular-nums font-medium"
+              style={{ color: pnlColor(ctrl.unrealized_pnl_quote) }}
+            >
+              {formatPnlValue(ctrl.unrealized_pnl_quote, quote)}
+            </td>
+            <td
+              className="px-4 py-2.5 text-sm text-right tabular-nums font-medium"
+              style={{ color: pnlColor(ctrl.global_pnl_quote) }}
+            >
+              {formatPnlValue(ctrl.global_pnl_quote, quote)}
+            </td>
+            <td className="px-4 py-2.5 text-sm text-right tabular-nums text-[var(--color-text-muted)]">
+              {formatValue(ctrl.volume_traded, quote)}
+            </td>
+          </>
+        );
+      })()}
       <td className="px-4 py-2.5 text-sm text-right tabular-nums text-[var(--color-text-muted)]">
         {formatUptime(ctrl.deployed_at)}
       </td>
@@ -534,6 +520,13 @@ export function ActiveBotsTab() {
     [controllers, sortKey, sortDir],
   );
 
+  // Currency conversion
+  const quoteCurrencies = useMemo(
+    () => controllers.map((c) => c.trading_pair?.split("-")[1] || "USDT"),
+    [controllers],
+  );
+  const { convert, formatPnlValue, formatValue, currencySymbol } = useRates(quoteCurrencies);
+
   if (!server) {
     return <p className="text-[var(--color-text-muted)]">Select a server</p>;
   }
@@ -547,9 +540,16 @@ export function ActiveBotsTab() {
 
   const serverOnline = data?.server_online !== false;
   const errorHint = data?.error_hint;
-  const totalPnl = data?.total_pnl ?? 0;
-  const totalVolume = data?.total_volume ?? 0;
   const activeBots = bots.filter((b) => b.status === "running").length;
+
+  // Compute totals with currency conversion
+  let totalPnl = 0;
+  let totalVolume = 0;
+  for (const ctrl of controllers) {
+    const quote = ctrl.trading_pair?.split("-")[1] || "USDT";
+    totalPnl += convert(ctrl.global_pnl_quote, quote).value;
+    totalVolume += convert(ctrl.volume_traded, quote).value;
+  }
 
   const isEmpty = controllers.length === 0 && bots.length === 0;
 
@@ -574,11 +574,11 @@ export function ActiveBotsTab() {
       <div className="grid grid-cols-2 gap-3 lg:grid-cols-[1fr_1fr_1fr_1fr_auto]">
         <StatCard
           label="Total PnL"
-          value={formatPnl(totalPnl)}
+          value={(totalPnl >= 0 ? "+" : "") + formatCurrencyVolume(totalPnl, currencySymbol)}
           icon={TrendingUp}
           valueColor={pnlColor(totalPnl)}
         />
-        <StatCard label="Volume" value={formatVolume(totalVolume)} icon={Volume2} />
+        <StatCard label="Volume" value={formatCurrencyVolume(totalVolume, currencySymbol)} icon={Volume2} />
         <StatCard label="Active Bots" value={String(activeBots)} icon={Bot} />
         <StatCard label="Controllers" value={String(controllers.length)} icon={Layers} />
         <button
@@ -626,6 +626,8 @@ export function ActiveBotsTab() {
                         server={server!}
                         isSelected={selectedKey === `${ctrl.bot_name}-${ctrl.controller_name}`}
                         onSelect={() => setSelectedKey(`${ctrl.bot_name}-${ctrl.controller_name}`)}
+                        formatPnlValue={formatPnlValue}
+                        formatValue={formatValue}
                       />
                     ))}
                   </tbody>

--- a/frontend/src/pages/tabs/BacktestingTab.tsx
+++ b/frontend/src/pages/tabs/BacktestingTab.tsx
@@ -166,7 +166,7 @@ function BacktestChart({ data }: { data: BacktestData }) {
 
   useEffect(() => {
     if (!priceRef.current || data.candles.length === 0) return;
-    const isDark = theme === "dark";
+    const isDark = theme !== "light";
     let ro: ResizeObserver | undefined;
     let isSyncing = false;
 

--- a/frontend/src/pages/tabs/BotRunsTab.tsx
+++ b/frontend/src/pages/tabs/BotRunsTab.tsx
@@ -1,0 +1,365 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Circle, Database, Filter, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { useServer } from "@/hooks/useServer";
+import { api, type BotRunInfo } from "@/lib/api";
+
+function formatTimestamp(ts: string | null): string {
+  if (!ts) return "—";
+  try {
+    const d = new Date(ts);
+    return d.toLocaleString("en-US", {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+  } catch {
+    return ts;
+  }
+}
+
+function formatDuration(start: string | null, end: string | null): string {
+  if (!start) return "—";
+  const startMs = new Date(start).getTime();
+  const endMs = end ? new Date(end).getTime() : Date.now();
+  const diffMs = endMs - startMs;
+  if (diffMs < 0) return "—";
+  const days = Math.floor(diffMs / 86400000);
+  const hours = Math.floor((diffMs % 86400000) / 3600000);
+  const mins = Math.floor((diffMs % 3600000) / 60000);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
+
+function formatPnl(value: number): string {
+  if (value === 0) return "—";
+  const sign = value >= 0 ? "+" : "";
+  return `${sign}$${Math.abs(value).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function formatVolume(value: number): string {
+  if (value === 0) return "—";
+  return `$${value.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  RUNNING: "text-[var(--color-green)]",
+  CREATED: "text-[var(--color-yellow)]",
+  STOPPED: "text-[var(--color-text-muted)]",
+  ERROR: "text-[var(--color-red)]",
+};
+
+const DEPLOYMENT_COLORS: Record<string, string> = {
+  DEPLOYED: "bg-[var(--color-green)]/15 text-[var(--color-green)]",
+  ARCHIVED: "bg-[var(--color-text-muted)]/15 text-[var(--color-text-muted)]",
+  FAILED: "bg-[var(--color-red)]/15 text-[var(--color-red)]",
+};
+
+function StatusDot({ status }: { status: string }) {
+  const color = STATUS_COLORS[status] ?? "text-[var(--color-text-muted)]";
+  return <Circle className={`h-2 w-2 fill-current ${color}`} />;
+}
+
+type FilterStatus = "ALL" | "RUNNING" | "STOPPED" | "ARCHIVED";
+
+export function BotRunsTab() {
+  const { server } = useServer();
+  const [filter, setFilter] = useState<FilterStatus>("ALL");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["bot-runs", server],
+    queryFn: () => api.getBotRuns(server!, { limit: 200 }),
+    enabled: !!server,
+    refetchInterval: 30_000,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (botName: string) => api.deleteBotRun(server!, botName),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["bot-runs", server] });
+    },
+  });
+
+  const runs = data?.runs ?? [];
+
+  const filtered = useMemo(() => {
+    if (filter === "ALL") return runs;
+    if (filter === "RUNNING") return runs.filter((r) => r.run_status === "RUNNING");
+    if (filter === "STOPPED") return runs.filter((r) => r.run_status === "STOPPED" && r.deployment_status !== "ARCHIVED");
+    if (filter === "ARCHIVED") return runs.filter((r) => r.deployment_status === "ARCHIVED");
+    return runs;
+  }, [runs, filter]);
+
+  const counts = useMemo(() => {
+    const c = { ALL: runs.length, RUNNING: 0, STOPPED: 0, ARCHIVED: 0 };
+    for (const r of runs) {
+      if (r.run_status === "RUNNING") c.RUNNING++;
+      else if (r.deployment_status === "ARCHIVED") c.ARCHIVED++;
+      else c.STOPPED++;
+    }
+    return c;
+  }, [runs]);
+
+  const archivedInView = useMemo(
+    () => filtered.filter((r) => r.deployment_status === "ARCHIVED"),
+    [filtered],
+  );
+
+  const allArchivedSelected = archivedInView.length > 0 && archivedInView.every((r) => selected.has(r.bot_name));
+
+  const toggleSelect = (botName: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(botName)) next.delete(botName);
+      else next.add(botName);
+      return next;
+    });
+  };
+
+  const toggleSelectAll = () => {
+    if (allArchivedSelected) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(archivedInView.map((r) => r.bot_name)));
+    }
+  };
+
+  const handleDelete = async (botName: string) => {
+    setDeleting(botName);
+    try {
+      await deleteMutation.mutateAsync(botName);
+      setSelected((prev) => {
+        const next = new Set(prev);
+        next.delete(botName);
+        return next;
+      });
+    } finally {
+      setDeleting(null);
+    }
+  };
+
+  const handleBulkDelete = async () => {
+    const toDelete = [...selected].filter((name) =>
+      runs.find((r) => r.bot_name === name && r.deployment_status === "ARCHIVED"),
+    );
+    if (toDelete.length === 0) return;
+    if (!confirm(`Delete ${toDelete.length} archived bot run(s)?`)) return;
+
+    for (const name of toDelete) {
+      setDeleting(name);
+      try {
+        await deleteMutation.mutateAsync(name);
+      } catch {
+        // continue with remaining
+      }
+    }
+    setSelected(new Set());
+    setDeleting(null);
+  };
+
+  if (!server) {
+    return <p className="text-[var(--color-text-muted)]">Select a server</p>;
+  }
+
+  if (isLoading) return <p className="text-[var(--color-text-muted)]">Loading...</p>;
+  if (error) {
+    return (
+      <p className="text-[var(--color-red)]">
+        {error instanceof Error ? error.message : "Error loading bot runs"}
+      </p>
+    );
+  }
+
+  if (runs.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-2 py-16 text-[var(--color-text-muted)]">
+        <Database className="h-10 w-10" />
+        <p>No bot runs found</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Filters + bulk actions */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Filter className="h-3.5 w-3.5 text-[var(--color-text-muted)]" />
+          {(["ALL", "RUNNING", "STOPPED", "ARCHIVED"] as const).map((f) => (
+            <button
+              key={f}
+              onClick={() => setFilter(f)}
+              className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                filter === f
+                  ? "bg-[var(--color-primary)]/15 text-[var(--color-primary)]"
+                  : "text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+              }`}
+            >
+              {f.charAt(0) + f.slice(1).toLowerCase()} ({counts[f]})
+            </button>
+          ))}
+        </div>
+
+        {selected.size > 0 && (
+          <button
+            onClick={handleBulkDelete}
+            disabled={deleting !== null}
+            className="flex items-center gap-1.5 rounded-md bg-[var(--color-red)]/10 px-3 py-1.5 text-xs font-medium text-[var(--color-red)] hover:bg-[var(--color-red)]/20 transition-colors disabled:opacity-50"
+          >
+            <Trash2 className="h-3 w-3" />
+            Delete {selected.size} selected
+          </button>
+        )}
+      </div>
+
+      {/* Table */}
+      <div className="overflow-hidden rounded-lg border border-[var(--color-border)]">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+                <th className="w-8 px-2 py-3">
+                  {archivedInView.length > 0 && (
+                    <input
+                      type="checkbox"
+                      checked={allArchivedSelected}
+                      onChange={toggleSelectAll}
+                      className="rounded border-[var(--color-border)] accent-[var(--color-primary)]"
+                    />
+                  )}
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+                  Bot Name
+                </th>
+                <th className="px-4 py-3 text-center text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+                  Status
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+                  PnL
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+                  Volume
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+                  Started
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
+                  Duration
+                </th>
+                <th className="w-10 px-2 py-3" />
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((run, i) => (
+                <BotRunRow
+                  key={`${run.bot_name}-${run.created_at}-${i}`}
+                  run={run}
+                  isSelected={selected.has(run.bot_name)}
+                  isDeleting={deleting === run.bot_name}
+                  onToggleSelect={() => toggleSelect(run.bot_name)}
+                  onDelete={() => handleDelete(run.bot_name)}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BotRunRow({
+  run,
+  isSelected,
+  isDeleting,
+  onToggleSelect,
+  onDelete,
+}: {
+  run: BotRunInfo;
+  isSelected: boolean;
+  isDeleting: boolean;
+  onToggleSelect: () => void;
+  onDelete: () => void;
+}) {
+  const deplClass = DEPLOYMENT_COLORS[run.deployment_status] ?? "bg-[var(--color-surface)] text-[var(--color-text-muted)]";
+  const isArchived = run.deployment_status === "ARCHIVED";
+  const pnl = run.global_pnl_quote;
+  const pnlColor = pnl > 0 ? "text-[var(--color-green)]" : pnl < 0 ? "text-[var(--color-red)]" : "text-[var(--color-text-muted)]";
+
+  return (
+    <tr className={`border-b border-[var(--color-border)]/30 transition-colors ${isDeleting ? "opacity-40" : "hover:bg-[var(--color-surface-hover)]/50"}`}>
+      <td className="w-8 px-2 py-2.5">
+        {isArchived && (
+          <input
+            type="checkbox"
+            checked={isSelected}
+            onChange={onToggleSelect}
+            disabled={isDeleting}
+            className="rounded border-[var(--color-border)] accent-[var(--color-primary)]"
+          />
+        )}
+      </td>
+      <td className="px-4 py-2.5">
+        <div>
+          <span className="font-medium">{run.bot_name}</span>
+          {run.num_controllers > 0 && (
+            <span className="ml-2 text-[10px] text-[var(--color-text-muted)]">
+              {run.num_controllers} ctrl{run.num_controllers > 1 ? "s" : ""}
+            </span>
+          )}
+        </div>
+        <div className="text-[11px] text-[var(--color-text-muted)]">
+          {run.account_name || "—"}
+        </div>
+      </td>
+      <td className="px-4 py-2.5">
+        <div className="flex flex-col items-center gap-1">
+          <div className="flex items-center gap-1.5">
+            <StatusDot status={run.run_status} />
+            <span className="text-xs capitalize">
+              {run.run_status?.toLowerCase() || "—"}
+            </span>
+          </div>
+          {run.deployment_status && (
+            <span className={`inline-flex rounded-full px-2 py-0.5 text-[10px] font-medium ${deplClass}`}>
+              {run.deployment_status}
+            </span>
+          )}
+        </div>
+      </td>
+      <td className={`px-4 py-2.5 text-right tabular-nums font-medium ${pnlColor}`}>
+        {formatPnl(pnl)}
+      </td>
+      <td className="px-4 py-2.5 text-right text-[var(--color-text-muted)] tabular-nums">
+        {formatVolume(run.volume_traded)}
+      </td>
+      <td className="px-4 py-2.5 text-right text-[var(--color-text-muted)] tabular-nums">
+        {formatTimestamp(run.created_at)}
+      </td>
+      <td className="px-4 py-2.5 text-right tabular-nums">
+        {formatDuration(run.created_at, run.stopped_at)}
+      </td>
+      <td className="w-10 px-2 py-2.5">
+        {isArchived && !isDeleting && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              if (confirm(`Delete "${run.bot_name}"?`)) onDelete();
+            }}
+            className="rounded p-1 text-[var(--color-text-muted)] hover:text-[var(--color-red)] hover:bg-[var(--color-red)]/10 transition-colors"
+            title="Delete bot run"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/pages/tabs/BotRunsTab.tsx
+++ b/frontend/src/pages/tabs/BotRunsTab.tsx
@@ -81,7 +81,7 @@ export function BotRunsTab() {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: (botName: string) => api.deleteBotRun(server!, botName),
+    mutationFn: (botRunId: number) => api.deleteBotRun(server!, botRunId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["bot-runs", server] });
     },
@@ -131,13 +131,14 @@ export function BotRunsTab() {
     }
   };
 
-  const handleDelete = async (botName: string) => {
-    setDeleting(botName);
+  const handleDelete = async (run: BotRunInfo) => {
+    if (!run.bot_run_id) return;
+    setDeleting(run.bot_name);
     try {
-      await deleteMutation.mutateAsync(botName);
+      await deleteMutation.mutateAsync(run.bot_run_id);
       setSelected((prev) => {
         const next = new Set(prev);
-        next.delete(botName);
+        next.delete(run.bot_name);
         return next;
       });
     } finally {
@@ -146,16 +147,16 @@ export function BotRunsTab() {
   };
 
   const handleBulkDelete = async () => {
-    const toDelete = [...selected].filter((name) =>
-      runs.find((r) => r.bot_name === name && r.deployment_status === "ARCHIVED"),
+    const toDelete = runs.filter(
+      (r) => selected.has(r.bot_name) && r.deployment_status === "ARCHIVED" && r.bot_run_id,
     );
     if (toDelete.length === 0) return;
     if (!confirm(`Delete ${toDelete.length} archived bot run(s)?`)) return;
 
-    for (const name of toDelete) {
-      setDeleting(name);
+    for (const run of toDelete) {
+      setDeleting(run.bot_name);
       try {
-        await deleteMutation.mutateAsync(name);
+        await deleteMutation.mutateAsync(run.bot_run_id!);
       } catch {
         // continue with remaining
       }
@@ -264,7 +265,7 @@ export function BotRunsTab() {
                   isSelected={selected.has(run.bot_name)}
                   isDeleting={deleting === run.bot_name}
                   onToggleSelect={() => toggleSelect(run.bot_name)}
-                  onDelete={() => handleDelete(run.bot_name)}
+                  onDelete={() => handleDelete(run)}
                 />
               ))}
             </tbody>

--- a/handlers/agents/__init__.py
+++ b/handlers/agents/__init__.py
@@ -277,6 +277,11 @@ async def _handle_set_llm(
         return
 
     context.user_data["agent_llm"] = llm_key
+
+    # Destroy existing session so the next interaction uses the new LLM
+    chat_id = update.effective_chat.id
+    await destroy_session(chat_id)
+
     label = AGENT_OPTIONS[llm_key]["label"]
     await query.message.edit_text(
         f"LLM set to {label}. New sessions will use this model.\n\n"
@@ -356,6 +361,9 @@ async def _handle_openrouter_pick(
     model = models[idx]
     agent_key = f"openrouter:{model.slug}"
     context.user_data["agent_llm"] = agent_key
+
+    # Destroy existing session so the next interaction uses the new LLM
+    await destroy_session(update.effective_chat.id)
 
     pricing = ""
     if model.prompt_price or model.completion_price:
@@ -453,6 +461,10 @@ async def _handle_openrouter_type_confirm(
         return
 
     context.user_data["agent_llm"] = f"openrouter:{slug}"
+
+    # Destroy existing session so the next interaction uses the new LLM
+    await destroy_session(update.effective_chat.id)
+
     await query.message.edit_text(
         f"LLM set to OpenRouter — {slug}.\n\n"
         "New sessions will use this model. Use /agent to continue."

--- a/handlers/agents/_shared.py
+++ b/handlers/agents/_shared.py
@@ -458,7 +458,6 @@ def build_initial_context(user_id: int, chat_id: int | str, user_data: dict | No
                 "mcp__condor__trading_agent_journal_write",
                 "mcp__condor__send_notification",
                 "mcp__condor__manage_notes",
-                "mcp__condor__manage_skills",
             ]
             tool_preload_hint = (
                 "IMPORTANT: At the very start of the session (before your first response), "

--- a/handlers/agents/_shared.py
+++ b/handlers/agents/_shared.py
@@ -99,9 +99,9 @@ DEFAULT_MODE = "condor"
 
 def reload_assistants() -> None:
     """Re-scan assistants/ folder. Call after adding/removing .md files."""
-    global AGENT_MODES
     _assistant_cache.clear()
-    AGENT_MODES = discover_assistants()
+    AGENT_MODES.clear()
+    AGENT_MODES.update(discover_assistants())
 
 
 # -- Mode context builders --

--- a/handlers/agents/_shared.py
+++ b/handlers/agents/_shared.py
@@ -287,6 +287,7 @@ def _condor_mcp_args(
 def build_mcp_servers_for_session(
     user_id: int, chat_id: int | str, user_data: dict | None = None,
     execution_mode: str = "loop",
+    server_name: str | None = None,
 ) -> list[dict[str, Any]]:
     """Build dynamic MCP server configs for an agent session.
 
@@ -299,8 +300,9 @@ def build_mcp_servers_for_session(
 
     cm = get_config_manager()
 
-    # Resolve which hummingbot server to use (respects user preferences)
-    server_name = get_effective_server(chat_id, user_data)
+    # Resolve which hummingbot server to use (explicit override > user preferences)
+    if not server_name:
+        server_name = get_effective_server(chat_id, user_data)
     if not server_name:
         accessible = cm.get_accessible_servers(user_id)
         server_name = accessible[0] if accessible else None
@@ -397,7 +399,7 @@ def build_mcp_servers_for_agent(
     return [mcp_hummingbot, condor]
 
 
-def build_initial_context(user_id: int, chat_id: int | str, user_data: dict | None = None, agent_key: str | None = None, platform: str = "telegram") -> str:
+def build_initial_context(user_id: int, chat_id: int | str, user_data: dict | None = None, agent_key: str | None = None, platform: str = "telegram", server_name: str | None = None) -> str:
     """Build an initial context prompt telling the agent about server, permissions, and formatting rules."""
     from config_manager import ServerPermission, get_config_manager, get_effective_server
     from condor.acp.pydantic_ai_client import is_pydantic_ai_model
@@ -408,8 +410,8 @@ def build_initial_context(user_id: int, chat_id: int | str, user_data: dict | No
     system_prompt = _build_system_prompt(platform)
     sections: list[str] = [system_prompt]
 
-    # Resolve active server (respects user preferences)
-    active_name = get_effective_server(chat_id, user_data)
+    # Resolve active server (explicit override > user preferences)
+    active_name = server_name or get_effective_server(chat_id, user_data)
     accessible = cm.get_accessible_servers(user_id)
     if not active_name:
         active_name = accessible[0] if accessible else None

--- a/handlers/agents/session.py
+++ b/handlers/agents/session.py
@@ -42,6 +42,7 @@ class AgentSession:
     is_busy: bool = False
     pending_context: str | None = None  # Lazy context: injected on first prompt
     _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    _abort_event: asyncio.Event = field(default_factory=asyncio.Event)
 
     async def prompt_stream(self, text: str):
         """Stream a prompt, managing the busy flag and lock.
@@ -55,6 +56,9 @@ class AgentSession:
             ctx = self.pending_context
             self.pending_context = None
             text = f"{ctx}\n\n---\n\nUser message:\n{text}"
+
+        # Clear abort flag for this new prompt
+        self._abort_event.clear()
 
         # Acquire lock with timeout -- prevents infinite wait when previous prompt is stuck
         try:
@@ -71,6 +75,10 @@ class AgentSession:
             loop = asyncio.get_event_loop()
             deadline = loop.time() + PROMPT_OVERALL_TIMEOUT
             async for event in self.client.prompt_stream(text):
+                # Check if abort was requested between events
+                if self._abort_event.is_set():
+                    yield PromptDone(stop_reason="cancelled")
+                    break
                 yield event
                 if isinstance(event, PromptDone):
                     break
@@ -89,19 +97,15 @@ class AgentSession:
     def abort(self) -> None:
         """Abort the current in-flight prompt.
 
-        Cancels the ACP-level request future and drains the event queue so
-        the next prompt_stream call starts clean. Also resets is_busy and
-        releases the lock if held.
+        Sets the abort event so prompt_stream breaks out on the next iteration,
+        which triggers its finally block to properly release the lock.
+        Also cancels the ACP-level request future and drains the event queue
+        so the next prompt starts clean.
         """
+        # Signal prompt_stream to stop iterating
+        self._abort_event.set()
         if isinstance(self.client, ACPClient):
             self.client.abort_prompt()
-        if self.is_busy:
-            self.is_busy = False
-            if self._lock.locked():
-                try:
-                    self._lock.release()
-                except RuntimeError:
-                    pass  # lock not held by this task
         log.info("Session %s: prompt aborted", self.chat_id)
 
 

--- a/handlers/agents/session.py
+++ b/handlers/agents/session.py
@@ -86,6 +86,24 @@ class AgentSession:
             self.is_busy = False
             self._lock.release()
 
+    def abort(self) -> None:
+        """Abort the current in-flight prompt.
+
+        Cancels the ACP-level request future and drains the event queue so
+        the next prompt_stream call starts clean. Also resets is_busy and
+        releases the lock if held.
+        """
+        if isinstance(self.client, ACPClient):
+            self.client.abort_prompt()
+        if self.is_busy:
+            self.is_busy = False
+            if self._lock.locked():
+                try:
+                    self._lock.release()
+                except RuntimeError:
+                    pass  # lock not held by this task
+        log.info("Session %s: prompt aborted", self.chat_id)
+
 
 async def get_or_create_session(
     chat_id: int | str,

--- a/handlers/agents/session.py
+++ b/handlers/agents/session.py
@@ -38,6 +38,7 @@ class AgentSession:
     agent_key: str  # "claude-code", "gemini", "codex", "copilot", "ollama:model", "lmstudio:model", etc.
     client: ACPClient | PydanticAIClient
     mode: str = "condor"  # "condor", "agent_builder"
+    server_name: str | None = None  # Which Condor server this session uses
     is_busy: bool = False
     pending_context: str | None = None  # Lazy context: injected on first prompt
     _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
@@ -95,6 +96,7 @@ async def get_or_create_session(
     mode: str = "condor",
     platform: str = "telegram",
     lazy_context: bool = False,
+    server_name: str | None = None,
 ) -> AgentSession:
     """Get existing session or create a new one.
 
@@ -120,7 +122,7 @@ async def get_or_create_session(
     # Build dynamic MCP servers from user's Condor permissions
     mcp_servers: list[dict] = []
     if user_id:
-        mcp_servers = build_mcp_servers_for_session(user_id, chat_id, user_data)
+        mcp_servers = build_mcp_servers_for_session(user_id, chat_id, user_data, server_name=server_name)
 
     # Check if agent_key requires PydanticAI client (ollama, lmstudio, openai, etc.)
     use_pydantic_ai = is_pydantic_ai_model(agent_key)
@@ -162,7 +164,16 @@ async def get_or_create_session(
         # Build initial context about server and permissions
         initial_context = ""
         if user_id:
-            initial_context = build_initial_context(user_id, chat_id, user_data, agent_key=agent_key, platform=platform)
+            initial_context = build_initial_context(user_id, chat_id, user_data, agent_key=agent_key, platform=platform, server_name=server_name)
+        # Resolve the server name that was actually used for this session
+        resolved_server = server_name
+        if not resolved_server and user_id:
+            from config_manager import get_config_manager, get_effective_server
+            resolved_server = get_effective_server(chat_id, user_data)
+            if not resolved_server:
+                cm = get_config_manager()
+                accessible = cm.get_accessible_servers(user_id)
+                resolved_server = accessible[0] if accessible else None
 
         if initial_context and not lazy_context:
             # Eager: send context now (blocks until agent processes it)
@@ -177,6 +188,7 @@ async def get_or_create_session(
             agent_key=agent_key,
             client=client,
             mode=mode,
+            server_name=resolved_server,
             pending_context=initial_context or None,
         )
     except Exception:

--- a/handlers/bots/_shared.py
+++ b/handlers/bots/_shared.py
@@ -180,6 +180,16 @@ def set_controller_config(context, config: Dict[str, Any]) -> None:
     context.user_data["controller_config_params"] = config
 
 
+def clean_config_for_save(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Strip internal fields (e.g. _config_name) before saving to backend.
+
+    The backend adds _config_name to YAML files, but Pydantic models with
+    extra='forbid' reject it on reload. Strip any underscore-prefixed keys
+    that aren't part of the controller config schema.
+    """
+    return {k: v for k, v in config.items() if not k.startswith("_")}
+
+
 def init_new_controller_config(
     context, controller_type: str = "grid_strike"
 ) -> Dict[str, Any]:

--- a/handlers/bots/controller_handlers.py
+++ b/handlers/bots/controller_handlers.py
@@ -43,6 +43,7 @@ from ._shared import (
     SIDE_LONG,
     SIDE_SHORT,
     calculate_auto_prices,
+    clean_config_for_save,
     clear_bots_state,
     fetch_candles,
     fetch_current_price,
@@ -1098,7 +1099,7 @@ async def handle_cfg_edit_save(
 
     try:
         client, _ = await get_bots_client(chat_id, context.user_data)
-        await client.controllers.create_or_update_controller_config(config_id, config)
+        await client.controllers.create_or_update_controller_config(config_id, clean_config_for_save(config))
         await query.answer()
 
         # Remove from modified since it's now saved
@@ -1145,7 +1146,7 @@ async def handle_cfg_edit_save_all(
     for config_id, config in modified.items():
         try:
             await client.controllers.create_or_update_controller_config(
-                config_id, config
+                config_id, clean_config_for_save(config)
             )
             saved.append(config_id)
         except Exception as e:
@@ -2923,7 +2924,7 @@ async def handle_gs_save(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     try:
         client, _ = await get_bots_client(chat_id, context.user_data)
         result = await client.controllers.create_or_update_controller_config(
-            config_id, config
+            config_id, clean_config_for_save(config)
         )
 
         # Clean up wizard state
@@ -4801,7 +4802,7 @@ async def handle_save_config(
         # Save to backend using config id as the config_name
         config_name = config.get("id", "")
         result = await client.controllers.create_or_update_controller_config(
-            config_name, config
+            config_name, clean_config_for_save(config)
         )
 
         # Clear state
@@ -6990,7 +6991,7 @@ async def handle_pmm_save(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         client, _ = await get_bots_client(chat_id, context.user_data)
         config_id = config.get("id", "")
         result = await client.controllers.create_or_update_controller_config(
-            config_id, config
+            config_id, clean_config_for_save(config)
         )
 
         if result.get("status") == "success" or "success" in str(result).lower():
@@ -8366,7 +8367,7 @@ async def handle_pv1_save(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         client, _ = await get_bots_client(chat_id, context.user_data)
         config_id = config.get("id", "")
         result = await client.controllers.create_or_update_controller_config(
-            config_id, config
+            config_id, clean_config_for_save(config)
         )
 
         if result.get("status") == "success" or "success" in str(result).lower():
@@ -8940,7 +8941,7 @@ async def handle_config_file_upload(
         # Save to backend
         client, _ = await get_bots_client(chat_id, context.user_data)
         result = await client.controllers.create_or_update_controller_config(
-            config_id, config
+            config_id, clean_config_for_save(config)
         )
 
         # Clear state

--- a/handlers/routines/__init__.py
+++ b/handlers/routines/__init__.py
@@ -103,6 +103,19 @@ def _generate_instance_id() -> str:
     return hashlib.md5(f"{time.time()}{id(object())}".encode()).hexdigest()[:6]
 
 
+def _sync_instance_to_store(instance_id: str, inst_meta: dict) -> None:
+    """Sync a Telegram instance's state to the shared RoutineStore."""
+    try:
+        store = get_routine_store()
+        existing = store._instances.get(instance_id)
+        if existing:
+            existing.update(inst_meta)
+        else:
+            store.add_instance(instance_id, inst_meta.copy())
+    except Exception:
+        pass
+
+
 # =============================================================================
 # Formatting Helpers
 # =============================================================================
@@ -330,6 +343,10 @@ async def _run_continuous_routine(
     instances = application.user_data.get(chat_id, {}).get("routine_instances", {})
     if instance_id in instances:
         del instances[instance_id]
+    try:
+        get_routine_store().remove_instance(instance_id)
+    except Exception:
+        pass
 
 
 async def _interval_job_callback(context: CallbackContext) -> None:
@@ -366,6 +383,9 @@ async def _interval_job_callback(context: CallbackContext) -> None:
     instances[instance_id]["last_duration"] = duration
     run_count = instances[instance_id].get("run_count", 0) + 1
     instances[instance_id]["run_count"] = run_count
+
+    # Sync to shared store
+    _sync_instance_to_store(instance_id, instances[instance_id])
 
     # Send result message for scheduled one-shot routines
     schedule = instances[instance_id].get("schedule", {})
@@ -415,6 +435,10 @@ async def _oneshot_job_callback(context: CallbackContext) -> None:
     )
     if instance_id in instances:
         del instances[instance_id]
+        try:
+            get_routine_store().remove_instance(instance_id)
+        except Exception:
+            pass
 
     if background:
         # Send result as new message
@@ -467,6 +491,8 @@ async def _daily_job_callback(context: CallbackContext) -> None:
         instances[instance_id]["run_count"] = (
             instances[instance_id].get("run_count", 0) + 1
         )
+        # Sync to shared store
+        _sync_instance_to_store(instance_id, instances[instance_id])
 
     # Send notification
     icon = "✅" if not result.startswith("Error") else "❌"
@@ -596,17 +622,25 @@ def _create_continuous_instance(
 
     # Store instance
     instances = _get_instances(context)
-    instances[instance_id] = {
+    inst_meta = {
         "routine_name": routine_name,
         "config": config_dict.copy(),
         "schedule": {"type": "continuous"},
         "status": "running",
+        "source": "telegram",
         "created_at": time.time(),
         "last_run_at": None,
         "last_result": None,
         "last_duration": None,
         "run_count": 0,
     }
+    instances[instance_id] = inst_meta
+
+    # Sync to shared store for web/MCP visibility
+    try:
+        get_routine_store().add_instance(instance_id, inst_meta.copy())
+    except Exception:
+        pass
 
     # Create and store asyncio task (copy config to isolate from draft changes)
     frozen_config = config_dict.copy()
@@ -1686,6 +1720,7 @@ async def restore_scheduled_jobs(application) -> int:
                         )
                     )
                     _continuous_tasks[instance_id] = task
+                    _sync_instance_to_store(instance_id, inst)
                     restored += 1
                     logger.info(
                         f"Restored continuous routine {instance_id}: {routine_name}"
@@ -1718,6 +1753,7 @@ async def restore_scheduled_jobs(application) -> int:
                         name=job_name_str,
                         chat_id=chat_id,
                     )
+                    _sync_instance_to_store(instance_id, inst)
                     restored += 1
                     logger.info(
                         f"Restored interval job {instance_id} for {routine_name} (every {interval}s)"
@@ -1733,6 +1769,7 @@ async def restore_scheduled_jobs(application) -> int:
                         name=job_name_str,
                         chat_id=chat_id,
                     )
+                    _sync_instance_to_store(instance_id, inst)
                     restored += 1
                     logger.info(
                         f"Restored daily job {instance_id} for {routine_name} (at {time_str})"

--- a/handlers/routines/__init__.py
+++ b/handlers/routines/__init__.py
@@ -19,6 +19,7 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import CallbackContext, ContextTypes
 
 from handlers import clear_all_input_states
+import condor.reports
 from condor.routine_store import get_routine_store
 from routines.base import discover_routines, get_routine, get_routine_by_state, normalize_result
 from utils.auth import restricted
@@ -234,11 +235,11 @@ async def _execute_routine(
     config_dict: dict,
     chat_id: int,
     active_server: str | None = None,
-) -> tuple[str, float]:
-    """Execute a routine and return (result, duration)."""
+) -> tuple[str, float, str | None]:
+    """Execute a routine and return (result, duration, report_id)."""
     routine = get_routine(routine_name)
     if not routine:
-        return "Routine not found", 0
+        return "Routine not found", 0, None
 
     start = time.time()
 
@@ -252,6 +253,9 @@ async def _execute_routine(
         user_data.setdefault("preferences", {}).setdefault("general", {})["active_server"] = active_server
     context._user_data = user_data
 
+    # Reset report capture before execution
+    condor.reports._last_report_id = None
+
     try:
         config = routine.config_class(**config_dict)
         raw_result = await routine.run_fn(config, context)
@@ -263,6 +267,7 @@ async def _execute_routine(
         logger.error(f"Routine {routine_name}[{instance_id}] failed: {e}")
 
     duration = time.time() - start
+    report_id = condor.reports._last_report_id
 
     # Bridge to shared store so web dashboard can see Telegram-triggered results
     if rich_result:
@@ -272,7 +277,7 @@ async def _execute_routine(
         except Exception:
             pass
 
-    return result_text, duration
+    return result_text, duration, report_id
 
 
 async def _run_continuous_routine(
@@ -343,7 +348,7 @@ async def _interval_job_callback(context: CallbackContext) -> None:
         logger.warning(f"Instance {instance_id} no longer exists, skipping execution")
         return
 
-    result, duration = await _execute_routine(
+    result, duration, report_id = await _execute_routine(
         context, instance_id, routine_name, config_dict, chat_id,
         active_server=data.get("active_server"),
     )
@@ -372,8 +377,14 @@ async def _interval_job_callback(context: CallbackContext) -> None:
         f"```\n{result[:400]}\n```"
     )
     try:
+        keyboard = None
+        if report_id:
+            keyboard = InlineKeyboardMarkup([[
+                InlineKeyboardButton("📤 Share Report", callback_data=f"routines:share:{report_id}"),
+            ]])
         await context.bot.send_message(
-            chat_id=chat_id, text=text, parse_mode="MarkdownV2"
+            chat_id=chat_id, text=text, parse_mode="MarkdownV2",
+            reply_markup=keyboard,
         )
     except Exception as e:
         logger.error(f"Failed to send interval result: {e}")
@@ -393,7 +404,7 @@ async def _oneshot_job_callback(context: CallbackContext) -> None:
     msg_id = data.get("msg_id")
     background = data.get("background", False)
 
-    result, duration = await _execute_routine(
+    result, duration, report_id = await _execute_routine(
         context, instance_id, routine_name, config_dict, chat_id,
         active_server=data.get("active_server"),
     )
@@ -414,15 +425,21 @@ async def _oneshot_job_callback(context: CallbackContext) -> None:
             f"```\n{result[:400]}\n```"
         )
         try:
+            keyboard = None
+            if report_id:
+                keyboard = InlineKeyboardMarkup([[
+                    InlineKeyboardButton("📤 Share Report", callback_data=f"routines:share:{report_id}"),
+                ]])
             await context.bot.send_message(
-                chat_id=chat_id, text=text, parse_mode="MarkdownV2"
+                chat_id=chat_id, text=text, parse_mode="MarkdownV2",
+                reply_markup=keyboard,
             )
         except Exception as e:
             logger.error(f"Failed to send result: {e}")
     elif msg_id:
         # Update the detail view
         await _refresh_detail_msg(
-            context, chat_id, msg_id, routine_name, result, duration
+            context, chat_id, msg_id, routine_name, result, duration, report_id
         )
 
 
@@ -434,7 +451,7 @@ async def _daily_job_callback(context: CallbackContext) -> None:
     config_dict = data["config_dict"]
     chat_id = data["chat_id"]
 
-    result, duration = await _execute_routine(
+    result, duration, report_id = await _execute_routine(
         context, instance_id, routine_name, config_dict, chat_id,
         active_server=data.get("active_server"),
     )
@@ -458,8 +475,14 @@ async def _daily_job_callback(context: CallbackContext) -> None:
         f"```\n{result[:400]}\n```"
     )
     try:
+        keyboard = None
+        if report_id:
+            keyboard = InlineKeyboardMarkup([[
+                InlineKeyboardButton("📤 Share Report", callback_data=f"routines:share:{report_id}"),
+            ]])
         await context.bot.send_message(
-            chat_id=chat_id, text=text, parse_mode="MarkdownV2"
+            chat_id=chat_id, text=text, parse_mode="MarkdownV2",
+            reply_markup=keyboard,
         )
     except Exception as e:
         logger.error(f"Failed to send daily result: {e}")
@@ -958,6 +981,36 @@ async def _show_daily_menu(
     await _edit_or_send(update, text, InlineKeyboardMarkup(keyboard))
 
 
+async def _share_report(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, report_id: str
+) -> None:
+    """Send a report HTML file as a Telegram document."""
+    from condor.reports import CHARTS_DIR, get_report
+
+    chat_id = update.effective_chat.id
+    entry = get_report(report_id)
+    if not entry:
+        await update.callback_query.answer("Report not found", show_alert=True)
+        return
+
+    file_path = CHARTS_DIR / entry["filename"]
+    if not file_path.exists():
+        await update.callback_query.answer("Report file missing", show_alert=True)
+        return
+
+    try:
+        with open(file_path, "rb") as f:
+            await context.bot.send_document(
+                chat_id=chat_id,
+                document=f,
+                filename=f"{entry['title']}.html",
+                caption=f"📊 {entry['title']}",
+            )
+    except Exception as e:
+        logger.error(f"Failed to share report {report_id}: {e}")
+        await update.callback_query.answer(f"Error: {e}", show_alert=True)
+
+
 async def _show_help(
     update: Update, context: ContextTypes.DEFAULT_TYPE, routine_name: str
 ) -> None:
@@ -995,6 +1048,7 @@ async def _refresh_detail_msg(
     routine_name: str,
     result: str | None = None,
     duration: float | None = None,
+    report_id: str | None = None,
 ) -> None:
     """Refresh the routine detail message after execution."""
     routine = get_routine(routine_name)
@@ -1078,6 +1132,15 @@ async def _refresh_detail_msg(
                     f"⏹ Stop All ({len(running)})",
                     callback_data=f"routines:stopall:{routine_name}",
                 )
+            ]
+        )
+
+    if report_id:
+        keyboard.append(
+            [
+                InlineKeyboardButton(
+                    "📤 Share Report", callback_data=f"routines:share:{report_id}"
+                ),
             ]
         )
 
@@ -1518,6 +1581,10 @@ async def routines_callback_handler(
                 count += 1
         await query.answer(f"⏹ Stopped {count}")
         await _show_tasks(update, context)
+
+    elif action == "share" and len(parts) >= 3:
+        await query.answer()
+        await _share_report(update, context, parts[2])
 
     elif action == "help" and len(parts) >= 3:
         await query.answer()

--- a/main.py
+++ b/main.py
@@ -223,6 +223,7 @@ def reload_handlers():
         "handlers.config.api_keys",
         "handlers.config.gateway",
         "handlers.config.user_preferences",
+        "routines.base",
         "handlers.routines",
         "handlers.agents",
         "handlers.agents.menu",
@@ -232,7 +233,6 @@ def reload_handlers():
         "handlers.agents._shared",
         "handlers.admin",
         "handlers.admin.update",
-        "routines.base",
         "utils.auth",
         "utils.telegram_formatters",
         "config_manager",
@@ -488,11 +488,20 @@ async def watch_and_reload(application: Application) -> None:
 
     handlers_path = Path(__file__).parent / "handlers"
     routines_path = Path(__file__).parent / "routines"
-    logger.info(f"👀 Watching for changes in: {handlers_path}, {routines_path}")
+    assistants_path = Path(__file__).parent / "assistants"
+    watch_paths = [handlers_path, routines_path]
+    if assistants_path.exists():
+        watch_paths.append(assistants_path)
+    logger.info(f"👀 Watching for changes in: {', '.join(str(p) for p in watch_paths)}")
 
-    async for changes in awatch(handlers_path, routines_path):
+    async for changes in awatch(*watch_paths):
         logger.info(f"📝 Detected changes: {changes}")
         try:
+            # Reload assistants if any .md file in assistants/ changed
+            if any(str(assistants_path) in str(path) for _, path in changes):
+                from handlers.agents._shared import reload_assistants
+                reload_assistants()
+                logger.info("✅ Auto-reloaded assistants")
             reload_handlers()
             register_handlers(application)
             logger.info("✅ Auto-reloaded handlers successfully")

--- a/mcp_servers/condor/condor_client.py
+++ b/mcp_servers/condor/condor_client.py
@@ -1,0 +1,47 @@
+"""HTTP client for calling the Condor main-process web API."""
+
+import re
+
+import aiohttp
+
+from mcp_servers.condor.exceptions import APIError
+from mcp_servers.condor.settings import settings
+
+
+async def call_main_api(method: str, path: str, body: dict | None = None) -> dict | list:
+    """Call the Condor web API in the main process.
+
+    The MCP server runs as a subprocess -- TickEngines must be created in the
+    main process so they survive beyond the MCP subprocess lifecycle.
+
+    Raises APIError on failure instead of returning {"error": ...}.
+    """
+    from condor.web.auth import create_jwt
+    from utils.config import WEB_PORT
+
+    url = f"http://127.0.0.1:{WEB_PORT}/api/v1{path}"
+    token = create_jwt(settings.user_id, role="user")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.request(method, url, json=body, headers=headers, timeout=aiohttp.ClientTimeout(total=15)) as resp:
+                data = await resp.json()
+                if resp.status >= 400:
+                    detail = data.get("detail", str(data)) if isinstance(data, dict) else str(data)
+                    raise APIError(f"API error ({resp.status}): {detail}")
+                return data
+    except APIError:
+        raise
+    except Exception as e:
+        raise APIError(f"Failed to reach main process API: {e}")
+
+
+def slug_from_agent_id(agent_id: str) -> str:
+    """Extract strategy slug from agent_id.
+
+    agent_id formats: '{slug}_{session_num}' or '{slug}_e{num}'
+    The slug itself may contain underscores, so split from the right.
+    """
+    m = re.match(r'^(.+?)_(?:e?\d+)$', agent_id)
+    return m.group(1) if m else agent_id

--- a/mcp_servers/condor/exceptions.py
+++ b/mcp_servers/condor/exceptions.py
@@ -1,0 +1,13 @@
+"""Exception hierarchy for the Condor MCP server."""
+
+
+class CondorMCPError(Exception):
+    """Base exception for all Condor MCP errors."""
+
+
+class ToolError(CondorMCPError):
+    """Error within a tool's business logic."""
+
+
+class APIError(CondorMCPError):
+    """Error calling the main-process HTTP API."""

--- a/mcp_servers/condor/middleware.py
+++ b/mcp_servers/condor/middleware.py
@@ -1,0 +1,27 @@
+"""Error-handling middleware for MCP tool functions."""
+
+import functools
+import logging
+
+from mcp_servers.condor.exceptions import APIError, ToolError
+
+logger = logging.getLogger("condor.mcp")
+
+
+def handle_errors(action_name: str):
+    """Decorator that catches exceptions and returns error dicts."""
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        async def wrapper(*args, **kwargs):
+            try:
+                return await fn(*args, **kwargs)
+            except (ToolError, APIError):
+                raise
+            except Exception as e:
+                logger.exception("MCP tool error in %s", action_name)
+                return {"error": f"{action_name} failed: {e}"}
+
+        return wrapper
+
+    return decorator

--- a/mcp_servers/condor/server.py
+++ b/mcp_servers/condor/server.py
@@ -246,6 +246,46 @@ async def _local_manage_routines_run(name: str, config: dict | None, strategy_id
         return {"error": f"Routine '{name}' failed: {e}"}
 
 
+async def _local_manage_routines_start(name: str, config: dict | None) -> dict:
+    """Start a continuous routine as a background task."""
+    routine = _resolve_routine(name)
+    if not routine:
+        return {"error": f"Routine '{name}' not found"}
+    if not routine.is_continuous:
+        return {"error": f"Routine '{name}' is not continuous — use action='run' instead"}
+
+    from condor.routine_store import get_routine_store
+    store = get_routine_store()
+    try:
+        instance_id = await store.start_continuous(
+            routine_name=name,
+            config=config or {},
+            server_name=ACTIVE_SERVER,
+            user_id=CHAT_ID,
+        )
+        return {"started": True, "instance_id": instance_id, "routine": name}
+    except Exception as e:
+        return {"error": f"Failed to start: {e}"}
+
+
+def _local_manage_routines_stop(instance_id: str) -> dict:
+    """Stop a running routine instance."""
+    from condor.routine_store import get_routine_store
+    store = get_routine_store()
+    stopped = store.stop(instance_id)
+    if stopped:
+        return {"stopped": True, "instance_id": instance_id}
+    return {"error": f"Instance '{instance_id}' not found or already stopped"}
+
+
+def _local_manage_routines_list_instances() -> dict:
+    """List all running/scheduled routine instances."""
+    from condor.routine_store import get_routine_store
+    store = get_routine_store()
+    instances = store.list_instances()
+    return {"instances": instances}
+
+
 def _get_agent_routines_dir(strategy_id: str | None) -> "Path | None":
     """Resolve the routines directory for a strategy."""
     from pathlib import Path
@@ -390,6 +430,9 @@ async def manage_routines(
     - "list": List all available routines with name, description, type, and scope
     - "describe": Show config schema for a routine (requires name)
     - "run": Execute a one-shot routine and return its result (requires name, optional config)
+    - "start": Start a continuous routine as a background task (requires name, optional config)
+    - "stop": Stop a running routine instance (requires name=instance_id)
+    - "list_instances": List all running/scheduled routine instances
 
     Actions -- Agent-Local Routine CRUD (requires strategy_id or CONDOR_AGENT_SLUG):
     - "create_routine": Create a new agent-local routine (requires name, code)
@@ -403,8 +446,8 @@ async def manage_routines(
 
     Args:
         action: The action to perform.
-        name: Routine name (required for all except list).
-        config: Config overrides for run (optional, merged with defaults).
+        name: Routine name (required for all except list/list_instances). For "stop", pass the instance_id as name.
+        config: Config overrides for run/start (optional, merged with defaults).
         strategy_id: Strategy ID for agent-local routine CRUD operations.
         code: Python source code for create_routine / edit_routine.
 
@@ -443,6 +486,19 @@ async def manage_routines(
         if not name:
             return {"error": "name is required"}
         return _local_manage_routines_delete(name, strategy_id)
+
+    if action == "start":
+        if not name:
+            return {"error": "name is required"}
+        return await _local_manage_routines_start(name, config)
+
+    if action == "stop":
+        if not name:
+            return {"error": "instance_id is required (pass as name)"}
+        return _local_manage_routines_stop(name)
+
+    if action == "list_instances":
+        return _local_manage_routines_list_instances()
 
     return {"error": f"Unknown action: {action}"}
 

--- a/mcp_servers/condor/server.py
+++ b/mcp_servers/condor/server.py
@@ -1,42 +1,19 @@
 """Condor MCP Server -- exposes Condor capabilities to AI agents.
 
-Provides local-only tools for routines, servers, user context,
-trading agents, skills, and notes via MCP.
-
-Accepts CLI args (--chat-id, --user-id, --agent-slug) or falls back to
-CONDOR_CHAT_ID / CONDOR_USER_ID / CONDOR_AGENT_SLUG env vars.
+Thin wrapper layer: tool registration + docstrings only.
+All business logic lives in mcp_servers.condor.tools.*
 """
-
-import argparse
-import json
-import os
 
 from mcp.server.fastmcp import FastMCP
 
+from mcp_servers.condor.middleware import handle_errors
+from mcp_servers.condor.tools import context, notes, notification, routines, servers, trading_agent
+
 mcp = FastMCP("condor")
-
-# Parse CLI args, fall back to env vars
-_parser = argparse.ArgumentParser(add_help=False)
-_parser.add_argument("--chat-id", type=int, default=None)
-_parser.add_argument("--user-id", type=int, default=None)
-_parser.add_argument("--agent-slug", default=None)
-_parser.add_argument("--bot-token", default=None)
-_parser.add_argument("--server-name", default=None)
-_args, _ = _parser.parse_known_args()
-
-CHAT_ID = _args.chat_id if _args.chat_id is not None else int(os.environ.get("CONDOR_CHAT_ID", "0"))
-USER_ID = _args.user_id if _args.user_id is not None else int(os.environ.get("CONDOR_USER_ID", "0"))
-TELEGRAM_BOT_TOKEN = _args.bot_token or os.environ.get("TELEGRAM_BOT_TOKEN", "")
-CONDOR_AGENT_SLUG = _args.agent_slug or os.environ.get("CONDOR_AGENT_SLUG", "")
-ACTIVE_SERVER = _args.server_name or os.environ.get("CONDOR_SERVER_NAME", "")
-
-
-# =============================================================================
-# Notification Tool
-# =============================================================================
 
 
 @mcp.tool()
+@handle_errors("send notification")
 async def send_notification(
     text: str,
     parse_mode: str = "Markdown",
@@ -50,373 +27,11 @@ async def send_notification(
     Returns:
         {"sent": true} on success, {"error": "..."} on failure.
     """
-    if not TELEGRAM_BOT_TOKEN:
-        return {"error": "TELEGRAM_BOT_TOKEN not configured"}
-    if not CHAT_ID:
-        return {"error": "CONDOR_CHAT_ID not configured"}
-
-    import httpx
-
-    url = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage"
-    payload = {
-        "chat_id": CHAT_ID,
-        "text": text,
-        "parse_mode": parse_mode,
-    }
-    try:
-        async with httpx.AsyncClient(timeout=10) as client:
-            resp = await client.post(url, json=payload)
-            data = resp.json()
-            if data.get("ok"):
-                return {"sent": True}
-            # Retry without parse_mode if formatting fails
-            if "can't parse" in data.get("description", "").lower():
-                payload.pop("parse_mode")
-                resp = await client.post(url, json=payload)
-                data = resp.json()
-                if data.get("ok"):
-                    return {"sent": True}
-            return {"error": data.get("description", "Unknown Telegram API error")}
-    except Exception as e:
-        return {"error": f"Failed to send: {e}"}
-
-
-# =============================================================================
-# Routines Tools (local: list and describe only)
-# =============================================================================
-
-
-def _local_manage_routines_list(strategy_id: str | None = None) -> dict:
-    from pathlib import Path
-    from routines.base import discover_routines, discover_routines_from_path
-
-    routines = discover_routines(force_reload=True)
-    result = []
-    for name, routine in sorted(routines.items()):
-        result.append({
-            "name": name,
-            "description": routine.description,
-            "type": "continuous" if routine.is_continuous else "one-shot",
-            "scope": "global",
-        })
-
-    if strategy_id:
-        # Specific strategy requested — only list its routines
-        agent_routines_dir = _get_agent_routines_dir(strategy_id)
-        if agent_routines_dir and agent_routines_dir.exists():
-            agent_routines = discover_routines_from_path(agent_routines_dir)
-            for name, routine in sorted(agent_routines.items()):
-                result.append({
-                    "name": name,
-                    "description": routine.description,
-                    "type": "continuous" if routine.is_continuous else "one-shot",
-                    "scope": "agent",
-                    "agent": strategy_id,
-                })
-    else:
-        # No specific strategy — scan all agents for their local routines
-        # First try CONDOR_AGENT_SLUG (scoped MCP session)
-        if CONDOR_AGENT_SLUG:
-            agent_routines_dir = Path("trading_agents") / CONDOR_AGENT_SLUG / "routines"
-            if agent_routines_dir.exists():
-                agent_routines = discover_routines_from_path(agent_routines_dir)
-                for name, routine in sorted(agent_routines.items()):
-                    result.append({
-                        "name": name,
-                        "description": routine.description,
-                        "type": "continuous" if routine.is_continuous else "one-shot",
-                        "scope": "agent",
-                        "agent": CONDOR_AGENT_SLUG,
-                    })
-        else:
-            # No agent scope — discover routines from ALL strategies
-            from condor.trading_agent.strategy import StrategyStore
-            store = StrategyStore()
-            for s in store.list_all():
-                agent_routines_dir = Path("trading_agents") / s.slug / "routines"
-                if not agent_routines_dir.exists():
-                    continue
-                agent_routines = discover_routines_from_path(agent_routines_dir)
-                for name, routine in sorted(agent_routines.items()):
-                    result.append({
-                        "name": name,
-                        "description": routine.description,
-                        "type": "continuous" if routine.is_continuous else "one-shot",
-                        "scope": "agent",
-                        "agent": s.slug,
-                    })
-
-    return {"routines": result}
-
-
-def _resolve_routine(name: str):
-    """Look up a routine: agent-local first, then global."""
-    if CONDOR_AGENT_SLUG:
-        from routines.base import discover_routines_from_path
-        from pathlib import Path
-
-        agent_routines_dir = Path("trading_agents") / CONDOR_AGENT_SLUG / "routines"
-        if agent_routines_dir.exists():
-            agent_routines = discover_routines_from_path(agent_routines_dir)
-            if name in agent_routines:
-                return agent_routines[name]
-
-    from routines.base import discover_routines
-    return discover_routines(force_reload=True).get(name)
-
-
-def _local_manage_routines_describe(name: str) -> dict:
-    routine = _resolve_routine(name)
-    if not routine:
-        return {"error": f"Routine '{name}' not found"}
-    fields = routine.get_fields()
-    return {
-        "name": name,
-        "description": routine.description,
-        "type": "continuous" if routine.is_continuous else "one-shot",
-        "fields": fields,
-    }
-
-
-async def _local_manage_routines_run(name: str, config: dict | None, strategy_id: str | None = None) -> dict:
-    """Execute a one-shot routine and return its result."""
-    import asyncio
-
-    routine = None
-
-    # If strategy_id provided, look in agent-local routines first
-    if strategy_id:
-        routines_dir = _get_agent_routines_dir(strategy_id)
-        if routines_dir and routines_dir.exists():
-            from routines.base import discover_routines_from_path
-            agent_routines = discover_routines_from_path(routines_dir)
-            routine = agent_routines.get(name)
-
-    # Fall back to default resolution (CONDOR_AGENT_SLUG → global)
-    if not routine:
-        routine = _resolve_routine(name)
-
-    if not routine:
-        return {"error": f"Routine '{name}' not found"}
-
-    if routine.is_continuous:
-        return {
-            "error": f"Routine '{name}' is continuous and cannot be run via MCP. "
-            "Use the Telegram /routines command to start/stop continuous routines."
-        }
-
-    # Build config from defaults + overrides
-    try:
-        config_obj = routine.config_class(**(config or {}))
-    except Exception as e:
-        return {"error": f"Invalid config: {e}"}
-
-    # Minimal mock context — provides _chat_id for API client resolution
-    class MCPContext:
-        def __init__(self):
-            self._chat_id = CHAT_ID
-            self._user_id = USER_ID
-            self._user_data: dict = {}
-            self.bot = None
-            self.application = None
-
-        @property
-        def user_data(self):
-            return self._user_data
-
-    context = MCPContext()
-
-    try:
-        result = await asyncio.wait_for(
-            routine.run_fn(config_obj, context), timeout=120
-        )
-        # Normalize RoutineResult for JSON serialization (strip binary chart_image)
-        from routines.base import normalize_result
-        nr = normalize_result(result)
-        return {"name": name, "result": {
-            "text": nr.text,
-            "table_data": nr.table_data,
-            "table_columns": nr.table_columns,
-            "chart_image": "(PNG bytes, view via dashboard)" if nr.chart_image else None,
-            "sections": nr.sections,
-        }}
-    except asyncio.TimeoutError:
-        return {"error": f"Routine '{name}' timed out after 120s"}
-    except Exception as e:
-        return {"error": f"Routine '{name}' failed: {e}"}
-
-
-async def _local_manage_routines_start(name: str, config: dict | None) -> dict:
-    """Start a continuous routine as a background task."""
-    routine = _resolve_routine(name)
-    if not routine:
-        return {"error": f"Routine '{name}' not found"}
-    if not routine.is_continuous:
-        return {"error": f"Routine '{name}' is not continuous — use action='run' instead"}
-
-    from condor.routine_store import get_routine_store
-    store = get_routine_store()
-    try:
-        instance_id = await store.start_continuous(
-            routine_name=name,
-            config=config or {},
-            server_name=ACTIVE_SERVER,
-            user_id=CHAT_ID,
-        )
-        return {"started": True, "instance_id": instance_id, "routine": name}
-    except Exception as e:
-        return {"error": f"Failed to start: {e}"}
-
-
-def _local_manage_routines_stop(instance_id: str) -> dict:
-    """Stop a running routine instance."""
-    from condor.routine_store import get_routine_store
-    store = get_routine_store()
-    stopped = store.stop(instance_id)
-    if stopped:
-        return {"stopped": True, "instance_id": instance_id}
-    return {"error": f"Instance '{instance_id}' not found or already stopped"}
-
-
-def _local_manage_routines_list_instances() -> dict:
-    """List all running/scheduled routine instances."""
-    from condor.routine_store import get_routine_store
-    store = get_routine_store()
-    instances = store.list_instances()
-    return {"instances": instances}
-
-
-def _get_agent_routines_dir(strategy_id: str | None) -> "Path | None":
-    """Resolve the routines directory for a strategy."""
-    from pathlib import Path
-
-    # If strategy_id given, resolve slug from StrategyStore
-    if strategy_id:
-        from condor.trading_agent.strategy import StrategyStore
-        store = StrategyStore()
-        s = store.get(strategy_id)
-        if not s:
-            return None
-        return Path("trading_agents") / s.slug / "routines"
-
-    # Fall back to CONDOR_AGENT_SLUG env var
-    if CONDOR_AGENT_SLUG:
-        return Path("trading_agents") / CONDOR_AGENT_SLUG / "routines"
-
-    return None
-
-
-def _local_manage_routines_create(name: str, code: str, strategy_id: str | None) -> dict:
-    """Create a new agent-local routine file."""
-    import re
-    from pathlib import Path
-
-    if not name or not re.match(r"^[a-z][a-z0-9_]*$", name):
-        return {"error": "name must be lowercase alphanumeric with underscores (e.g. 'my_scanner')"}
-    if not code:
-        return {"error": "code is required"}
-
-    routines_dir = _get_agent_routines_dir(strategy_id)
-    if not routines_dir:
-        return {"error": "strategy_id is required (or CONDOR_AGENT_SLUG must be set)"}
-
-    file_path = routines_dir / f"{name}.py"
-    if file_path.exists():
-        return {"error": f"Routine '{name}' already exists. Use action='edit_routine' to update it."}
-
-    # Validate the code has required components
-    if "class Config" not in code:
-        return {"error": "Routine code must define a 'class Config(BaseModel)' class"}
-    if "async def run" not in code and "def run" not in code:
-        return {"error": "Routine code must define a 'run(config, context)' function"}
-
-    routines_dir.mkdir(parents=True, exist_ok=True)
-    file_path.write_text(code)
-
-    # Verify it loads
-    from routines.base import discover_routines_from_path
-    loaded = discover_routines_from_path(routines_dir)
-    if name not in loaded:
-        # Remove the broken file
-        file_path.unlink()
-        return {"error": "Routine file was created but failed to load. Check for syntax errors."}
-
-    routine = loaded[name]
-    return {
-        "created": True,
-        "name": name,
-        "description": routine.description,
-        "path": str(file_path),
-    }
-
-
-def _local_manage_routines_read(name: str, strategy_id: str | None) -> dict:
-    """Read the source code of a routine."""
-    from pathlib import Path
-
-    # Check agent-local first
-    routines_dir = _get_agent_routines_dir(strategy_id)
-    if routines_dir:
-        file_path = routines_dir / f"{name}.py"
-        if file_path.exists():
-            return {"name": name, "code": file_path.read_text(), "scope": "agent"}
-
-    # Check global routines
-    global_path = Path("routines") / f"{name}.py"
-    if global_path.exists():
-        return {"name": name, "code": global_path.read_text(), "scope": "global"}
-
-    return {"error": f"Routine '{name}' not found"}
-
-
-def _local_manage_routines_edit(name: str, code: str, strategy_id: str | None) -> dict:
-    """Update the source code of an agent-local routine."""
-    routines_dir = _get_agent_routines_dir(strategy_id)
-    if not routines_dir:
-        return {"error": "strategy_id is required (or CONDOR_AGENT_SLUG must be set)"}
-
-    file_path = routines_dir / f"{name}.py"
-    if not file_path.exists():
-        return {"error": f"Agent routine '{name}' not found. Use action='create_routine' first."}
-
-    if not code:
-        return {"error": "code is required"}
-
-    # Write new code
-    old_code = file_path.read_text()
-    file_path.write_text(code)
-
-    # Verify it loads
-    from routines.base import discover_routines_from_path
-    loaded = discover_routines_from_path(routines_dir)
-    if name not in loaded:
-        # Restore old code
-        file_path.write_text(old_code)
-        return {"error": "Updated code failed to load (syntax error?). Reverted to previous version."}
-
-    routine = loaded[name]
-    return {
-        "updated": True,
-        "name": name,
-        "description": routine.description,
-    }
-
-
-def _local_manage_routines_delete(name: str, strategy_id: str | None) -> dict:
-    """Delete an agent-local routine."""
-    routines_dir = _get_agent_routines_dir(strategy_id)
-    if not routines_dir:
-        return {"error": "strategy_id is required (or CONDOR_AGENT_SLUG must be set)"}
-
-    file_path = routines_dir / f"{name}.py"
-    if not file_path.exists():
-        return {"error": f"Agent routine '{name}' not found"}
-
-    file_path.unlink()
-    return {"deleted": True, "name": name}
+    return await notification.send_notification(text, parse_mode)
 
 
 @mcp.tool()
+@handle_errors("manage routines")
 async def manage_routines(
     action: str,
     name: str | None = None,
@@ -454,97 +69,11 @@ async def manage_routines(
     Returns:
         Action-specific result dict.
     """
-    if action == "list":
-        return _local_manage_routines_list(strategy_id)
-
-    if action == "describe":
-        if not name:
-            return {"error": "name is required"}
-        return _local_manage_routines_describe(name)
-
-    if action == "run":
-        if not name:
-            return {"error": "name is required"}
-        return await _local_manage_routines_run(name, config, strategy_id)
-
-    if action == "create_routine":
-        if not name:
-            return {"error": "name is required"}
-        return _local_manage_routines_create(name, code or "", strategy_id)
-
-    if action == "read_routine":
-        if not name:
-            return {"error": "name is required"}
-        return _local_manage_routines_read(name, strategy_id)
-
-    if action == "edit_routine":
-        if not name:
-            return {"error": "name is required"}
-        return _local_manage_routines_edit(name, code or "", strategy_id)
-
-    if action == "delete_routine":
-        if not name:
-            return {"error": "name is required"}
-        return _local_manage_routines_delete(name, strategy_id)
-
-    if action == "start":
-        if not name:
-            return {"error": "name is required"}
-        return await _local_manage_routines_start(name, config)
-
-    if action == "stop":
-        if not name:
-            return {"error": "instance_id is required (pass as name)"}
-        return _local_manage_routines_stop(name)
-
-    if action == "list_instances":
-        return _local_manage_routines_list_instances()
-
-    return {"error": f"Unknown action: {action}"}
-
-
-# =============================================================================
-# Servers Tools (local: list and status only)
-# =============================================================================
-
-
-def _local_manage_servers_list() -> dict:
-    from config_manager import get_config_manager
-
-    cm = get_config_manager()
-    accessible = cm.get_accessible_servers(USER_ID)
-    active_server = cm.get_chat_default_server(CHAT_ID)
-    servers = []
-    for name in accessible:
-        server = cm.get_server(name)
-        if not server:
-            continue
-        perm = cm.get_server_permission(USER_ID, name)
-        servers.append({
-            "name": name,
-            "host": server["host"],
-            "port": server["port"],
-            "permission": perm.value if perm else "unknown",
-            "is_active": name == active_server,
-        })
-    return {"servers": servers, "active_server": active_server}
-
-
-async def _local_manage_servers_status(name: str | None) -> dict:
-    from config_manager import get_config_manager
-
-    cm = get_config_manager()
-    if not name:
-        name = cm.get_chat_default_server(CHAT_ID)
-        if not name:
-            return {"error": "No active server"}
-    if not cm.has_server_access(USER_ID, name):
-        return {"error": f"No access to server '{name}'"}
-    status = await cm.check_server_status(name)
-    return {"server": name, **status}
+    return await routines.manage_routines(action, name, config, strategy_id, code)
 
 
 @mcp.tool()
+@handle_errors("manage servers")
 async def manage_servers(
     action: str,
     name: str | None = None,
@@ -562,21 +91,11 @@ async def manage_servers(
     Returns:
         Action-specific result dict.
     """
-    if action == "list":
-        return _local_manage_servers_list()
-
-    if action == "status":
-        return await _local_manage_servers_status(name)
-
-    return {"error": f"Unknown action: {action}"}
-
-
-# =============================================================================
-# User Context Tools
-# =============================================================================
+    return await servers.manage_servers(action, name)
 
 
 @mcp.tool()
+@handle_errors("get user context")
 async def get_user_context() -> dict:
     """Get the current user's context within Condor.
 
@@ -586,276 +105,11 @@ async def get_user_context() -> dict:
         - user_role: User's role (admin, user, pending, blocked)
         - is_admin: Whether the user is an admin
     """
-    from config_manager import get_config_manager
-
-    cm = get_config_manager()
-    active_server = cm.get_chat_default_server(CHAT_ID)
-    user_role = cm.get_user_role(USER_ID)
-    is_admin = cm.is_admin(USER_ID)
-
-    return {
-        "active_server": active_server,
-        "user_role": user_role.value if user_role else None,
-        "is_admin": is_admin,
-    }
-
-
-# =============================================================================
-# Trading Agent Tools (mostly local)
-# =============================================================================
-
-
-def _local_journal_read(params: dict) -> dict:
-    from condor.trading_agent.journal import JournalManager
-    from condor.trading_agent.engine import get_engine
-
-    agent_id = params.get("agent_id", "")
-    if not agent_id:
-        return {"error": "agent_id is required"}
-
-    engine = get_engine(agent_id)
-    if engine:
-        if engine.is_experiment:
-            return {"content": "(experiment mode — no journal, results saved to dry_runs/)"}
-        session_dir = engine.session_dir
-        agent_dir = engine.strategy.agent_dir
-    else:
-        from condor.trading_agent.journal import resolve_agent_dirs
-        session_dir, agent_dir = resolve_agent_dirs(agent_id)
-    if not session_dir:
-        return {"content": "(no journal available for this agent)"}
-    jm = JournalManager(agent_id, session_dir=session_dir, agent_dir=agent_dir)
-
-    section = params.get("section", "recent")
-    max_entries = params.get("max_entries", 30)
-
-    if section == "full":
-        return {"content": jm.read_full()}
-    elif section == "learnings":
-        return {"content": jm.read_learnings()}
-    elif section in ("state", "summary"):
-        return {"content": jm.read_state()}
-    elif section == "runs":
-        runs = jm.list_runs(limit=max_entries)
-        return {"runs": runs}
-    elif section.startswith("run:"):
-        try:
-            tick_num = int(section.split(":", 1)[1])
-        except (ValueError, IndexError):
-            return {"error": "Invalid run format. Use 'run:N' where N is the tick number."}
-        content = jm.read_run_snapshot(tick_num)
-        if not content:
-            return {"error": f"No run snapshot found for tick #{tick_num}"}
-        return {"content": content}
-    else:
-        return {"content": jm.read_recent(max_entries=max_entries)}
-
-
-def _local_journal_write(params: dict) -> dict:
-    from condor.trading_agent.journal import JournalManager
-    from condor.trading_agent.engine import get_engine
-
-    agent_id = params.get("agent_id", "")
-    if not agent_id:
-        return {"error": "agent_id is required"}
-
-    engine = get_engine(agent_id)
-    if engine:
-        if engine.is_experiment:
-            return {"error": "experiments don't have a journal — use dry_runs/ for results"}
-        session_dir = engine.session_dir
-        agent_dir = engine.strategy.agent_dir
-    else:
-        from condor.trading_agent.journal import resolve_agent_dirs
-        session_dir, agent_dir = resolve_agent_dirs(agent_id)
-    if not session_dir:
-        return {"error": "no journal available for this agent"}
-    jm = JournalManager(agent_id, session_dir=session_dir, agent_dir=agent_dir)
-
-    entry_type = params.get("entry_type", "action")
-    text = params.get("text", "")
-    if not text:
-        return {"error": "text is required"}
-
-    if entry_type == "learning":
-        category = params.get("category", "market")
-        jm.append_learning(text, category=category)
-    elif entry_type == "state":
-        jm.write_state(text)
-    else:
-        tick = params.get("tick", 0)
-        reasoning = params.get("reasoning", "")
-        risk_note = params.get("risk_note", "")
-        jm.append_action(tick, text, reasoning, risk_note)
-    return {"written": True}
+    return await context.get_user_context()
 
 
 @mcp.tool()
-async def trading_agent_journal_read(
-    agent_id: str,
-    section: str = "recent",
-    max_entries: int = 30,
-) -> dict:
-    """Read the trading agent's journal.
-
-    Args:
-        agent_id: The trading agent instance ID.
-        section: What to read:
-                 "recent" (last 10 decisions from run snapshots),
-                 "learnings" (all learnings, max 20),
-                 "summary" (current status one-liner),
-                 "state" (alias for summary),
-                 "full" (entire journal),
-                 "runs" (list recent run snapshots),
-                 "run:N" (read specific run snapshot, e.g. "run:3").
-        max_entries: Max entries for recent/runs (default 30).
-
-    Returns:
-        {"content": "<journal text>"} or {"runs": [...]} for runs listing.
-    """
-    return _local_journal_read(
-        {"agent_id": agent_id, "section": section, "max_entries": max_entries}
-    )
-
-
-@mcp.tool()
-async def trading_agent_journal_write(
-    agent_id: str,
-    entry_type: str,
-    text: str,
-    reasoning: str = "",
-    risk_note: str = "",
-    tick: int = 0,
-    category: str = "",
-) -> dict:
-    """Write to the trading agent's journal. Keep entries SHORT (one line).
-
-    Args:
-        agent_id: The trading agent instance ID.
-        entry_type: "action", "learning", or "state".
-            - "action": What you did this tick (auto-trimmed to last 10).
-            - "learning": A new insight. Duplicates are auto-filtered. Only write
-              if this is genuinely new and not already in learnings (max 20).
-            - "state": Overwrite the current state snapshot (e.g. price, position, grids).
-        text: The entry content. Keep it to ONE short line.
-        reasoning: One-sentence reasoning (for actions only).
-        risk_note: Optional risk note (for actions only).
-        tick: Current tick number (for actions only).
-        category: Learning category: "market" (observations, patterns, volatility)
-            or "execution" (errors, fills, timing). Only used when entry_type="learning".
-            Defaults to "market".
-
-    Returns:
-        {"written": true}
-    """
-    return _local_journal_write({
-        "agent_id": agent_id,
-        "entry_type": entry_type,
-        "text": text,
-        "reasoning": reasoning,
-        "risk_note": risk_note,
-        "tick": tick,
-        "category": category,
-    })
-
-
-@mcp.tool()
-async def manage_notes(
-    action: str,
-    key: str | None = None,
-    value: str | None = None,
-) -> dict:
-    """Manage persistent key-value notes for Condor's memory.
-
-    Use this to remember facts across sessions: client chat IDs, server aliases,
-    trading preferences, or any context the user asks you to remember.
-
-    Actions:
-    - "list": List all saved notes
-    - "get": Get a specific note (requires key)
-    - "set": Save a note (requires key and value)
-    - "delete": Delete a note (requires key)
-
-    Naming convention for keys:
-    - Use dot-separated namespaces: "server.brigado_2.group_chat_id"
-    - Common prefixes: "server.", "client.", "routine.", "trading."
-
-    Args:
-        action: The action to perform (list, get, set, delete)
-        key: The note key (required for get, set, delete)
-        value: The note value (required for set)
-
-    Returns:
-        Action-specific result dict.
-    """
-    params: dict = {"action": action}
-    if key is not None:
-        params["key"] = key
-    if value is not None:
-        params["value"] = value
-
-    return _local_manage_notes(params)
-
-
-def _local_manage_notes(params: dict) -> dict:
-    """File-based notes storage."""
-    import json
-    from pathlib import Path
-
-    notes_file = Path("data") / "notes" / f"chat_{CHAT_ID}.json"
-
-    def _load() -> dict:
-        if notes_file.exists():
-            try:
-                return json.loads(notes_file.read_text())
-            except Exception:
-                return {}
-        return {}
-
-    def _save(notes: dict) -> None:
-        notes_file.parent.mkdir(parents=True, exist_ok=True)
-        notes_file.write_text(json.dumps(notes, indent=2))
-
-    action = params.get("action", "list")
-
-    if action == "list":
-        return {"notes": _load()}
-
-    elif action == "get":
-        key = params.get("key")
-        if not key:
-            return {"error": "key is required"}
-        notes = _load()
-        value = notes.get(key)
-        if value is None:
-            return {"error": f"Note '{key}' not found"}
-        return {"key": key, "value": value}
-
-    elif action == "set":
-        key = params.get("key")
-        value = params.get("value")
-        if not key or value is None:
-            return {"error": "key and value are required"}
-        notes = _load()
-        notes[key] = str(value)
-        _save(notes)
-        return {"saved": True, "key": key, "value": str(value)}
-
-    elif action == "delete":
-        key = params.get("key")
-        if not key:
-            return {"error": "key is required"}
-        notes = _load()
-        if key not in notes:
-            return {"error": f"Note '{key}' not found"}
-        del notes[key]
-        _save(notes)
-        return {"deleted": True, "key": key}
-
-    return {"error": f"Unknown action: {action}"}
-
-
-@mcp.tool()
+@handle_errors("manage trading agent")
 async def manage_trading_agent(
     action: str,
     agent_id: str | None = None,
@@ -887,13 +141,17 @@ async def manage_trading_agent(
     - "list_routines": List global + agent-local routines for a strategy (requires strategy_id)
     - "run_routine": Execute a one-shot routine (requires strategy_id, name, optional config)
 
+    Actions -- Journal:
+    - "journal_read": Read journal entries (requires agent_id, optional section/max_entries)
+    - "journal_write": Write a journal entry (requires agent_id, entry_type, text)
+
     Actions -- Monitoring:
     - "agent_tracker": Get the full tracker markdown (tick history, executor ledger, snapshots) (requires agent_id)
     - "agent_journal": Get recent journal entries and learnings (requires agent_id)
 
     Args:
         action: The action to perform.
-        agent_id: Agent instance ID (for lifecycle/monitoring actions).
+        agent_id: Agent instance ID (for lifecycle/monitoring/journal actions).
         strategy_id: Strategy ID (for strategy/routine/start actions).
         name: Strategy name (for create/update) or routine name (for run_routine).
         description: Strategy description (for create/update).
@@ -907,372 +165,111 @@ async def manage_trading_agent(
     Returns:
         Action-specific result dict.
     """
-    # Strategy operations work locally (file-based StrategyStore)
-    local_strategy_actions = {
-        "list_strategies", "get_strategy", "create_strategy",
-        "update_strategy", "delete_strategy",
-    }
-
-    if action in local_strategy_actions:
-        return _local_manage_strategy(action, strategy_id, name, description,
-                                       instructions, agent_key, skills, config)
-
-    # Routine actions scoped to a strategy
-    if action == "list_routines":
-        if not strategy_id:
-            return {"error": "strategy_id is required"}
-        return _local_strategy_list_routines(strategy_id)
-
-    if action == "run_routine":
-        if not strategy_id:
-            return {"error": "strategy_id is required"}
-        if not name:
-            return {"error": "name is required"}
-        return await _local_manage_routines_run(name, config, strategy_id)
-
-    # Agent lifecycle actions
-    lifecycle_actions = {"start_agent", "stop_agent", "pause_agent", "resume_agent", "list_agents"}
-    if action in lifecycle_actions:
-        return await _local_agent_lifecycle(action, strategy_id, agent_id, config)
-
-    # Journal/monitoring that's file-based
-    if action in ("agent_tracker", "agent_journal"):
-        return _local_agent_monitoring(action, agent_id)
-
-    return {"error": f"Unknown action: {action}"}
-
-
-def _local_strategy_list_routines(strategy_id: str) -> dict:
-    """List global + agent-local routines for a strategy, with scope labels."""
-    from routines.base import discover_routines, discover_routines_from_path
-
-    result = []
-
-    # Global routines
-    for name, routine in sorted(discover_routines(force_reload=True).items()):
-        result.append({
-            "name": name,
-            "description": routine.description,
-            "type": "continuous" if routine.is_continuous else "one-shot",
-            "scope": "global",
-        })
-
-    # Agent-local routines
-    routines_dir = _get_agent_routines_dir(strategy_id)
-    if routines_dir and routines_dir.exists():
-        for name, routine in sorted(discover_routines_from_path(routines_dir).items()):
-            result.append({
-                "name": name,
-                "description": routine.description,
-                "type": "continuous" if routine.is_continuous else "one-shot",
-                "scope": "agent",
-            })
-
-    return {"routines": result}
-
-
-def _local_manage_strategy(
-    action: str, strategy_id: str | None, name: str | None,
-    description: str | None, instructions: str | None,
-    agent_key: str | None, skills: list[str] | None, config: dict | None,
-) -> dict:
-    from condor.trading_agent.strategy import StrategyStore
-
-    store = StrategyStore()
-
-    if action == "list_strategies":
-        strategies = store.list_all()
-        return {
-            "strategies": [
-                {
-                    "id": s.id,
-                    "name": s.name,
-                    "description": s.description,
-                    "agent_key": s.agent_key,
-                    "skills": s.skills,
-                    "default_config": s.default_config,
-                }
-                for s in strategies
-            ]
-        }
-
-    elif action == "get_strategy":
-        if not strategy_id:
-            return {"error": "strategy_id is required"}
-        s = store.get(strategy_id)
-        if not s:
-            return {"error": f"Strategy '{strategy_id}' not found"}
-        return {
-            "id": s.id,
-            "name": s.name,
-            "description": s.description,
-            "agent_key": s.agent_key,
-            "instructions": s.instructions,
-            "skills": s.skills,
-            "default_config": s.default_config,
-            "created_by": s.created_by,
-            "created_at": s.created_at,
-        }
-
-    elif action == "create_strategy":
-        if not name or not instructions:
-            return {"error": "name and instructions are required"}
-        strategy = store.create(
-            name=name,
-            description=description or "",
-            agent_key=agent_key or "claude-code",
-            instructions=instructions,
-            skills=skills,
-            default_config=config,
-            created_by=USER_ID,
-        )
-        return {"created": True, "strategy_id": strategy.id, "name": strategy.name}
-
-    elif action == "update_strategy":
-        if not strategy_id:
-            return {"error": "strategy_id is required"}
-        s = store.get(strategy_id)
-        if not s:
-            return {"error": f"Strategy '{strategy_id}' not found"}
-        if name:
-            s.name = name
-        if description:
-            s.description = description
-        if instructions:
-            s.instructions = instructions
-        if agent_key:
-            s.agent_key = agent_key
-        if skills is not None:
-            s.skills = skills
-        if config:
-            s.default_config = config
-        store.update(s)
-        return {"updated": True, "strategy_id": s.id, "name": s.name}
-
-    elif action == "delete_strategy":
-        if not strategy_id:
-            return {"error": "strategy_id is required"}
-        deleted = store.delete(strategy_id)
-        return {"deleted": deleted}
-
-    return {"error": f"Unknown strategy action: {action}"}
-
-
-async def _call_main_api(method: str, path: str, body: dict | None = None) -> dict | list:
-    """Call the Condor web API in the main process.
-
-    The MCP server runs as a subprocess -- TickEngines must be created in the
-    main process so they survive beyond the MCP subprocess lifecycle.
-    """
-    import aiohttp
-    from condor.web.auth import create_jwt
-
-    from utils.config import WEB_PORT
-
-    url = f"http://127.0.0.1:{WEB_PORT}/api/v1{path}"
-    token = create_jwt(USER_ID, role="user")
-    headers = {"Authorization": f"Bearer {token}"}
-
-    try:
-        async with aiohttp.ClientSession() as session:
-            async with session.request(method, url, json=body, headers=headers, timeout=aiohttp.ClientTimeout(total=15)) as resp:
-                data = await resp.json()
-                if resp.status >= 400:
-                    detail = data.get("detail", str(data)) if isinstance(data, dict) else str(data)
-                    return {"error": f"API error ({resp.status}): {detail}"}
-                return data
-    except Exception as e:
-        return {"error": f"Failed to reach main process API: {e}"}
-
-
-async def _local_agent_lifecycle(
-    action: str, strategy_id: str | None, agent_id: str | None, config: dict | None,
-) -> dict:
-    # All lifecycle actions delegate to the main process via the web API.
-    # This ensures TickEngines live in the main process and survive beyond
-    # the MCP subprocess that created them.
-
-    if action == "list_agents":
-        result = await _call_main_api("GET", "/agents")
-        if isinstance(result, dict) and "error" in result:
-            return result
-        # The web API returns a list of AgentSummary objects.
-        # Extract running instances for a flat list like the old format.
-        agents = []
-        if isinstance(result, list):
-            for agent_summary in result:
-                for inst in agent_summary.get("instances", []):
-                    agents.append(inst)
-        if not agents:
-            return {"agents": [], "message": "No agents running"}
-        return {"agents": agents}
-
-    if action == "start_agent":
-        if not strategy_id:
-            return {"error": "strategy_id is required"}
-
-        # Resolve the strategy slug from strategy_id
-        from condor.trading_agent.strategy import StrategyStore
-        store = StrategyStore()
-        strategy = store.get(strategy_id)
-        if not strategy:
-            return {"error": f"Strategy '{strategy_id}' not found"}
-
-        # Build config with server resolution and overrides
-        from condor.trading_agent.config import load_full_config
-        from config_manager import get_config_manager, get_effective_server
-        config_dict = load_full_config(strategy.agent_dir, strategy.default_config)
-        if config:
-            if config.get("dry_run") and "execution_mode" not in config:
-                config["execution_mode"] = "dry_run"
-            config_dict.update(config)
-        if not config or "server_name" not in config:
-            effective = ACTIVE_SERVER or get_effective_server(CHAT_ID)
-            if not effective:
-                cm = get_config_manager()
-                accessible = cm.get_accessible_servers(USER_ID)
-                effective = accessible[0] if accessible else None
-            if effective:
-                config_dict["server_name"] = effective
-
-        # Extract trading_context from config (web API expects it separately)
-        trading_context = config_dict.pop("trading_context", "")
-
-        result = await _call_main_api("POST", f"/agents/{strategy.slug}/start", {
-            "config": config_dict,
-            "trading_context": trading_context,
-            "chat_id": CHAT_ID,
-            "user_id": USER_ID,
-        })
-        return result
-
-    if action == "stop_agent":
-        if not agent_id:
-            return {"error": "agent_id is required"}
-        # Extract slug from agent_id (format: {slug}_{session_num} or {slug}_e{num})
-        slug = _slug_from_agent_id(agent_id)
-        result = await _call_main_api("POST", f"/agents/{slug}/stop?agent_id={agent_id}")
-        return result
-
-    if action == "pause_agent":
-        if not agent_id:
-            return {"error": "agent_id is required"}
-        slug = _slug_from_agent_id(agent_id)
-        result = await _call_main_api("POST", f"/agents/{slug}/pause?agent_id={agent_id}")
-        return result
-
-    if action == "resume_agent":
-        if not agent_id:
-            return {"error": "agent_id is required"}
-        slug = _slug_from_agent_id(agent_id)
-        result = await _call_main_api("POST", f"/agents/{slug}/resume?agent_id={agent_id}")
-        return result
-
-    return {"error": f"Unknown lifecycle action: {action}"}
-
-
-def _slug_from_agent_id(agent_id: str) -> str:
-    """Extract strategy slug from agent_id.
-
-    agent_id formats: '{slug}_{session_num}' or '{slug}_e{num}'
-    The slug itself may contain underscores, so split from the right.
-    """
-    import re
-    # Match trailing _N or _eN
-    m = re.match(r'^(.+?)_(?:e?\d+)$', agent_id)
-    return m.group(1) if m else agent_id
-
-
-def _local_agent_monitoring(action: str, agent_id: str | None) -> dict:
-    if not agent_id:
-        return {"error": "agent_id is required"}
-
-    from condor.trading_agent.journal import JournalManager
-    from condor.trading_agent.engine import get_engine
-
-    engine = get_engine(agent_id)
-    if engine:
-        if engine.is_experiment:
-            return {"error": "experiments don't have a journal — use dry_runs/ for results"}
-        session_dir = engine.session_dir
-        agent_dir = engine.strategy.agent_dir
-    else:
-        from condor.trading_agent.journal import resolve_agent_dirs
-        session_dir, agent_dir = resolve_agent_dirs(agent_id)
-    if not session_dir:
-        return {"error": "no journal available for this agent"}
-    jm = JournalManager(agent_id, session_dir=session_dir, agent_dir=agent_dir)
-
-    if action == "agent_tracker":
-        content = jm.read_full()
-        summary = jm.get_summary_dict()
-        return {"tracker_md": content, "summary": summary}
-
-    elif action == "agent_journal":
-        return {
-            "recent_actions": jm.read_recent(max_entries=30),
-            "learnings": jm.read_learnings(),
-            "entry_count": jm.entry_count(),
-        }
-
-    return {"error": f"Unknown monitoring action: {action}"}
+    return await trading_agent.manage_trading_agent(
+        action, agent_id, strategy_id, name, description,
+        instructions, agent_key, skills, config,
+    )
 
 
 @mcp.tool()
-async def manage_skills(
+@handle_errors("manage notes")
+async def manage_notes(
     action: str,
-    name: str | None = None,
-    params: dict | None = None,
+    key: str | None = None,
+    value: str | None = None,
 ) -> dict:
-    """(Deprecated) Use manage_routines instead.
+    """Manage persistent key-value notes for Condor's memory.
 
-    Skills are being replaced by routines. Use manage_routines(action="run", ...)
-    to execute analysis scripts directly.
+    Use this to remember facts across sessions: client chat IDs, server aliases,
+    trading preferences, or any context the user asks you to remember.
 
     Actions:
-    - "list": List all available skills with descriptions
-    - "test": Test a skill with given params (requires name)
+    - "list": List all saved notes
+    - "get": Get a specific note (requires key)
+    - "set": Save a note (requires key and value)
+    - "delete": Delete a note (requires key)
+
+    Naming convention for keys:
+    - Use dot-separated namespaces: "server.brigado_2.group_chat_id"
+    - Common prefixes: "server.", "client.", "routine.", "trading."
 
     Args:
-        action: The action to perform (list, test).
-        name: Skill name (for test).
-        params: Skill parameters (for test, e.g. {"connector_name": "binance", "trading_pair": "BTC-USDT"}).
+        action: The action to perform (list, get, set, delete)
+        key: The note key (required for get, set, delete)
+        value: The note value (required for set)
 
     Returns:
         Action-specific result dict.
     """
-    if action == "list":
-        return _local_manage_skills_list()
-
-    if action == "test":
-        if not name:
-            return {"error": "name is required"}
-        return _local_skill_test(name, params or {})
-
-    return {"error": f"Unknown action: {action}"}
+    return await notes.manage_notes(action, key, value)
 
 
-def _local_manage_skills_list() -> dict:
-    from condor.trading_agent.providers import list_providers
-
-    items = []
-    for p in list_providers():
-        items.append({
-            "name": p.name,
-            "is_core": p.is_core,
-            "type": "provider",
-        })
-    return {"skills": items}
+# ---------------------------------------------------------------------------
+# Backward-compatibility aliases for journal tools
+# ---------------------------------------------------------------------------
 
 
-def _local_skill_test(name: str, config: dict) -> dict:
-    from condor.trading_agent.providers import get_provider
+@mcp.tool()
+@handle_errors("journal read")
+async def trading_agent_journal_read(
+    agent_id: str,
+    section: str = "recent",
+    max_entries: int = 30,
+) -> dict:
+    """Read the trading agent's journal.
 
-    provider = get_provider(name)
-    if provider:
-        return {"error": f"Provider '{name}' requires the Condor bot to be running for testing (needs API client)"}
+    Args:
+        agent_id: The trading agent instance ID.
+        section: What to read:
+                 "recent" (last 10 decisions from run snapshots),
+                 "learnings" (all learnings, max 20),
+                 "summary" (current status one-liner),
+                 "state" (alias for summary),
+                 "full" (entire journal),
+                 "runs" (list recent run snapshots),
+                 "run:N" (read specific run snapshot, e.g. "run:3").
+        max_entries: Max entries for recent/runs (default 30).
 
-    return {"error": f"Skills have been removed; use manage_routines instead. Provider '{name}' not found."}
+    Returns:
+        {"content": "<journal text>"} or {"runs": [...]} for runs listing.
+    """
+    return trading_agent.journal_read(agent_id, section, max_entries)
+
+
+@mcp.tool()
+@handle_errors("journal write")
+async def trading_agent_journal_write(
+    agent_id: str,
+    entry_type: str,
+    text: str,
+    reasoning: str = "",
+    risk_note: str = "",
+    tick: int = 0,
+    category: str = "",
+) -> dict:
+    """Write to the trading agent's journal. Keep entries SHORT (one line).
+
+    Args:
+        agent_id: The trading agent instance ID.
+        entry_type: "action", "learning", or "state".
+            - "action": What you did this tick (auto-trimmed to last 10).
+            - "learning": A new insight. Duplicates are auto-filtered. Only write
+              if this is genuinely new and not already in learnings (max 20).
+            - "state": Overwrite the current state snapshot (e.g. price, position, grids).
+        text: The entry content. Keep it to ONE short line.
+        reasoning: One-sentence reasoning (for actions only).
+        risk_note: Optional risk note (for actions only).
+        tick: Current tick number (for actions only).
+        category: Learning category: "market" (observations, patterns, volatility)
+            or "execution" (errors, fills, timing). Only used when entry_type="learning".
+            Defaults to "market".
+
+    Returns:
+        {"written": true}
+    """
+    return trading_agent.journal_write(
+        agent_id, entry_type, text, reasoning, risk_note, tick, category,
+    )
 
 
 if __name__ == "__main__":

--- a/mcp_servers/condor/settings.py
+++ b/mcp_servers/condor/settings.py
@@ -1,0 +1,35 @@
+"""CLI args + env vars singleton for the Condor MCP server."""
+
+import argparse
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class Settings:
+    chat_id: int
+    user_id: int
+    bot_token: str
+    agent_slug: str
+    active_server: str
+
+
+def _parse_settings() -> Settings:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--chat-id", type=int, default=None)
+    parser.add_argument("--user-id", type=int, default=None)
+    parser.add_argument("--agent-slug", default=None)
+    parser.add_argument("--bot-token", default=None)
+    parser.add_argument("--server-name", default=None)
+    args, _ = parser.parse_known_args()
+
+    return Settings(
+        chat_id=args.chat_id if args.chat_id is not None else int(os.environ.get("CONDOR_CHAT_ID", "0")),
+        user_id=args.user_id if args.user_id is not None else int(os.environ.get("CONDOR_USER_ID", "0")),
+        bot_token=args.bot_token or os.environ.get("TELEGRAM_BOT_TOKEN", ""),
+        agent_slug=args.agent_slug or os.environ.get("CONDOR_AGENT_SLUG", ""),
+        active_server=args.server_name or os.environ.get("CONDOR_SERVER_NAME", ""),
+    )
+
+
+settings = _parse_settings()

--- a/mcp_servers/condor/tools/context.py
+++ b/mcp_servers/condor/tools/context.py
@@ -1,0 +1,18 @@
+"""Get current user context."""
+
+from mcp_servers.condor.settings import settings
+
+
+async def get_user_context() -> dict:
+    from config_manager import get_config_manager
+
+    cm = get_config_manager()
+    active_server = cm.get_chat_default_server(settings.chat_id)
+    user_role = cm.get_user_role(settings.user_id)
+    is_admin = cm.is_admin(settings.user_id)
+
+    return {
+        "active_server": active_server,
+        "user_role": user_role.value if user_role else None,
+        "is_admin": is_admin,
+    }

--- a/mcp_servers/condor/tools/notes.py
+++ b/mcp_servers/condor/tools/notes.py
@@ -1,0 +1,60 @@
+"""Persistent key-value notes storage."""
+
+import json
+from pathlib import Path
+
+from mcp_servers.condor.settings import settings
+
+
+def _notes_file() -> Path:
+    return Path("data") / "notes" / f"chat_{settings.chat_id}.json"
+
+
+def _load() -> dict:
+    f = _notes_file()
+    if f.exists():
+        try:
+            return json.loads(f.read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def _save(notes: dict) -> None:
+    f = _notes_file()
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(json.dumps(notes, indent=2))
+
+
+async def manage_notes(action: str, key: str | None = None, value: str | None = None) -> dict:
+    if action == "list":
+        return {"notes": _load()}
+
+    elif action == "get":
+        if not key:
+            return {"error": "key is required"}
+        notes = _load()
+        v = notes.get(key)
+        if v is None:
+            return {"error": f"Note '{key}' not found"}
+        return {"key": key, "value": v}
+
+    elif action == "set":
+        if not key or value is None:
+            return {"error": "key and value are required"}
+        notes = _load()
+        notes[key] = str(value)
+        _save(notes)
+        return {"saved": True, "key": key, "value": str(value)}
+
+    elif action == "delete":
+        if not key:
+            return {"error": "key is required"}
+        notes = _load()
+        if key not in notes:
+            return {"error": f"Note '{key}' not found"}
+        del notes[key]
+        _save(notes)
+        return {"deleted": True, "key": key}
+
+    return {"error": f"Unknown action: {action}"}

--- a/mcp_servers/condor/tools/notification.py
+++ b/mcp_servers/condor/tools/notification.py
@@ -1,0 +1,40 @@
+"""Send Telegram notifications to the user."""
+
+import httpx
+
+from mcp_servers.condor.settings import settings
+
+
+async def send_notification(text: str, parse_mode: str = "Markdown") -> dict:
+    """Send a Telegram message to the user.
+
+    Returns:
+        {"sent": true} on success, {"error": "..."} on failure.
+    """
+    if not settings.bot_token:
+        return {"error": "TELEGRAM_BOT_TOKEN not configured"}
+    if not settings.chat_id:
+        return {"error": "CONDOR_CHAT_ID not configured"}
+
+    url = f"https://api.telegram.org/bot{settings.bot_token}/sendMessage"
+    payload = {
+        "chat_id": settings.chat_id,
+        "text": text,
+        "parse_mode": parse_mode,
+    }
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.post(url, json=payload)
+            data = resp.json()
+            if data.get("ok"):
+                return {"sent": True}
+            # Retry without parse_mode if formatting fails
+            if "can't parse" in data.get("description", "").lower():
+                payload.pop("parse_mode")
+                resp = await client.post(url, json=payload)
+                data = resp.json()
+                if data.get("ok"):
+                    return {"sent": True}
+            return {"error": data.get("description", "Unknown Telegram API error")}
+    except Exception as e:
+        return {"error": f"Failed to send: {e}"}

--- a/mcp_servers/condor/tools/routines.py
+++ b/mcp_servers/condor/tools/routines.py
@@ -1,0 +1,357 @@
+"""Routine discovery, execution, and CRUD operations."""
+
+import asyncio
+from pathlib import Path
+
+from mcp_servers.condor.settings import settings
+
+
+def _get_agent_routines_dir(strategy_id: str | None) -> Path | None:
+    """Resolve the routines directory for a strategy."""
+    if strategy_id:
+        from condor.trading_agent.strategy import StrategyStore
+        store = StrategyStore()
+        s = store.get(strategy_id)
+        if not s:
+            return None
+        return Path("trading_agents") / s.slug / "routines"
+
+    if settings.agent_slug:
+        return Path("trading_agents") / settings.agent_slug / "routines"
+
+    return None
+
+
+def _resolve_routine(name: str):
+    """Look up a routine: agent-local first, then global."""
+    if settings.agent_slug:
+        from routines.base import discover_routines_from_path
+
+        agent_routines_dir = Path("trading_agents") / settings.agent_slug / "routines"
+        if agent_routines_dir.exists():
+            agent_routines = discover_routines_from_path(agent_routines_dir)
+            if name in agent_routines:
+                return agent_routines[name]
+
+    from routines.base import discover_routines
+    return discover_routines(force_reload=True).get(name)
+
+
+def list_routines(strategy_id: str | None = None) -> dict:
+    from routines.base import discover_routines, discover_routines_from_path
+
+    routines = discover_routines(force_reload=True)
+    result = []
+    for name, routine in sorted(routines.items()):
+        result.append({
+            "name": name,
+            "description": routine.description,
+            "type": "continuous" if routine.is_continuous else "one-shot",
+            "scope": "global",
+        })
+
+    if strategy_id:
+        agent_routines_dir = _get_agent_routines_dir(strategy_id)
+        if agent_routines_dir and agent_routines_dir.exists():
+            agent_routines = discover_routines_from_path(agent_routines_dir)
+            for name, routine in sorted(agent_routines.items()):
+                result.append({
+                    "name": name,
+                    "description": routine.description,
+                    "type": "continuous" if routine.is_continuous else "one-shot",
+                    "scope": "agent",
+                    "agent": strategy_id,
+                })
+    else:
+        if settings.agent_slug:
+            agent_routines_dir = Path("trading_agents") / settings.agent_slug / "routines"
+            if agent_routines_dir.exists():
+                agent_routines = discover_routines_from_path(agent_routines_dir)
+                for name, routine in sorted(agent_routines.items()):
+                    result.append({
+                        "name": name,
+                        "description": routine.description,
+                        "type": "continuous" if routine.is_continuous else "one-shot",
+                        "scope": "agent",
+                        "agent": settings.agent_slug,
+                    })
+        else:
+            from condor.trading_agent.strategy import StrategyStore
+            store = StrategyStore()
+            for s in store.list_all():
+                agent_routines_dir = Path("trading_agents") / s.slug / "routines"
+                if not agent_routines_dir.exists():
+                    continue
+                agent_routines = discover_routines_from_path(agent_routines_dir)
+                for name, routine in sorted(agent_routines.items()):
+                    result.append({
+                        "name": name,
+                        "description": routine.description,
+                        "type": "continuous" if routine.is_continuous else "one-shot",
+                        "scope": "agent",
+                        "agent": s.slug,
+                    })
+
+    return {"routines": result}
+
+
+def describe_routine(name: str) -> dict:
+    routine = _resolve_routine(name)
+    if not routine:
+        return {"error": f"Routine '{name}' not found"}
+    fields = routine.get_fields()
+    return {
+        "name": name,
+        "description": routine.description,
+        "type": "continuous" if routine.is_continuous else "one-shot",
+        "fields": fields,
+    }
+
+
+class MCPContext:
+    """Minimal mock context for routine execution."""
+
+    def __init__(self):
+        self._chat_id = settings.chat_id
+        self._user_id = settings.user_id
+        self._user_data: dict = {}
+        self.bot = None
+        self.application = None
+
+    @property
+    def user_data(self):
+        return self._user_data
+
+
+async def run_routine(name: str, config: dict | None, strategy_id: str | None = None) -> dict:
+    """Execute a one-shot routine and return its result."""
+    routine = None
+
+    if strategy_id:
+        routines_dir = _get_agent_routines_dir(strategy_id)
+        if routines_dir and routines_dir.exists():
+            from routines.base import discover_routines_from_path
+            agent_routines = discover_routines_from_path(routines_dir)
+            routine = agent_routines.get(name)
+
+    if not routine:
+        routine = _resolve_routine(name)
+
+    if not routine:
+        return {"error": f"Routine '{name}' not found"}
+
+    if routine.is_continuous:
+        return {
+            "error": f"Routine '{name}' is continuous and cannot be run via MCP. "
+            "Use the Telegram /routines command to start/stop continuous routines."
+        }
+
+    try:
+        config_obj = routine.config_class(**(config or {}))
+    except Exception as e:
+        return {"error": f"Invalid config: {e}"}
+
+    context = MCPContext()
+
+    try:
+        result = await asyncio.wait_for(
+            routine.run_fn(config_obj, context), timeout=120
+        )
+        from routines.base import normalize_result
+        nr = normalize_result(result)
+        return {"name": name, "result": {
+            "text": nr.text,
+            "table_data": nr.table_data,
+            "table_columns": nr.table_columns,
+            "chart_image": "(PNG bytes, view via dashboard)" if nr.chart_image else None,
+            "sections": nr.sections,
+        }}
+    except asyncio.TimeoutError:
+        return {"error": f"Routine '{name}' timed out after 120s"}
+    except Exception as e:
+        return {"error": f"Routine '{name}' failed: {e}"}
+
+
+async def start_routine(name: str, config: dict | None) -> dict:
+    """Start a continuous routine as a background task."""
+    routine = _resolve_routine(name)
+    if not routine:
+        return {"error": f"Routine '{name}' not found"}
+    if not routine.is_continuous:
+        return {"error": f"Routine '{name}' is not continuous — use action='run' instead"}
+
+    from condor.routine_store import get_routine_store
+    store = get_routine_store()
+    try:
+        instance_id = await store.start_continuous(
+            routine_name=name,
+            config=config or {},
+            server_name=settings.active_server,
+            user_id=settings.chat_id,
+        )
+        return {"started": True, "instance_id": instance_id, "routine": name}
+    except Exception as e:
+        return {"error": f"Failed to start: {e}"}
+
+
+def stop_routine(instance_id: str) -> dict:
+    """Stop a running routine instance."""
+    from condor.routine_store import get_routine_store
+    store = get_routine_store()
+    stopped = store.stop(instance_id)
+    if stopped:
+        return {"stopped": True, "instance_id": instance_id}
+    return {"error": f"Instance '{instance_id}' not found or already stopped"}
+
+
+def list_instances() -> dict:
+    """List all running/scheduled routine instances."""
+    from condor.routine_store import get_routine_store
+    store = get_routine_store()
+    instances = store.list_instances()
+    return {"instances": instances}
+
+
+def create_routine(name: str, code: str, strategy_id: str | None) -> dict:
+    """Create a new agent-local routine file."""
+    import re
+
+    if not name or not re.match(r"^[a-z][a-z0-9_]*$", name):
+        return {"error": "name must be lowercase alphanumeric with underscores (e.g. 'my_scanner')"}
+    if not code:
+        return {"error": "code is required"}
+
+    routines_dir = _get_agent_routines_dir(strategy_id)
+    if not routines_dir:
+        return {"error": "strategy_id is required (or CONDOR_AGENT_SLUG must be set)"}
+
+    file_path = routines_dir / f"{name}.py"
+    if file_path.exists():
+        return {"error": f"Routine '{name}' already exists. Use action='edit_routine' to update it."}
+
+    if "class Config" not in code:
+        return {"error": "Routine code must define a 'class Config(BaseModel)' class"}
+    if "async def run" not in code and "def run" not in code:
+        return {"error": "Routine code must define a 'run(config, context)' function"}
+
+    routines_dir.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(code)
+
+    from routines.base import discover_routines_from_path
+    loaded = discover_routines_from_path(routines_dir)
+    if name not in loaded:
+        file_path.unlink()
+        return {"error": "Routine file was created but failed to load. Check for syntax errors."}
+
+    routine = loaded[name]
+    return {
+        "created": True,
+        "name": name,
+        "description": routine.description,
+        "path": str(file_path),
+    }
+
+
+def read_routine(name: str, strategy_id: str | None) -> dict:
+    """Read the source code of a routine."""
+    routines_dir = _get_agent_routines_dir(strategy_id)
+    if routines_dir:
+        file_path = routines_dir / f"{name}.py"
+        if file_path.exists():
+            return {"name": name, "code": file_path.read_text(), "scope": "agent"}
+
+    global_path = Path("routines") / f"{name}.py"
+    if global_path.exists():
+        return {"name": name, "code": global_path.read_text(), "scope": "global"}
+
+    return {"error": f"Routine '{name}' not found"}
+
+
+def edit_routine(name: str, code: str, strategy_id: str | None) -> dict:
+    """Update the source code of an agent-local routine."""
+    routines_dir = _get_agent_routines_dir(strategy_id)
+    if not routines_dir:
+        return {"error": "strategy_id is required (or CONDOR_AGENT_SLUG must be set)"}
+
+    file_path = routines_dir / f"{name}.py"
+    if not file_path.exists():
+        return {"error": f"Agent routine '{name}' not found. Use action='create_routine' first."}
+
+    if not code:
+        return {"error": "code is required"}
+
+    old_code = file_path.read_text()
+    file_path.write_text(code)
+
+    from routines.base import discover_routines_from_path
+    loaded = discover_routines_from_path(routines_dir)
+    if name not in loaded:
+        file_path.write_text(old_code)
+        return {"error": "Updated code failed to load (syntax error?). Reverted to previous version."}
+
+    routine = loaded[name]
+    return {
+        "updated": True,
+        "name": name,
+        "description": routine.description,
+    }
+
+
+def delete_routine(name: str, strategy_id: str | None) -> dict:
+    """Delete an agent-local routine."""
+    routines_dir = _get_agent_routines_dir(strategy_id)
+    if not routines_dir:
+        return {"error": "strategy_id is required (or CONDOR_AGENT_SLUG must be set)"}
+
+    file_path = routines_dir / f"{name}.py"
+    if not file_path.exists():
+        return {"error": f"Agent routine '{name}' not found"}
+
+    file_path.unlink()
+    return {"deleted": True, "name": name}
+
+
+async def manage_routines(
+    action: str,
+    name: str | None = None,
+    config: dict | None = None,
+    strategy_id: str | None = None,
+    code: str | None = None,
+) -> dict:
+    if action == "list":
+        return list_routines(strategy_id)
+    if action == "describe":
+        if not name:
+            return {"error": "name is required"}
+        return describe_routine(name)
+    if action == "run":
+        if not name:
+            return {"error": "name is required"}
+        return await run_routine(name, config, strategy_id)
+    if action == "create_routine":
+        if not name:
+            return {"error": "name is required"}
+        return create_routine(name, code or "", strategy_id)
+    if action == "read_routine":
+        if not name:
+            return {"error": "name is required"}
+        return read_routine(name, strategy_id)
+    if action == "edit_routine":
+        if not name:
+            return {"error": "name is required"}
+        return edit_routine(name, code or "", strategy_id)
+    if action == "delete_routine":
+        if not name:
+            return {"error": "name is required"}
+        return delete_routine(name, strategy_id)
+    if action == "start":
+        if not name:
+            return {"error": "name is required"}
+        return await start_routine(name, config)
+    if action == "stop":
+        if not name:
+            return {"error": "instance_id is required (pass as name)"}
+        return stop_routine(name)
+    if action == "list_instances":
+        return list_instances()
+    return {"error": f"Unknown action: {action}"}

--- a/mcp_servers/condor/tools/routines.py
+++ b/mcp_servers/condor/tools/routines.py
@@ -115,7 +115,9 @@ class MCPContext:
         self._chat_id = settings.chat_id
         self._user_id = settings.user_id
         self._user_data: dict = {}
-        self.bot = None
+        # Use the HTTP fallback bot from routine_store so messages are delivered
+        from condor.routine_store import _http_bot
+        self.bot = _http_bot
         self.application = None
 
     @property

--- a/mcp_servers/condor/tools/servers.py
+++ b/mcp_servers/condor/tools/servers.py
@@ -1,0 +1,47 @@
+"""Server list and status tools."""
+
+from mcp_servers.condor.settings import settings
+
+
+def list_servers() -> dict:
+    from config_manager import get_config_manager
+
+    cm = get_config_manager()
+    accessible = cm.get_accessible_servers(settings.user_id)
+    active_server = cm.get_chat_default_server(settings.chat_id)
+    servers = []
+    for name in accessible:
+        server = cm.get_server(name)
+        if not server:
+            continue
+        perm = cm.get_server_permission(settings.user_id, name)
+        servers.append({
+            "name": name,
+            "host": server["host"],
+            "port": server["port"],
+            "permission": perm.value if perm else "unknown",
+            "is_active": name == active_server,
+        })
+    return {"servers": servers, "active_server": active_server}
+
+
+async def check_status(name: str | None) -> dict:
+    from config_manager import get_config_manager
+
+    cm = get_config_manager()
+    if not name:
+        name = cm.get_chat_default_server(settings.chat_id)
+        if not name:
+            return {"error": "No active server"}
+    if not cm.has_server_access(settings.user_id, name):
+        return {"error": f"No access to server '{name}'"}
+    status = await cm.check_server_status(name)
+    return {"server": name, **status}
+
+
+async def manage_servers(action: str, name: str | None = None) -> dict:
+    if action == "list":
+        return list_servers()
+    if action == "status":
+        return await check_status(name)
+    return {"error": f"Unknown action: {action}"}

--- a/mcp_servers/condor/tools/trading_agent.py
+++ b/mcp_servers/condor/tools/trading_agent.py
@@ -1,0 +1,396 @@
+"""Trading agent strategy CRUD, lifecycle, monitoring, and journal."""
+
+from pathlib import Path
+
+from mcp_servers.condor.condor_client import call_main_api, slug_from_agent_id
+from mcp_servers.condor.exceptions import APIError
+from mcp_servers.condor.settings import settings
+
+
+# ---------------------------------------------------------------------------
+# Strategy CRUD
+# ---------------------------------------------------------------------------
+
+
+def _manage_strategy(
+    action: str, strategy_id: str | None, name: str | None,
+    description: str | None, instructions: str | None,
+    agent_key: str | None, skills: list[str] | None, config: dict | None,
+) -> dict:
+    from condor.trading_agent.strategy import StrategyStore
+
+    store = StrategyStore()
+
+    if action == "list_strategies":
+        strategies = store.list_all()
+        return {
+            "strategies": [
+                {
+                    "id": s.id,
+                    "name": s.name,
+                    "description": s.description,
+                    "agent_key": s.agent_key,
+                    "skills": s.skills,
+                    "default_config": s.default_config,
+                }
+                for s in strategies
+            ]
+        }
+
+    elif action == "get_strategy":
+        if not strategy_id:
+            return {"error": "strategy_id is required"}
+        s = store.get(strategy_id)
+        if not s:
+            return {"error": f"Strategy '{strategy_id}' not found"}
+        return {
+            "id": s.id,
+            "name": s.name,
+            "description": s.description,
+            "agent_key": s.agent_key,
+            "instructions": s.instructions,
+            "skills": s.skills,
+            "default_config": s.default_config,
+            "created_by": s.created_by,
+            "created_at": s.created_at,
+        }
+
+    elif action == "create_strategy":
+        if not name or not instructions:
+            return {"error": "name and instructions are required"}
+        strategy = store.create(
+            name=name,
+            description=description or "",
+            agent_key=agent_key or "claude-code",
+            instructions=instructions,
+            skills=skills,
+            default_config=config,
+            created_by=settings.user_id,
+        )
+        return {"created": True, "strategy_id": strategy.id, "name": strategy.name}
+
+    elif action == "update_strategy":
+        if not strategy_id:
+            return {"error": "strategy_id is required"}
+        s = store.get(strategy_id)
+        if not s:
+            return {"error": f"Strategy '{strategy_id}' not found"}
+        if name:
+            s.name = name
+        if description:
+            s.description = description
+        if instructions:
+            s.instructions = instructions
+        if agent_key:
+            s.agent_key = agent_key
+        if skills is not None:
+            s.skills = skills
+        if config:
+            s.default_config = config
+        store.update(s)
+        return {"updated": True, "strategy_id": s.id, "name": s.name}
+
+    elif action == "delete_strategy":
+        if not strategy_id:
+            return {"error": "strategy_id is required"}
+        deleted = store.delete(strategy_id)
+        return {"deleted": deleted}
+
+    return {"error": f"Unknown strategy action: {action}"}
+
+
+# ---------------------------------------------------------------------------
+# Strategy-scoped routine listing
+# ---------------------------------------------------------------------------
+
+
+def _strategy_list_routines(strategy_id: str) -> dict:
+    """List global + agent-local routines for a strategy, with scope labels."""
+    from routines.base import discover_routines, discover_routines_from_path
+
+    result = []
+
+    for name, routine in sorted(discover_routines(force_reload=True).items()):
+        result.append({
+            "name": name,
+            "description": routine.description,
+            "type": "continuous" if routine.is_continuous else "one-shot",
+            "scope": "global",
+        })
+
+    from mcp_servers.condor.tools.routines import _get_agent_routines_dir
+    routines_dir = _get_agent_routines_dir(strategy_id)
+    if routines_dir and routines_dir.exists():
+        for name, routine in sorted(discover_routines_from_path(routines_dir).items()):
+            result.append({
+                "name": name,
+                "description": routine.description,
+                "type": "continuous" if routine.is_continuous else "one-shot",
+                "scope": "agent",
+            })
+
+    return {"routines": result}
+
+
+# ---------------------------------------------------------------------------
+# Agent lifecycle (delegates to main process via web API)
+# ---------------------------------------------------------------------------
+
+
+async def _agent_lifecycle(
+    action: str, strategy_id: str | None, agent_id: str | None, config: dict | None,
+) -> dict:
+    try:
+        if action == "list_agents":
+            result = await call_main_api("GET", "/agents")
+            agents = []
+            if isinstance(result, list):
+                for agent_summary in result:
+                    for inst in agent_summary.get("instances", []):
+                        agents.append(inst)
+            if not agents:
+                return {"agents": [], "message": "No agents running"}
+            return {"agents": agents}
+
+        if action == "start_agent":
+            if not strategy_id:
+                return {"error": "strategy_id is required"}
+
+            from condor.trading_agent.strategy import StrategyStore
+            store = StrategyStore()
+            strategy = store.get(strategy_id)
+            if not strategy:
+                return {"error": f"Strategy '{strategy_id}' not found"}
+
+            from condor.trading_agent.config import load_full_config
+            from config_manager import get_config_manager, get_effective_server
+            config_dict = load_full_config(strategy.agent_dir, strategy.default_config)
+            if config:
+                if config.get("dry_run") and "execution_mode" not in config:
+                    config["execution_mode"] = "dry_run"
+                config_dict.update(config)
+            if not config or "server_name" not in config:
+                effective = settings.active_server or get_effective_server(settings.chat_id)
+                if not effective:
+                    cm = get_config_manager()
+                    accessible = cm.get_accessible_servers(settings.user_id)
+                    effective = accessible[0] if accessible else None
+                if effective:
+                    config_dict["server_name"] = effective
+
+            trading_context = config_dict.pop("trading_context", "")
+
+            return await call_main_api("POST", f"/agents/{strategy.slug}/start", {
+                "config": config_dict,
+                "trading_context": trading_context,
+                "chat_id": settings.chat_id,
+                "user_id": settings.user_id,
+            })
+
+        if action == "stop_agent":
+            if not agent_id:
+                return {"error": "agent_id is required"}
+            slug = slug_from_agent_id(agent_id)
+            return await call_main_api("POST", f"/agents/{slug}/stop?agent_id={agent_id}")
+
+        if action == "pause_agent":
+            if not agent_id:
+                return {"error": "agent_id is required"}
+            slug = slug_from_agent_id(agent_id)
+            return await call_main_api("POST", f"/agents/{slug}/pause?agent_id={agent_id}")
+
+        if action == "resume_agent":
+            if not agent_id:
+                return {"error": "agent_id is required"}
+            slug = slug_from_agent_id(agent_id)
+            return await call_main_api("POST", f"/agents/{slug}/resume?agent_id={agent_id}")
+
+        return {"error": f"Unknown lifecycle action: {action}"}
+    except APIError as e:
+        return {"error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# Journal read/write
+# ---------------------------------------------------------------------------
+
+
+def _resolve_journal_manager(agent_id: str):
+    """Get JournalManager for an agent, returns (jm, error_dict)."""
+    from condor.trading_agent.journal import JournalManager
+    from condor.trading_agent.engine import get_engine
+
+    engine = get_engine(agent_id)
+    if engine:
+        if engine.is_experiment:
+            return None, {"content": "(experiment mode — no journal, results saved to dry_runs/)"}
+        session_dir = engine.session_dir
+        agent_dir = engine.strategy.agent_dir
+    else:
+        from condor.trading_agent.journal import resolve_agent_dirs
+        session_dir, agent_dir = resolve_agent_dirs(agent_id)
+    if not session_dir:
+        return None, {"content": "(no journal available for this agent)"}
+    return JournalManager(agent_id, session_dir=session_dir, agent_dir=agent_dir), None
+
+
+def journal_read(agent_id: str, section: str = "recent", max_entries: int = 30) -> dict:
+    if not agent_id:
+        return {"error": "agent_id is required"}
+
+    jm, err = _resolve_journal_manager(agent_id)
+    if err:
+        return err
+
+    if section == "full":
+        return {"content": jm.read_full()}
+    elif section == "learnings":
+        return {"content": jm.read_learnings()}
+    elif section in ("state", "summary"):
+        return {"content": jm.read_state()}
+    elif section == "runs":
+        runs = jm.list_runs(limit=max_entries)
+        return {"runs": runs}
+    elif section.startswith("run:"):
+        try:
+            tick_num = int(section.split(":", 1)[1])
+        except (ValueError, IndexError):
+            return {"error": "Invalid run format. Use 'run:N' where N is the tick number."}
+        content = jm.read_run_snapshot(tick_num)
+        if not content:
+            return {"error": f"No run snapshot found for tick #{tick_num}"}
+        return {"content": content}
+    else:
+        return {"content": jm.read_recent(max_entries=max_entries)}
+
+
+def journal_write(
+    agent_id: str, entry_type: str, text: str,
+    reasoning: str = "", risk_note: str = "", tick: int = 0, category: str = "",
+) -> dict:
+    if not agent_id:
+        return {"error": "agent_id is required"}
+    if not text:
+        return {"error": "text is required"}
+
+    from condor.trading_agent.journal import JournalManager
+    from condor.trading_agent.engine import get_engine
+
+    engine = get_engine(agent_id)
+    if engine:
+        if engine.is_experiment:
+            return {"error": "experiments don't have a journal — use dry_runs/ for results"}
+        session_dir = engine.session_dir
+        agent_dir = engine.strategy.agent_dir
+    else:
+        from condor.trading_agent.journal import resolve_agent_dirs
+        session_dir, agent_dir = resolve_agent_dirs(agent_id)
+    if not session_dir:
+        return {"error": "no journal available for this agent"}
+    jm = JournalManager(agent_id, session_dir=session_dir, agent_dir=agent_dir)
+
+    if entry_type == "learning":
+        jm.append_learning(text, category=category or "market")
+    elif entry_type == "state":
+        jm.write_state(text)
+    else:
+        jm.append_action(tick, text, reasoning, risk_note)
+    return {"written": True}
+
+
+# ---------------------------------------------------------------------------
+# Agent monitoring (file-based)
+# ---------------------------------------------------------------------------
+
+
+def _agent_monitoring(action: str, agent_id: str | None) -> dict:
+    if not agent_id:
+        return {"error": "agent_id is required"}
+
+    jm, err = _resolve_journal_manager(agent_id)
+    if err:
+        # For monitoring, convert experiment/missing journal to error
+        if "experiment" in str(err.get("content", "")):
+            return {"error": "experiments don't have a journal — use dry_runs/ for results"}
+        return {"error": "no journal available for this agent"}
+
+    if action == "agent_tracker":
+        content = jm.read_full()
+        summary = jm.get_summary_dict()
+        return {"tracker_md": content, "summary": summary}
+
+    elif action == "agent_journal":
+        return {
+            "recent_actions": jm.read_recent(max_entries=30),
+            "learnings": jm.read_learnings(),
+            "entry_count": jm.entry_count(),
+        }
+
+    return {"error": f"Unknown monitoring action: {action}"}
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+async def manage_trading_agent(
+    action: str,
+    agent_id: str | None = None,
+    strategy_id: str | None = None,
+    name: str | None = None,
+    description: str | None = None,
+    instructions: str | None = None,
+    agent_key: str | None = None,
+    skills: list[str] | None = None,
+    config: dict | None = None,
+    # Journal params (for journal_read/journal_write actions)
+    section: str = "recent",
+    max_entries: int = 30,
+    entry_type: str = "action",
+    text: str = "",
+    reasoning: str = "",
+    risk_note: str = "",
+    tick: int = 0,
+    category: str = "",
+) -> dict:
+    # Strategy operations
+    local_strategy_actions = {
+        "list_strategies", "get_strategy", "create_strategy",
+        "update_strategy", "delete_strategy",
+    }
+    if action in local_strategy_actions:
+        return _manage_strategy(action, strategy_id, name, description,
+                                instructions, agent_key, skills, config)
+
+    # Routine actions scoped to a strategy
+    if action == "list_routines":
+        if not strategy_id:
+            return {"error": "strategy_id is required"}
+        return _strategy_list_routines(strategy_id)
+
+    if action == "run_routine":
+        if not strategy_id:
+            return {"error": "strategy_id is required"}
+        if not name:
+            return {"error": "name is required"}
+        from mcp_servers.condor.tools.routines import run_routine
+        return await run_routine(name, config, strategy_id)
+
+    # Agent lifecycle actions
+    lifecycle_actions = {"start_agent", "stop_agent", "pause_agent", "resume_agent", "list_agents"}
+    if action in lifecycle_actions:
+        return await _agent_lifecycle(action, strategy_id, agent_id, config)
+
+    # Journal actions (absorbed from standalone tools)
+    if action == "journal_read":
+        return journal_read(agent_id or "", section, max_entries)
+
+    if action == "journal_write":
+        return journal_write(agent_id or "", entry_type, text, reasoning, risk_note, tick, category)
+
+    # Journal/monitoring that's file-based
+    if action in ("agent_tracker", "agent_journal"):
+        return _agent_monitoring(action, agent_id)
+
+    return {"error": f"Unknown action: {action}"}

--- a/mcp_servers/hummingbot_api/formatters/executors.py
+++ b/mcp_servers/hummingbot_api/formatters/executors.py
@@ -204,8 +204,36 @@ def format_executor_detail(executor: dict[str, Any]) -> str:
     if close_timestamp is not None and close_timestamp != "N/A" and close_timestamp != 0:
         output += f"Closed: {format_timestamp(close_timestamp, '%Y-%m-%d %H:%M:%S')}\n"
 
-    # Show custom_info summary (skip large lists/dicts to keep response compact)
+    # Show full config if present (creation parameters)
+    config = executor.get("config")
+    if config and isinstance(config, dict):
+        output += "\nConfig:\n"
+        for key, value in config.items():
+            if isinstance(value, list):
+                output += f"  {key}: [{len(value)} items]\n"
+            else:
+                output += f"  {key}: {value}\n"
+
+    # Extract grid config from custom_info level prices
     if custom_info:
+        grid_levels = custom_info.get("grid_level_prices")
+        grid_tp = custom_info.get("grid_tp_prices")
+        if isinstance(grid_levels, list) and len(grid_levels) > 1:
+            output += "\nGrid Config (derived from level prices):\n"
+            output += f"  start_price: {format_number(min(grid_levels), decimals=2, compact=False)}\n"
+            output += f"  end_price: {format_number(max(grid_levels), decimals=2, compact=False)}\n"
+            output += f"  num_levels: {len(grid_levels)}\n"
+            sorted_levels = sorted(grid_levels)
+            spreads = [(sorted_levels[i+1] - sorted_levels[i]) / sorted_levels[i]
+                       for i in range(len(sorted_levels) - 1)]
+            avg_spread = sum(spreads) / len(spreads) if spreads else 0
+            output += f"  avg_spread_between_levels: {format_percentage(avg_spread)}\n"
+            if isinstance(grid_tp, list) and len(grid_tp) > 1:
+                tp_diffs = [abs(grid_tp[i] - grid_levels[i]) / grid_levels[i]
+                            for i in range(min(len(grid_tp), len(grid_levels)))]
+                avg_tp = sum(tp_diffs) / len(tp_diffs) if tp_diffs else 0
+                output += f"  avg_take_profit: {format_percentage(avg_tp)}\n"
+
         output += "\nCustom Info:\n"
         for key, value in custom_info.items():
             if isinstance(value, (list, dict)):

--- a/mcp_servers/hummingbot_api/server.py
+++ b/mcp_servers/hummingbot_api/server.py
@@ -128,31 +128,28 @@ async def configure_server(
         username: API username
         password: API password
     """
-    from mcp_servers.hummingbot_api.settings import ServerConfig, _load_server_config, save_server_config
+    from mcp_servers.hummingbot_api.settings import ServerConfig, save_server_config
 
-    # No params → show active server
+    # No params → show active server (use in-memory settings which include CLI overrides)
     if name is None and host is None and port is None and username is None and password is None:
-        current = _load_server_config()
         return (
             f"Active Server:\n\n"
-            f"  Name: {current.name}\n"
-            f"  URL: {current.url}\n"
-            f"  Username: {current.username}\n"
+            f"  Name: {settings.server_name}\n"
+            f"  URL: {settings.api_url}\n"
+            f"  Username: {settings.api_username}\n"
         )
 
-    # Build new config with partial updates
-    current = _load_server_config()
-
+    # Build new config with partial updates (use in-memory settings, not disk)
     from urllib.parse import urlparse
-    parsed = urlparse(current.url)
+    parsed = urlparse(settings.api_url)
     current_host = parsed.hostname or "localhost"
     current_port = parsed.port or 8000
 
-    final_name = name if name is not None else current.name
+    final_name = name if name is not None else settings.server_name
     final_host = host if host is not None else current_host
     final_port = port if port is not None else current_port
-    final_username = username if username is not None else current.username
-    final_password = password if password is not None else current.password
+    final_username = username if username is not None else settings.api_username
+    final_password = password if password is not None else settings.api_password
 
     new_config = ServerConfig(
         name=final_name,

--- a/mcp_servers/hummingbot_api/tools/bot_management.py
+++ b/mcp_servers/hummingbot_api/tools/bot_management.py
@@ -270,7 +270,8 @@ async def update_bot_controller_config(
                            "Set confirm_override=True to update it."),
             }
         else:
-            update_op = await client.controllers.update_bot_controller_config(bot_name, config_name, config_data)
+            clean_data = {k: v for k, v in config_data.items() if not k.startswith("_")}
+            update_op = await client.controllers.update_bot_controller_config(bot_name, config_name, clean_data)
             return {
                 "action": "update_config",
                 "exists": False,
@@ -283,7 +284,8 @@ async def update_bot_controller_config(
         # Ensure config_data has the correct id
         if "id" not in config_data or config_data["id"] != config_name:
             config_data["id"] = config_name
-        update_op = await client.controllers.update_bot_controller_config(bot_name, config_name, config_data)
+        clean_data = {k: v for k, v in config_data.items() if not k.startswith("_")}
+        update_op = await client.controllers.update_bot_controller_config(bot_name, config_name, clean_data)
         return {
             "action": "update_config",
             "exists": True,

--- a/mcp_servers/hummingbot_api/tools/controllers.py
+++ b/mcp_servers/hummingbot_api/tools/controllers.py
@@ -387,7 +387,9 @@ async def modify_controllers(
                                "Set confirm_override=True to update it."),
                 }
 
-            result = await client.controllers.create_or_update_controller_config(config_name, config_data)
+            # Strip internal fields like _config_name that cause Pydantic validation errors
+            clean_data = {k: v for k, v in config_data.items() if not k.startswith("_")}
+            result = await client.controllers.create_or_update_controller_config(config_name, clean_data)
             return {
                 "action": "upsert",
                 "target": "config",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Telegram bot for Hummingbot trading via Backend API"
 requires-python = ">=3.12"
 dependencies = [
     "python-telegram-bot[job-queue]",
-    "hummingbot-api-client==1.4.1",
+    "hummingbot-api-client==1.5.0",
     "python-dotenv",
     "PyYAML",
     "aiohttp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Telegram bot for Hummingbot trading via Backend API"
 requires-python = ">=3.12"
 dependencies = [
     "python-telegram-bot[job-queue]",
-    "hummingbot-api-client==1.5.0",
+    "hummingbot-api-client==1.5.2",
     "python-dotenv",
     "PyYAML",
     "aiohttp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Telegram bot for Hummingbot trading via Backend API"
 requires-python = ">=3.12"
 dependencies = [
     "python-telegram-bot[job-queue]",
-    "hummingbot-api-client==1.5.2",
+    "hummingbot-api-client==1.5.3",
     "python-dotenv",
     "PyYAML",
     "aiohttp",

--- a/routines/arb_check.py
+++ b/routines/arb_check.py
@@ -29,41 +29,27 @@ class Config(BaseModel):
 
 
 def _parse_exchanges(raw: str) -> list[str]:
-    """Parse comma-separated exchange list, stripping whitespace."""
     return [e.strip().lower() for e in raw.split(",") if e.strip()]
 
 
 async def _get_order_book(client, connector: str, trading_pair: str, depth: int) -> dict | None:
-    """Fetch full order book with bids and asks."""
     try:
         result = await client.market_data.get_order_book(
-            connector_name=connector,
-            trading_pair=trading_pair,
-            depth=depth,
+            connector_name=connector, trading_pair=trading_pair, depth=depth,
         )
-        if isinstance(result, dict):
-            return result
-        return None
+        return result if isinstance(result, dict) else None
     except Exception as e:
         logger.warning(f"Order book failed for {connector}/{trading_pair}: {e}")
         return None
 
 
 async def _get_fill_price(client, connector: str, trading_pair: str, amount: float, is_buy: bool) -> float | None:
-    """Get volume-weighted fill price from order book."""
     try:
         result = await client.market_data.get_price_for_volume(
-            connector_name=connector,
-            trading_pair=trading_pair,
-            volume=amount,
-            is_buy=is_buy,
+            connector_name=connector, trading_pair=trading_pair, volume=amount, is_buy=is_buy,
         )
         if isinstance(result, dict):
-            price = (
-                result.get("result_price")
-                or result.get("price")
-                or result.get("average_price")
-            )
+            price = result.get("result_price") or result.get("price") or result.get("average_price")
             return float(price) if price else None
         return None
     except Exception as e:
@@ -72,7 +58,6 @@ async def _get_fill_price(client, connector: str, trading_pair: str, amount: flo
 
 
 def _parse_level(level) -> tuple[float, float]:
-    """Parse a single OB level from list [price, size] or dict {price, quantity}."""
     if isinstance(level, dict):
         price = float(level.get("price", level.get("Price", 0)))
         size = float(level.get("quantity", level.get("size", level.get("amount", level.get("Quantity", 0)))))
@@ -81,19 +66,16 @@ def _parse_level(level) -> tuple[float, float]:
 
 
 def _parse_ob_levels(ob: dict) -> tuple[list, list]:
-    """Parse order book into [(price, size, cumulative)] for bids and asks."""
     bids_raw = ob.get("bids", [])
     asks_raw = ob.get("asks", [])
 
-    bids = []
-    cum = 0.0
+    bids, cum = [], 0.0
     for level in bids_raw:
         price, size = _parse_level(level)
         cum += size
         bids.append((price, size, cum))
 
-    asks = []
-    cum = 0.0
+    asks, cum = [], 0.0
     for level in asks_raw:
         price, size = _parse_level(level)
         cum += size
@@ -103,24 +85,17 @@ def _parse_ob_levels(ob: dict) -> tuple[list, list]:
 
 
 def _ob_stats(bids: list, asks: list) -> dict:
-    """Compute order book statistics."""
     best_bid = bids[0][0] if bids else None
     best_ask = asks[0][0] if asks else None
     mid = (best_bid + best_ask) / 2 if best_bid and best_ask else None
     spread_pct = ((best_ask - best_bid) / best_bid * 100) if best_bid and best_ask else None
-
     bid_depth_usd = sum(p * s for p, s, _ in bids)
     ask_depth_usd = sum(p * s for p, s, _ in asks)
 
     return {
-        "best_bid": best_bid,
-        "best_ask": best_ask,
-        "mid": mid,
-        "spread_pct": spread_pct,
-        "bid_depth_usd": bid_depth_usd,
-        "ask_depth_usd": ask_depth_usd,
-        "n_bid_levels": len(bids),
-        "n_ask_levels": len(asks),
+        "best_bid": best_bid, "best_ask": best_ask, "mid": mid,
+        "spread_pct": spread_pct, "bid_depth_usd": bid_depth_usd,
+        "ask_depth_usd": ask_depth_usd, "n_bid_levels": len(bids), "n_ask_levels": len(asks),
     }
 
 
@@ -128,88 +103,214 @@ def _spread_pct(buy_price: float, sell_price: float) -> float:
     return ((sell_price - buy_price) / buy_price) * 100
 
 
+def _filter_and_sort_exchanges(exchanges: list[str], ex_data: dict) -> tuple[list[str], list[tuple[str, str]]]:
+    """Filter out exchanges with invalid data and sort by spread (smallest first).
+
+    Returns (valid_exchanges, invalid_list) where invalid_list is [(name, reason), ...].
+    """
+    # First pass: filter exchanges with no OB or no prices
+    candidates = []
+    invalid = []
+    for ex in exchanges:
+        d = ex_data[ex]
+        s = d["stats"]
+        if not d["ob"]:
+            invalid.append((ex, "Order book fetch failed"))
+        elif not s.get("best_bid") or not s.get("best_ask"):
+            invalid.append((ex, "Missing bid/ask prices"))
+        else:
+            candidates.append(ex)
+
+    # Second pass: cross-validate prices — filter outliers where mid differs from median by >90%
+    if len(candidates) >= 2:
+        mids = [(ex, ex_data[ex]["stats"]["mid"]) for ex in candidates]
+        sorted_mids = sorted(m for _, m in mids)
+        median_mid = sorted_mids[len(sorted_mids) // 2]
+        still_valid = []
+        for ex in candidates:
+            mid = ex_data[ex]["stats"]["mid"]
+            if median_mid > 0 and abs(mid - median_mid) / median_mid > 0.5:
+                invalid.append((ex, f"Price outlier (mid={mid:.8g} vs median={median_mid:.6f})"))
+            else:
+                still_valid.append(ex)
+        candidates = still_valid
+
+    # Sort by spread (smallest first)
+    candidates.sort(key=lambda ex: ex_data[ex]["stats"].get("spread_pct") or float("inf"))
+
+    return candidates, invalid
+
+
 def _build_ob_chart(exchange_data: list[tuple[str, list, list]], pair: str):
-    """Build a Plotly figure with N order books stacked vertically (one per exchange)."""
+    """Build Plotly figure: left = shared-x OB depth, right = L1 dumbbell BPS chart."""
     import plotly.graph_objects as go
     from plotly.subplots import make_subplots
 
     n = len(exchange_data)
+
+    # Reference mid = first exchange (sorted by tightest spread)
+    ref_name = exchange_data[0][0]
+    ref_bids, ref_asks = exchange_data[0][1], exchange_data[0][2]
+    ref_mid = (ref_bids[0][0] + ref_asks[0][0]) / 2 if ref_bids and ref_asks else None
+
+    vs = 0.08 if n <= 4 else 0.05
+
     fig = make_subplots(
-        rows=n, cols=1,
-        subplot_titles=[f"{name.upper()} Order Book" for name, _, _ in exchange_data],
-        vertical_spacing=0.08 if n <= 4 else 0.05,
-        shared_xaxes=True,
+        rows=n, cols=2,
+        shared_xaxes="columns",
+        vertical_spacing=vs,
+        horizontal_spacing=0.10,
+        column_widths=[0.55, 0.45],
     )
 
+    c_bid = "rgba(0, 200, 83, 0.8)"
+    c_ask = "rgba(255, 82, 82, 0.8)"
+    f_bid = "rgba(0, 200, 83, 0.15)"
+    f_ask = "rgba(255, 82, 82, 0.15)"
+
     for row, (name, bids, asks) in enumerate(exchange_data, start=1):
+        # --- Left column: order book depth ---
         if bids:
-            bid_prices = [b[0] for b in bids]
-            bid_cum = [b[2] for b in bids]
-            fig.add_trace(
-                go.Scatter(
-                    x=bid_prices, y=bid_cum,
-                    fill="tozeroy",
-                    fillcolor="rgba(0, 200, 83, 0.15)",
-                    line=dict(color="rgba(0, 200, 83, 0.8)", width=2, shape="hv"),
-                    name="Bids",
-                    hovertemplate="Price: %{x:.4f}<br>Cumul. Size: %{y:.4f}<extra></extra>",
-                    showlegend=(row == 1),
-                    legendgroup="bids",
-                ),
-                row=row, col=1,
-            )
+            fig.add_trace(go.Scatter(
+                x=[b[0] for b in bids], y=[b[2] for b in bids],
+                fill="tozeroy", fillcolor=f_bid,
+                line=dict(color=c_bid, width=2, shape="hv"),
+                name="Bids", hovertemplate="Price: %{x:.6f}<br>Cumul: %{y:.2f}<extra></extra>",
+                showlegend=(row == 1), legendgroup="bids",
+            ), row=row, col=1)
 
         if asks:
-            ask_prices = [a[0] for a in asks]
-            ask_cum = [a[2] for a in asks]
-            fig.add_trace(
-                go.Scatter(
-                    x=ask_prices, y=ask_cum,
-                    fill="tozeroy",
-                    fillcolor="rgba(255, 82, 82, 0.15)",
-                    line=dict(color="rgba(255, 82, 82, 0.8)", width=2, shape="hv"),
-                    name="Asks",
-                    hovertemplate="Price: %{x:.4f}<br>Cumul. Size: %{y:.4f}<extra></extra>",
-                    showlegend=(row == 1),
-                    legendgroup="asks",
-                ),
-                row=row, col=1,
-            )
+            fig.add_trace(go.Scatter(
+                x=[a[0] for a in asks], y=[a[2] for a in asks],
+                fill="tozeroy", fillcolor=f_ask,
+                line=dict(color=c_ask, width=2, shape="hv"),
+                name="Asks", hovertemplate="Price: %{x:.6f}<br>Cumul: %{y:.2f}<extra></extra>",
+                showlegend=(row == 1), legendgroup="asks",
+            ), row=row, col=1)
 
-        # Mid-price vertical line
         if bids and asks:
             mid = (bids[0][0] + asks[0][0]) / 2
             fig.add_vline(
                 x=mid, row=row, col=1,
-                line=dict(color="rgba(255, 255, 255, 0.4)", width=1, dash="dash"),
-                annotation_text=f"Mid: {mid:.4f}",
-                annotation_font_size=10,
-                annotation_font_color="rgba(255,255,255,0.6)",
+                line=dict(color="rgba(255,255,255,0.4)", width=1, dash="dash"),
             )
 
-    # Shared x-axis range
+        # --- Right column: L1 dumbbell BPS ---
+        if bids and asks and ref_mid and ref_mid > 0:
+            bid_bps = ((bids[0][0] - ref_mid) / ref_mid) * 10000
+            ask_bps = ((asks[0][0] - ref_mid) / ref_mid) * 10000
+            mid_bps = (((bids[0][0] + asks[0][0]) / 2 - ref_mid) / ref_mid) * 10000
+
+            # Connecting line between bid and ask
+            fig.add_trace(go.Scatter(
+                x=[bid_bps, ask_bps], y=[0, 0],
+                mode="lines",
+                line=dict(color="rgba(255,255,255,0.25)", width=4),
+                showlegend=False, hoverinfo="skip",
+            ), row=row, col=2)
+
+            # Bid dot with BPS label
+            fig.add_trace(go.Scatter(
+                x=[bid_bps], y=[0],
+                mode="markers+text",
+                marker=dict(color=c_bid, size=13, line=dict(width=1.5, color="#1a1a2e")),
+                text=[f"{bid_bps:+.1f}"],
+                textposition="bottom center",
+                textfont=dict(size=10, color=c_bid),
+                name="L1 Bid", showlegend=(row == 1), legendgroup="l1_bid",
+                hovertemplate=f"Bid: {bids[0][0]:.6f} ({bid_bps:+.1f} BPS)<extra>{name.upper()}</extra>",
+            ), row=row, col=2)
+
+            # Ask dot with BPS label
+            fig.add_trace(go.Scatter(
+                x=[ask_bps], y=[0],
+                mode="markers+text",
+                marker=dict(color=c_ask, size=13, line=dict(width=1.5, color="#1a1a2e")),
+                text=[f"{ask_bps:+.1f}"],
+                textposition="top center",
+                textfont=dict(size=10, color=c_ask),
+                name="L1 Ask", showlegend=(row == 1), legendgroup="l1_ask",
+                hovertemplate=f"Ask: {asks[0][0]:.6f} ({ask_bps:+.1f} BPS)<extra>{name.upper()}</extra>",
+            ), row=row, col=2)
+
+            # Mid diamond for non-reference exchanges
+            if row > 1 and abs(mid_bps) > 0.5:
+                fig.add_trace(go.Scatter(
+                    x=[mid_bps], y=[0],
+                    mode="markers+text",
+                    marker=dict(color="rgba(88, 166, 255, 0.9)", size=9, symbol="diamond",
+                                line=dict(width=1, color="#1a1a2e")),
+                    text=[f"mid {mid_bps:+.1f}"],
+                    textposition="bottom center",
+                    textfont=dict(size=9, color="rgba(88, 166, 255, 0.7)"),
+                    showlegend=False,
+                    hovertemplate=f"Mid: {mid:.6f} ({mid_bps:+.1f} BPS)<extra>{name.upper()}</extra>",
+                ), row=row, col=2)
+
+            # Zero reference line
+            fig.add_vline(
+                x=0, row=row, col=2,
+                line=dict(color="rgba(255,255,255,0.4)", width=1, dash="dash"),
+            )
+
+    # Shared x-axis range for left column (OB depth charts)
     all_prices = []
     for _, bids, asks in exchange_data:
         all_prices.extend(b[0] for b in bids)
         all_prices.extend(a[0] for a in asks)
     if all_prices:
-        price_min, price_max = min(all_prices), max(all_prices)
-        margin = (price_max - price_min) * 0.02
-        fig.update_xaxes(range=[price_min - margin, price_max + margin])
+        pmin, pmax = min(all_prices), max(all_prices)
+        margin = (pmax - pmin) * 0.02
+        for row in range(1, n + 1):
+            fig.update_xaxes(range=[pmin - margin, pmax + margin], row=row, col=1)
 
-    row_height = 250
+    # Exchange name labels on the left side of each row
+    row_h = (1 - (n - 1) * vs) / n
+    for i, (name, _, _) in enumerate(exchange_data):
+        row_top = 1 - i * (row_h + vs)
+        row_center = row_top - row_h / 2
+        fig.add_annotation(
+            text=f"<b>{name.upper()}</b>",
+            xref="paper", yref="paper",
+            x=-0.07, y=row_center,
+            showarrow=False,
+            font=dict(size=13, color="#e0e0e0"),
+            textangle=-90,
+        )
+
+    # Column header annotations
+    fig.add_annotation(
+        text="<b>Order Book Depth</b>", xref="paper", yref="paper",
+        x=0.275, y=1.04, showarrow=False,
+        font=dict(size=14, color="#e0e0e0"),
+    )
+    fig.add_annotation(
+        text=f"<b>L1 BPS from {ref_name.upper()} Mid</b>",
+        xref="paper", yref="paper",
+        x=0.80, y=1.04, showarrow=False,
+        font=dict(size=14, color="#e0e0e0"),
+    )
+
+    row_height = 220
     fig.update_layout(
         height=max(400, row_height * n),
         template="plotly_dark",
         paper_bgcolor="#1a1a2e",
         plot_bgcolor="#16213e",
         font=dict(color="#e0e0e0"),
-        legend=dict(orientation="h", yanchor="top", y=-0.05, xanchor="center", x=0.5),
-        margin=dict(t=80, b=40, l=60, r=30),
+        legend=dict(orientation="h", yanchor="top", y=-0.06, xanchor="center", x=0.5),
+        margin=dict(t=60, b=50, l=80, r=30),
     )
+
+    # Axis labels — only on bottom row (shared x handles the rest)
     fig.update_xaxes(title_text="Price", row=n, col=1)
+    fig.update_xaxes(title_text="BPS from Reference", row=n, col=2)
     for row in range(1, n + 1):
-        fig.update_yaxes(title_text="Cumul. Size", row=row, col=1)
+        # Hide y-axis on right column (dumbbell doesn't need it)
+        fig.update_yaxes(
+            showticklabels=False, showgrid=False, zeroline=False,
+            range=[-1, 1], row=row, col=2,
+        )
 
     return fig
 
@@ -228,40 +329,46 @@ async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
 
     pair = config.trading_pair
 
-    # Fetch all order books and fill prices in parallel
-    tasks = []
-    for ex in exchanges:
-        tasks.append(_get_order_book(client, ex, pair, config.ob_depth))
-        tasks.append(_get_fill_price(client, ex, pair, config.amount, True))   # buy
-        tasks.append(_get_fill_price(client, ex, pair, config.amount, False))  # sell
+    # Fetch all order books and fill prices in parallel with asyncio.gather
+    ob_tasks = [_get_order_book(client, ex, pair, config.ob_depth) for ex in exchanges]
+    buy_tasks = [_get_fill_price(client, ex, pair, config.amount, True) for ex in exchanges]
+    sell_tasks = [_get_fill_price(client, ex, pair, config.amount, False) for ex in exchanges]
 
-    results = await asyncio.gather(*tasks)
+    all_results = await asyncio.gather(*ob_tasks, *buy_tasks, *sell_tasks)
 
-    # Unpack: every 3 results = (ob, fill_buy, fill_sell) per exchange
+    # Unpack results
+    n_ex = len(exchanges)
+    ob_results = all_results[:n_ex]
+    buy_results = all_results[n_ex:2 * n_ex]
+    sell_results = all_results[2 * n_ex:]
+
     ex_data = {}
     for i, ex in enumerate(exchanges):
-        ob = results[i * 3]
-        fill_buy = results[i * 3 + 1]
-        fill_sell = results[i * 3 + 2]
+        ob = ob_results[i]
         bids, asks = _parse_ob_levels(ob) if ob else ([], [])
         stats = _ob_stats(bids, asks) if ob else {}
         ex_data[ex] = {
             "ob": ob, "bids": bids, "asks": asks, "stats": stats,
-            "fill_buy": fill_buy, "fill_sell": fill_sell,
+            "fill_buy": buy_results[i], "fill_sell": sell_results[i],
         }
 
-    # Check at least some data came back
-    if not any(d["ob"] for d in ex_data.values()):
-        return f"Could not fetch order books from any exchange: {', '.join(exchanges)}"
+    # Filter invalid exchanges and sort by spread
+    valid_exchanges, invalid_exchanges = _filter_and_sort_exchanges(exchanges, ex_data)
 
-    # Build text output
+    if not valid_exchanges:
+        msg = f"Could not fetch valid order books from any exchange: {', '.join(exchanges)}"
+        if invalid_exchanges:
+            msg += "\n\nFiltered out:\n" + "\n".join(f"  {ex.upper()}: {reason}" for ex, reason in invalid_exchanges)
+        return msg
+
+    # Build text output (sorted by spread)
     lines = [
         f"CEX Order Book Comparison: {pair}",
-        f"Exchanges: {', '.join(e.upper() for e in exchanges)} | Quote: {config.amount} {pair.split('-')[0]}",
+        f"Exchanges: {', '.join(e.upper() for e in valid_exchanges)} | Quote: {config.amount} {pair.split('-')[0]}",
         "",
     ]
 
-    for ex in exchanges:
+    for ex in valid_exchanges:
         d = ex_data[ex]
         lines.append(f"--- {ex.upper()} ---")
         if d["stats"]:
@@ -273,33 +380,35 @@ async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
             lines.append(f"  Fill BUY  {config.amount} @ {d['fill_buy']:.6f}")
         if d["fill_sell"]:
             lines.append(f"  Fill SELL {config.amount} @ {d['fill_sell']:.6f}")
-        if not d["stats"] and not d["fill_buy"]:
-            lines.append("  No data available")
         lines.append("")
 
-    # Arb analysis across all pairs
+    if invalid_exchanges:
+        lines.append("--- Filtered Out ---")
+        for ex, reason in invalid_exchanges:
+            lines.append(f"  {ex.upper()}: {reason}")
+        lines.append("")
+
+    # Arb analysis across valid pairs
     lines.append("--- Arbitrage Matrix ---")
     opportunities = []
 
-    for ex_a, ex_b in combinations(exchanges, 2):
+    for ex_a, ex_b in combinations(valid_exchanges, 2):
         da, db = ex_data[ex_a], ex_data[ex_b]
 
-        # Buy on A, sell on B
         if da["fill_buy"] and db["fill_sell"]:
             s = _spread_pct(da["fill_buy"], db["fill_sell"])
             profit = (db["fill_sell"] - da["fill_buy"]) * config.amount
             label = f"BUY {ex_a.upper()} -> SELL {ex_b.upper()}: {s:+.4f}% (${profit:.4f})"
             (opportunities if s > 0 else lines).append(label)
 
-        # Buy on B, sell on A
         if db["fill_buy"] and da["fill_sell"]:
             s = _spread_pct(db["fill_buy"], da["fill_sell"])
             profit = (da["fill_sell"] - db["fill_buy"]) * config.amount
             label = f"BUY {ex_b.upper()} -> SELL {ex_a.upper()}: {s:+.4f}% (${profit:.4f})"
             (opportunities if s > 0 else lines).append(label)
 
-    # Mid-price diffs
-    mids = {ex: d["stats"]["mid"] for ex, d in ex_data.items() if d["stats"].get("mid")}
+    mids = {ex: d["stats"]["mid"] for ex, d in ex_data.items()
+            if ex in valid_exchanges and d["stats"].get("mid")}
     if len(mids) >= 2:
         lines.append("")
         for ex_a, ex_b in combinations(mids.keys(), 2):
@@ -318,50 +427,58 @@ async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
     try:
         from condor.reports import ReportBuilder
 
-        ex_label = " vs ".join(e.upper() for e in exchanges)
+        ex_label = " vs ".join(e.upper() for e in valid_exchanges)
         builder = ReportBuilder(f"CEX Arb: {pair} ({ex_label})")
-        builder.source("routine", "arb_check").tags(["arbitrage", "cex-cex", pair] + exchanges)
+        builder.source("routine", "arb_check").tags(["arbitrage", "cex-cex", pair] + valid_exchanges)
         builder.manual_order()
 
-        # KPIs - spreads per exchange
-        for ex in exchanges:
-            s = ex_data[ex]["stats"]
-            if s.get("spread_pct") is not None:
-                builder.kpi(f"{ex.upper()} Spread", f"{s['spread_pct']:.4f}%")
+        # KPIs - only essentials
+        builder.kpi("Exchanges", str(len(valid_exchanges)))
 
-        # KPIs - mid diffs
         if len(mids) >= 2:
             mid_vals = list(mids.values())
             max_diff = max(mid_vals) - min(mid_vals)
             max_diff_pct = (max_diff / min(mid_vals)) * 100
-            builder.kpi("Max Mid-Price Diff", f"{max_diff_pct:+.4f}%",
+            builder.kpi("Max Mid Diff", f"{max_diff_pct:+.4f}%",
                         trend="up" if max_diff_pct > 0.05 else "neutral")
 
-        # KPIs - arb opportunities
-        for ex_a, ex_b in combinations(exchanges, 2):
+        # Find best arb opportunity for KPI
+        best_arb = None
+        all_arb_routes = []
+        for ex_a, ex_b in combinations(valid_exchanges, 2):
             da, db = ex_data[ex_a], ex_data[ex_b]
             if da["fill_buy"] and db["fill_sell"]:
                 s = _spread_pct(da["fill_buy"], db["fill_sell"])
-                builder.kpi(f"BUY {ex_a.upper()} -> SELL {ex_b.upper()}", f"{s:+.4f}%",
-                            trend="up" if s > 0 else "down")
+                profit = (db["fill_sell"] - da["fill_buy"]) * config.amount
+                route = {"route": f"BUY {ex_a.upper()} → SELL {ex_b.upper()}", "spread": s, "profit": profit}
+                all_arb_routes.append(route)
+                if best_arb is None or s > best_arb["spread"]:
+                    best_arb = route
             if db["fill_buy"] and da["fill_sell"]:
                 s = _spread_pct(db["fill_buy"], da["fill_sell"])
-                builder.kpi(f"BUY {ex_b.upper()} -> SELL {ex_a.upper()}", f"{s:+.4f}%",
-                            trend="up" if s > 0 else "down")
+                profit = (da["fill_sell"] - db["fill_buy"]) * config.amount
+                route = {"route": f"BUY {ex_b.upper()} → SELL {ex_a.upper()}", "spread": s, "profit": profit}
+                all_arb_routes.append(route)
+                if best_arb is None or s > best_arb["spread"]:
+                    best_arb = route
 
-        # Order book depth chart (all exchanges stacked)
+        if best_arb:
+            builder.kpi("Best Route", f"{best_arb['route']}  {best_arb['spread']:+.4f}%",
+                        trend="up" if best_arb["spread"] > 0 else "down")
+
+        # Order book depth chart (valid exchanges, sorted by spread)
         chart_data = [
             (ex, ex_data[ex]["bids"], ex_data[ex]["asks"])
-            for ex in exchanges if ex_data[ex]["ob"]
+            for ex in valid_exchanges if ex_data[ex]["ob"]
         ]
         if len(chart_data) >= 2:
             fig = _build_ob_chart(chart_data, pair)
             builder.plotly(fig)
 
-        # Comparison table
+        # Comparison table (sorted by spread)
         builder.markdown(f"## Order Book Comparison ({config.ob_depth} levels)")
         table_rows = []
-        for ex in exchanges:
+        for ex in valid_exchanges:
             d = ex_data[ex]
             row = {"Exchange": ex.upper()}
             if d["stats"]:
@@ -372,46 +489,56 @@ async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
                 row["Spread"] = f"{s['spread_pct']:.4f}%"
                 row["Bid Depth (USD)"] = f"${s['bid_depth_usd']:,.0f}"
                 row["Ask Depth (USD)"] = f"${s['ask_depth_usd']:,.0f}"
-            else:
-                row["Best Bid"] = "N/A"
-                row["Best Ask"] = "N/A"
             row[f"Fill BUY {config.amount}"] = f"{d['fill_buy']:.6f}" if d["fill_buy"] else "N/A"
             row[f"Fill SELL {config.amount}"] = f"{d['fill_sell']:.6f}" if d["fill_sell"] else "N/A"
             table_rows.append(row)
         builder.table(table_rows)
 
-        # Arb matrix table
-        arb_rows = []
-        for ex_a, ex_b in combinations(exchanges, 2):
-            da, db = ex_data[ex_a], ex_data[ex_b]
-            row = {"Route": f"{ex_a.upper()} <-> {ex_b.upper()}"}
-            if da["fill_buy"] and db["fill_sell"]:
-                s = _spread_pct(da["fill_buy"], db["fill_sell"])
-                row[f"BUY {ex_a.upper()} SELL {ex_b.upper()}"] = f"{s:+.4f}%"
-            else:
-                row[f"BUY {ex_a.upper()} SELL {ex_b.upper()}"] = "N/A"
-            if db["fill_buy"] and da["fill_sell"]:
-                s = _spread_pct(db["fill_buy"], da["fill_sell"])
-                row[f"BUY {ex_b.upper()} SELL {ex_a.upper()}"] = f"{s:+.4f}%"
-            else:
-                row[f"BUY {ex_b.upper()} SELL {ex_a.upper()}"] = "N/A"
-            if da["stats"].get("mid") and db["stats"].get("mid"):
-                row["Mid Diff"] = f"{_spread_pct(da['stats']['mid'], db['stats']['mid']):+.4f}%"
-            arb_rows.append(row)
-        if arb_rows:
-            builder.markdown("## Arbitrage Matrix")
+        # Arb routes table — sorted by spread (best first)
+        if all_arb_routes:
+            all_arb_routes.sort(key=lambda r: r["spread"], reverse=True)
+            arb_rows = []
+            for r in all_arb_routes:
+                arb_rows.append({
+                    "Route": r["route"],
+                    "Spread": f"{r['spread']:+.4f}%",
+                    f"Profit ({config.amount} {pair.split('-')[0]})": f"${r['profit']:.4f}",
+                    "Signal": "✅" if r["spread"] > 0 else "❌",
+                })
+            builder.markdown("## Arbitrage Routes (sorted by spread)")
             builder.table(arb_rows)
 
+        # Mid-price differences
+        if len(mids) >= 2:
+            mid_rows = []
+            for ex_a, ex_b in combinations(mids.keys(), 2):
+                diff = _spread_pct(mids[ex_a], mids[ex_b])
+                mid_rows.append({
+                    "Pair": f"{ex_a.upper()} vs {ex_b.upper()}",
+                    "Mid Diff": f"{diff:+.4f}%",
+                    f"{ex_a.upper()} Mid": f"{mids[ex_a]:.6f}",
+                    f"{ex_b.upper()} Mid": f"{mids[ex_b]:.6f}",
+                })
+            mid_rows.sort(key=lambda r: abs(float(r["Mid Diff"].replace("%", "").replace("+", ""))), reverse=True)
+            builder.markdown("## Mid-Price Differences")
+            builder.table(mid_rows)
+
+        # Filtered exchanges note
+        if invalid_exchanges:
+            builder.markdown("## Filtered Exchanges")
+            filtered_rows = [{"Exchange": ex.upper(), "Reason": reason} for ex, reason in invalid_exchanges]
+            builder.table(filtered_rows)
+
         # Top levels detail per exchange
-        for ex in exchanges:
+        for ex in valid_exchanges:
             d = ex_data[ex]
             bids, asks = d["bids"], d["asks"]
-            n = min(10, max(len(bids), len(asks)))
-            if n == 0:
+            nlvl = min(10, max(len(bids), len(asks)))
+            if nlvl == 0:
                 continue
-            builder.markdown(f"### {ex.upper()} - Top {n} Levels")
+            builder.markdown(f"### {ex.upper()} - Top {nlvl} Levels")
             levels = []
-            for i in range(n):
+            for i in range(nlvl):
                 row = {"#": i + 1}
                 if i < len(bids):
                     row["Bid Price"] = f"{bids[i][0]:.6f}"

--- a/routines/arb_check.py
+++ b/routines/arb_check.py
@@ -1,194 +1,356 @@
-"""Check for CEX/DEX arbitrage opportunities."""
+"""CEX vs CEX order book arbitrage checker with depth visualization."""
 
 CATEGORY = "Arbitrage"
 
-from decimal import Decimal
+import asyncio
+import logging
 
 from pydantic import BaseModel, Field
 from telegram.ext import ContextTypes
 
 from config_manager import get_client
 
+logger = logging.getLogger(__name__)
+
 
 class Config(BaseModel):
-    """Check CEX vs DEX price arbitrage opportunities."""
+    """Compare order books between two CEX exchanges to find arbitrage opportunities."""
 
     trading_pair: str = Field(
         default="SOL-USDC", description="Trading pair (e.g. SOL-USDC)"
     )
-    amount: float = Field(default=1.0, description="Amount to quote")
-    cex_connector: str = Field(default="binance", description="CEX connector")
-    dex_connector: str = Field(default="jupiter", description="DEX connector")
-    dex_network: str = Field(default="solana-mainnet-beta", description="DEX network")
+    amount: float = Field(default=1.0, description="Amount to quote (in base asset)")
+    cex_connector: str = Field(default="binance", description="First CEX exchange")
+    cex_connector_2: str = Field(default="kucoin", description="Second CEX exchange")
+    ob_depth: int = Field(default=20, description="Order book depth (levels)")
+
+
+async def _get_order_book(client, connector: str, trading_pair: str, depth: int) -> dict | None:
+    """Fetch full order book with bids and asks."""
+    try:
+        result = await client.market_data.get_order_book(
+            connector_name=connector,
+            trading_pair=trading_pair,
+            depth=depth,
+        )
+        if isinstance(result, dict):
+            return result
+        return None
+    except Exception as e:
+        logger.warning(f"Order book failed for {connector}/{trading_pair}: {e}")
+        return None
+
+
+async def _get_fill_price(client, connector: str, trading_pair: str, amount: float, is_buy: bool) -> float | None:
+    """Get volume-weighted fill price from order book."""
+    try:
+        result = await client.market_data.get_price_for_volume(
+            connector_name=connector,
+            trading_pair=trading_pair,
+            volume=amount,
+            is_buy=is_buy,
+        )
+        if isinstance(result, dict):
+            price = (
+                result.get("result_price")
+                or result.get("price")
+                or result.get("average_price")
+            )
+            return float(price) if price else None
+        return None
+    except Exception as e:
+        logger.warning(f"Fill price failed for {connector}/{trading_pair}: {e}")
+        return None
+
+
+def _parse_ob_levels(ob: dict) -> tuple[list, list]:
+    """Parse order book into [(price, size, cumulative)] for bids and asks."""
+    bids_raw = ob.get("bids", [])
+    asks_raw = ob.get("asks", [])
+
+    bids = []
+    cum = 0.0
+    for level in bids_raw:
+        price, size = float(level[0]), float(level[1])
+        cum += size
+        bids.append((price, size, cum))
+
+    asks = []
+    cum = 0.0
+    for level in asks_raw:
+        price, size = float(level[0]), float(level[1])
+        cum += size
+        asks.append((price, size, cum))
+
+    return bids, asks
+
+
+def _ob_stats(bids: list, asks: list) -> dict:
+    """Compute order book statistics."""
+    best_bid = bids[0][0] if bids else None
+    best_ask = asks[0][0] if asks else None
+    mid = (best_bid + best_ask) / 2 if best_bid and best_ask else None
+    spread_pct = ((best_ask - best_bid) / best_bid * 100) if best_bid and best_ask else None
+
+    bid_depth_usd = sum(p * s for p, s, _ in bids)
+    ask_depth_usd = sum(p * s for p, s, _ in asks)
+
+    return {
+        "best_bid": best_bid,
+        "best_ask": best_ask,
+        "mid": mid,
+        "spread_pct": spread_pct,
+        "bid_depth_usd": bid_depth_usd,
+        "ask_depth_usd": ask_depth_usd,
+        "n_bid_levels": len(bids),
+        "n_ask_levels": len(asks),
+    }
+
+
+def _spread_pct(buy_price: float, sell_price: float) -> float:
+    return ((sell_price - buy_price) / buy_price) * 100
+
+
+def _build_ob_chart(bids1, asks1, bids2, asks2, cex1: str, cex2: str, pair: str):
+    """Build a Plotly figure with two order books stacked vertically."""
+    import plotly.graph_objects as go
+    from plotly.subplots import make_subplots
+
+    fig = make_subplots(
+        rows=2, cols=1,
+        subplot_titles=[f"{cex1.upper()} Order Book", f"{cex2.upper()} Order Book"],
+        vertical_spacing=0.12,
+        shared_xaxes=True,
+    )
+
+    for row, (bids, asks, name) in enumerate(
+        [(bids1, asks1, cex1), (bids2, asks2, cex2)], start=1
+    ):
+        if bids:
+            bid_prices = [b[0] for b in bids]
+            bid_cum = [b[2] for b in bids]
+            fig.add_trace(
+                go.Scatter(
+                    x=bid_prices, y=bid_cum,
+                    fill="tozeroy",
+                    fillcolor="rgba(0, 200, 83, 0.15)",
+                    line=dict(color="rgba(0, 200, 83, 0.8)", width=2, shape="hv"),
+                    name=f"Bids",
+                    hovertemplate="Price: %{x:.4f}<br>Cumul. Size: %{y:.4f}<extra></extra>",
+                    showlegend=(row == 1),
+                    legendgroup="bids",
+                ),
+                row=row, col=1,
+            )
+
+        if asks:
+            ask_prices = [a[0] for a in asks]
+            ask_cum = [a[2] for a in asks]
+            fig.add_trace(
+                go.Scatter(
+                    x=ask_prices, y=ask_cum,
+                    fill="tozeroy",
+                    fillcolor="rgba(255, 82, 82, 0.15)",
+                    line=dict(color="rgba(255, 82, 82, 0.8)", width=2, shape="hv"),
+                    name=f"Asks",
+                    hovertemplate="Price: %{x:.4f}<br>Cumul. Size: %{y:.4f}<extra></extra>",
+                    showlegend=(row == 1),
+                    legendgroup="asks",
+                ),
+                row=row, col=1,
+            )
+
+        # Mid-price vertical line
+        if bids and asks:
+            mid = (bids[0][0] + asks[0][0]) / 2
+            fig.add_vline(
+                x=mid, row=row, col=1,
+                line=dict(color="rgba(255, 255, 255, 0.4)", width=1, dash="dash"),
+                annotation_text=f"Mid: {mid:.4f}",
+                annotation_font_size=10,
+                annotation_font_color="rgba(255,255,255,0.6)",
+            )
+
+    # Shared x-axis range
+    all_prices = (
+        [b[0] for b in bids1] + [a[0] for a in asks1]
+        + [b[0] for b in bids2] + [a[0] for a in asks2]
+    )
+    if all_prices:
+        price_min, price_max = min(all_prices), max(all_prices)
+        margin = (price_max - price_min) * 0.02
+        fig.update_xaxes(range=[price_min - margin, price_max + margin])
+
+    fig.update_layout(
+        height=600,
+        template="plotly_dark",
+        paper_bgcolor="#1a1a2e",
+        plot_bgcolor="#16213e",
+        font=dict(color="#e0e0e0"),
+        legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="center", x=0.5),
+        margin=dict(t=80, b=40, l=60, r=30),
+    )
+    fig.update_xaxes(title_text="Price", row=2, col=1)
+    fig.update_yaxes(title_text="Cumulative Size", row=1, col=1)
+    fig.update_yaxes(title_text="Cumulative Size", row=2, col=1)
+
+    return fig
 
 
 async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
-    """Check arbitrage between CEX and DEX."""
+    """Compare order books between two CEX exchanges."""
     chat_id = context._chat_id if hasattr(context, "_chat_id") else None
     client = await get_client(chat_id, context=context)
 
     if not client:
         return "No server available. Configure servers in /config."
 
-    results = []
-    cex_buy, cex_sell = None, None
-    dex_buy, dex_sell = None, None
+    cex1 = config.cex_connector
+    cex2 = config.cex_connector_2
+    pair = config.trading_pair
 
-    # --- CEX Quotes ---
-    try:
-        # Get CEX price for volume (buy and sell)
-        async def get_cex_quote(is_buy: bool):
-            try:
-                result = await client.market_data.get_price_for_volume(
-                    connector_name=config.cex_connector,
-                    trading_pair=config.trading_pair,
-                    volume=config.amount,
-                    is_buy=is_buy,
-                )
-                if isinstance(result, dict):
-                    return (
-                        result.get("result_price")
-                        or result.get("price")
-                        or result.get("average_price")
-                    )
-                return None
-            except Exception as e:
-                return None
+    # Fetch everything in parallel
+    ob1, ob2, fill_buy1, fill_sell1, fill_buy2, fill_sell2 = await asyncio.gather(
+        _get_order_book(client, cex1, pair, config.ob_depth),
+        _get_order_book(client, cex2, pair, config.ob_depth),
+        _get_fill_price(client, cex1, pair, config.amount, True),
+        _get_fill_price(client, cex1, pair, config.amount, False),
+        _get_fill_price(client, cex2, pair, config.amount, True),
+        _get_fill_price(client, cex2, pair, config.amount, False),
+    )
 
-        import asyncio
+    if not ob1 and not ob2:
+        return f"Could not fetch order books from either {cex1} or {cex2}."
 
-        cex_buy, cex_sell = await asyncio.gather(
-            get_cex_quote(True), get_cex_quote(False)
-        )
+    # Parse order books
+    bids1, asks1 = _parse_ob_levels(ob1) if ob1 else ([], [])
+    bids2, asks2 = _parse_ob_levels(ob2) if ob2 else ([], [])
+    stats1 = _ob_stats(bids1, asks1) if ob1 else {}
+    stats2 = _ob_stats(bids2, asks2) if ob2 else {}
 
-        if cex_buy:
-            results.append(f"CEX BUY:  {float(cex_buy):.6f}")
-        if cex_sell:
-            results.append(f"CEX SELL: {float(cex_sell):.6f}")
+    # Build text output
+    lines = [
+        f"CEX-CEX Order Book Comparison: {pair}",
+        f"{cex1.upper()} vs {cex2.upper()} | Quote: {config.amount} {pair.split('-')[0]}",
+        "",
+    ]
 
-        if not cex_buy and not cex_sell:
-            results.append(f"CEX: No quotes from {config.cex_connector}")
+    for name, stats, fill_buy, fill_sell in [
+        (cex1, stats1, fill_buy1, fill_sell1),
+        (cex2, stats2, fill_buy2, fill_sell2),
+    ]:
+        lines.append(f"--- {name.upper()} ---")
+        if stats:
+            lines.append(f"  Best Bid: {stats['best_bid']:.6f} | Best Ask: {stats['best_ask']:.6f}")
+            lines.append(f"  Mid: {stats['mid']:.6f} | Spread: {stats['spread_pct']:.4f}%")
+            lines.append(f"  Depth: Bid ${stats['bid_depth_usd']:,.0f} | Ask ${stats['ask_depth_usd']:,.0f} ({stats['n_bid_levels']}/{stats['n_ask_levels']} levels)")
+        if fill_buy:
+            lines.append(f"  Fill BUY  {config.amount} @ {fill_buy:.6f}")
+        if fill_sell:
+            lines.append(f"  Fill SELL {config.amount} @ {fill_sell:.6f}")
+        if not stats and not fill_buy:
+            lines.append("  No data available")
+        lines.append("")
 
-    except Exception as e:
-        results.append(f"CEX Error: {str(e)}")
-
-    # --- DEX Quotes ---
-    try:
-        if hasattr(client, "gateway_swap"):
-
-            async def get_dex_quote(side: str):
-                try:
-                    result = await client.gateway_swap.get_swap_quote(
-                        connector=config.dex_connector,
-                        network=config.dex_network,
-                        trading_pair=config.trading_pair,
-                        side=side,
-                        amount=Decimal(str(config.amount)),
-                        slippage_pct=Decimal("1.0"),
-                    )
-                    if isinstance(result, dict):
-                        return result.get("price")
-                    return None
-                except Exception:
-                    return None
-
-            dex_buy, dex_sell = await asyncio.gather(
-                get_dex_quote("BUY"), get_dex_quote("SELL")
-            )
-
-            if dex_buy:
-                results.append(f"DEX BUY:  {float(dex_buy):.6f}")
-            if dex_sell:
-                results.append(f"DEX SELL: {float(dex_sell):.6f}")
-
-            if not dex_buy and not dex_sell:
-                results.append(f"DEX: No quotes from {config.dex_connector}")
-        else:
-            results.append("DEX: Gateway not available")
-
-    except Exception as e:
-        results.append(f"DEX Error: {str(e)}")
-
-    # --- Arbitrage Analysis ---
-    results.append("")
-    results.append("--- Arbitrage ---")
-
+    # Arb analysis
+    lines.append("--- Arbitrage ---")
     opportunities = []
 
-    # Strategy 1: Buy CEX, Sell DEX
-    if cex_buy and dex_sell:
-        cex_buy_f = float(cex_buy)
-        dex_sell_f = float(dex_sell)
-        # For a BUY on CEX: price is what we pay per unit
-        # For a SELL on DEX: price is what we receive per unit
-        spread_pct = ((dex_sell_f - cex_buy_f) / cex_buy_f) * 100
-        profit = (dex_sell_f - cex_buy_f) * config.amount
-        if spread_pct > 0:
-            opportunities.append(
-                f"BUY CEX -> SELL DEX: +{spread_pct:.2f}% (${profit:.2f})"
-            )
-        else:
-            results.append(f"BUY CEX -> SELL DEX: {spread_pct:.2f}%")
+    if fill_buy1 and fill_sell2:
+        s = _spread_pct(fill_buy1, fill_sell2)
+        profit = (fill_sell2 - fill_buy1) * config.amount
+        label = f"BUY {cex1} -> SELL {cex2}: {s:+.4f}% (${profit:.4f})"
+        (opportunities if s > 0 else lines).append(label)
 
-    # Strategy 2: Buy DEX, Sell CEX
-    if dex_buy and cex_sell:
-        dex_buy_f = float(dex_buy)
-        cex_sell_f = float(cex_sell)
-        spread_pct = ((cex_sell_f - dex_buy_f) / dex_buy_f) * 100
-        profit = (cex_sell_f - dex_buy_f) * config.amount
-        if spread_pct > 0:
-            opportunities.append(
-                f"BUY DEX -> SELL CEX: +{spread_pct:.2f}% (${profit:.2f})"
-            )
-        else:
-            results.append(f"BUY DEX -> SELL CEX: {spread_pct:.2f}%")
+    if fill_buy2 and fill_sell1:
+        s = _spread_pct(fill_buy2, fill_sell1)
+        profit = (fill_sell1 - fill_buy2) * config.amount
+        label = f"BUY {cex2} -> SELL {cex1}: {s:+.4f}% (${profit:.4f})"
+        (opportunities if s > 0 else lines).append(label)
+
+    if stats1.get("mid") and stats2.get("mid"):
+        mid_diff = _spread_pct(stats1["mid"], stats2["mid"])
+        lines.append(f"Mid-price diff: {mid_diff:+.4f}% ({cex1}: {stats1['mid']:.6f}, {cex2}: {stats2['mid']:.6f})")
 
     if opportunities:
-        results.append("")
-        results.append("OPPORTUNITIES FOUND:")
-        results.extend(opportunities)
+        lines.append("")
+        lines.append("OPPORTUNITIES FOUND:")
+        lines.extend(opportunities)
     else:
-        results.append("No profitable arbitrage found.")
+        lines.append("No profitable arbitrage at current depth.")
 
-    # Generate HTML report
+    # Generate report
     try:
         from condor.reports import ReportBuilder
 
-        builder = ReportBuilder(f"Arb Check: {config.trading_pair}")
-        builder.source("routine", "arb_check").tags(["arbitrage", config.trading_pair])
-        if cex_buy and dex_sell:
-            spread = ((float(dex_sell) - float(cex_buy)) / float(cex_buy)) * 100
-            builder.kpi("CEX→DEX Spread", f"{spread:+.2f}%", trend="up" if spread > 0 else "down")
-        if dex_buy and cex_sell:
-            spread = ((float(cex_sell) - float(dex_buy)) / float(dex_buy)) * 100
-            builder.kpi("DEX→CEX Spread", f"{spread:+.2f}%", trend="up" if spread > 0 else "down")
-        builder.markdown("\n".join(results))
+        builder = ReportBuilder(f"CEX Arb: {pair} ({cex1} vs {cex2})")
+        builder.source("routine", "arb_check").tags(["arbitrage", "cex-cex", pair, cex1, cex2])
+        builder.manual_order()
 
+        # KPIs
+        if stats1.get("spread_pct") is not None:
+            builder.kpi(f"{cex1} Spread", f"{stats1['spread_pct']:.4f}%")
+        if stats2.get("spread_pct") is not None:
+            builder.kpi(f"{cex2} Spread", f"{stats2['spread_pct']:.4f}%")
+        if stats1.get("mid") and stats2.get("mid"):
+            md = _spread_pct(stats1["mid"], stats2["mid"])
+            builder.kpi("Mid-Price Diff", f"{md:+.4f}%", trend="up" if abs(md) > 0.05 else "neutral")
+        if fill_buy1 and fill_sell2:
+            s = _spread_pct(fill_buy1, fill_sell2)
+            builder.kpi(f"BUY {cex1} -> SELL {cex2}", f"{s:+.4f}%", trend="up" if s > 0 else "down")
+        if fill_buy2 and fill_sell1:
+            s = _spread_pct(fill_buy2, fill_sell1)
+            builder.kpi(f"BUY {cex2} -> SELL {cex1}", f"{s:+.4f}%", trend="up" if s > 0 else "down")
+
+        # Order book depth chart
+        if (bids1 or asks1) and (bids2 or asks2):
+            fig = _build_ob_chart(bids1, asks1, bids2, asks2, cex1, cex2, pair)
+            builder.plotly(fig)
+
+        # Comparison table
+        builder.markdown(f"## Order Book Comparison ({config.ob_depth} levels)")
         table_rows = []
-        if cex_buy or cex_sell:
-            table_rows.append({
-                "Source": f"CEX ({config.cex_connector})",
-                "Buy": f"{float(cex_buy):.6f}" if cex_buy else "N/A",
-                "Sell": f"{float(cex_sell):.6f}" if cex_sell else "N/A",
-            })
-        if dex_buy or dex_sell:
-            table_rows.append({
-                "Source": f"DEX ({config.dex_connector})",
-                "Buy": f"{float(dex_buy):.6f}" if dex_buy else "N/A",
-                "Sell": f"{float(dex_sell):.6f}" if dex_sell else "N/A",
-            })
-        if cex_buy and dex_sell:
-            spread = ((float(dex_sell) - float(cex_buy)) / float(cex_buy)) * 100
-            table_rows.append({"Source": "Spread (CEX->DEX)", "Buy": "", "Sell": f"{spread:+.2f}%"})
-        if dex_buy and cex_sell:
-            spread = ((float(cex_sell) - float(dex_buy)) / float(dex_buy)) * 100
-            table_rows.append({"Source": "Spread (DEX->CEX)", "Buy": "", "Sell": f"{spread:+.2f}%"})
+        for name, stats, fb, fs in [
+            (cex1, stats1, fill_buy1, fill_sell1),
+            (cex2, stats2, fill_buy2, fill_sell2),
+        ]:
+            row = {"Exchange": name.upper()}
+            if stats:
+                row["Best Bid"] = f"{stats['best_bid']:.6f}"
+                row["Best Ask"] = f"{stats['best_ask']:.6f}"
+                row["Mid Price"] = f"{stats['mid']:.6f}"
+                row["Spread"] = f"{stats['spread_pct']:.4f}%"
+                row["Bid Depth (USD)"] = f"${stats['bid_depth_usd']:,.0f}"
+                row["Ask Depth (USD)"] = f"${stats['ask_depth_usd']:,.0f}"
+            else:
+                row["Best Bid"] = "N/A"
+                row["Best Ask"] = "N/A"
+            row[f"Fill BUY {config.amount}"] = f"{fb:.6f}" if fb else "N/A"
+            row[f"Fill SELL {config.amount}"] = f"{fs:.6f}" if fs else "N/A"
+            table_rows.append(row)
+        builder.table(table_rows)
 
-        if table_rows:
-            builder.table(table_rows)
+        # Top levels detail per exchange
+        for name, bids, asks in [(cex1, bids1, asks1), (cex2, bids2, asks2)]:
+            n = min(10, max(len(bids), len(asks)))
+            builder.markdown(f"### {name.upper()} - Top {n} Levels")
+            levels = []
+            for i in range(n):
+                row = {"#": i + 1}
+                if i < len(bids):
+                    row["Bid Price"] = f"{bids[i][0]:.6f}"
+                    row["Bid Size"] = f"{bids[i][1]:.4f}"
+                    row["Bid Cumul."] = f"{bids[i][2]:.4f}"
+                if i < len(asks):
+                    row["Ask Price"] = f"{asks[i][0]:.6f}"
+                    row["Ask Size"] = f"{asks[i][1]:.4f}"
+                    row["Ask Cumul."] = f"{asks[i][2]:.4f}"
+                levels.append(row)
+            if levels:
+                builder.table(levels)
+
         builder.save()
     except Exception as e:
-        import logging
-        logging.getLogger(__name__).warning(f"Report generation failed: {e}")
+        logger.warning(f"Report generation failed: {e}")
 
-    return "\n".join(results)
+    return "\n".join(lines)

--- a/routines/arb_check.py
+++ b/routines/arb_check.py
@@ -4,6 +4,7 @@ CATEGORY = "Arbitrage"
 
 import asyncio
 import logging
+from itertools import combinations
 
 from pydantic import BaseModel, Field
 from telegram.ext import ContextTypes
@@ -14,15 +15,22 @@ logger = logging.getLogger(__name__)
 
 
 class Config(BaseModel):
-    """Compare order books between two CEX exchanges to find arbitrage opportunities."""
+    """Compare order books across multiple CEX exchanges to find arbitrage opportunities."""
 
     trading_pair: str = Field(
         default="SOL-USDC", description="Trading pair (e.g. SOL-USDC)"
     )
+    exchanges: str = Field(
+        default="binance,kucoin",
+        description="Comma-separated exchanges (e.g. binance,kucoin,htx,gate_io)",
+    )
     amount: float = Field(default=1.0, description="Amount to quote (in base asset)")
-    cex_connector: str = Field(default="binance", description="First CEX exchange")
-    cex_connector_2: str = Field(default="kucoin", description="Second CEX exchange")
     ob_depth: int = Field(default=20, description="Order book depth (levels)")
+
+
+def _parse_exchanges(raw: str) -> list[str]:
+    """Parse comma-separated exchange list, stripping whitespace."""
+    return [e.strip().lower() for e in raw.split(",") if e.strip()]
 
 
 async def _get_order_book(client, connector: str, trading_pair: str, depth: int) -> dict | None:
@@ -63,6 +71,15 @@ async def _get_fill_price(client, connector: str, trading_pair: str, amount: flo
         return None
 
 
+def _parse_level(level) -> tuple[float, float]:
+    """Parse a single OB level from list [price, size] or dict {price, quantity}."""
+    if isinstance(level, dict):
+        price = float(level.get("price", level.get("Price", 0)))
+        size = float(level.get("quantity", level.get("size", level.get("amount", level.get("Quantity", 0)))))
+        return price, size
+    return float(level[0]), float(level[1])
+
+
 def _parse_ob_levels(ob: dict) -> tuple[list, list]:
     """Parse order book into [(price, size, cumulative)] for bids and asks."""
     bids_raw = ob.get("bids", [])
@@ -71,14 +88,14 @@ def _parse_ob_levels(ob: dict) -> tuple[list, list]:
     bids = []
     cum = 0.0
     for level in bids_raw:
-        price, size = float(level[0]), float(level[1])
+        price, size = _parse_level(level)
         cum += size
         bids.append((price, size, cum))
 
     asks = []
     cum = 0.0
     for level in asks_raw:
-        price, size = float(level[0]), float(level[1])
+        price, size = _parse_level(level)
         cum += size
         asks.append((price, size, cum))
 
@@ -111,21 +128,20 @@ def _spread_pct(buy_price: float, sell_price: float) -> float:
     return ((sell_price - buy_price) / buy_price) * 100
 
 
-def _build_ob_chart(bids1, asks1, bids2, asks2, cex1: str, cex2: str, pair: str):
-    """Build a Plotly figure with two order books stacked vertically."""
+def _build_ob_chart(exchange_data: list[tuple[str, list, list]], pair: str):
+    """Build a Plotly figure with N order books stacked vertically (one per exchange)."""
     import plotly.graph_objects as go
     from plotly.subplots import make_subplots
 
+    n = len(exchange_data)
     fig = make_subplots(
-        rows=2, cols=1,
-        subplot_titles=[f"{cex1.upper()} Order Book", f"{cex2.upper()} Order Book"],
-        vertical_spacing=0.12,
+        rows=n, cols=1,
+        subplot_titles=[f"{name.upper()} Order Book" for name, _, _ in exchange_data],
+        vertical_spacing=0.08 if n <= 4 else 0.05,
         shared_xaxes=True,
     )
 
-    for row, (bids, asks, name) in enumerate(
-        [(bids1, asks1, cex1), (bids2, asks2, cex2)], start=1
-    ):
+    for row, (name, bids, asks) in enumerate(exchange_data, start=1):
         if bids:
             bid_prices = [b[0] for b in bids]
             bid_cum = [b[2] for b in bids]
@@ -135,7 +151,7 @@ def _build_ob_chart(bids1, asks1, bids2, asks2, cex1: str, cex2: str, pair: str)
                     fill="tozeroy",
                     fillcolor="rgba(0, 200, 83, 0.15)",
                     line=dict(color="rgba(0, 200, 83, 0.8)", width=2, shape="hv"),
-                    name=f"Bids",
+                    name="Bids",
                     hovertemplate="Price: %{x:.4f}<br>Cumul. Size: %{y:.4f}<extra></extra>",
                     showlegend=(row == 1),
                     legendgroup="bids",
@@ -152,7 +168,7 @@ def _build_ob_chart(bids1, asks1, bids2, asks2, cex1: str, cex2: str, pair: str)
                     fill="tozeroy",
                     fillcolor="rgba(255, 82, 82, 0.15)",
                     line=dict(color="rgba(255, 82, 82, 0.8)", width=2, shape="hv"),
-                    name=f"Asks",
+                    name="Asks",
                     hovertemplate="Price: %{x:.4f}<br>Cumul. Size: %{y:.4f}<extra></extra>",
                     showlegend=(row == 1),
                     legendgroup="asks",
@@ -172,168 +188,228 @@ def _build_ob_chart(bids1, asks1, bids2, asks2, cex1: str, cex2: str, pair: str)
             )
 
     # Shared x-axis range
-    all_prices = (
-        [b[0] for b in bids1] + [a[0] for a in asks1]
-        + [b[0] for b in bids2] + [a[0] for a in asks2]
-    )
+    all_prices = []
+    for _, bids, asks in exchange_data:
+        all_prices.extend(b[0] for b in bids)
+        all_prices.extend(a[0] for a in asks)
     if all_prices:
         price_min, price_max = min(all_prices), max(all_prices)
         margin = (price_max - price_min) * 0.02
         fig.update_xaxes(range=[price_min - margin, price_max + margin])
 
+    row_height = 250
     fig.update_layout(
-        height=600,
+        height=max(400, row_height * n),
         template="plotly_dark",
         paper_bgcolor="#1a1a2e",
         plot_bgcolor="#16213e",
         font=dict(color="#e0e0e0"),
-        legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="center", x=0.5),
+        legend=dict(orientation="h", yanchor="top", y=-0.05, xanchor="center", x=0.5),
         margin=dict(t=80, b=40, l=60, r=30),
     )
-    fig.update_xaxes(title_text="Price", row=2, col=1)
-    fig.update_yaxes(title_text="Cumulative Size", row=1, col=1)
-    fig.update_yaxes(title_text="Cumulative Size", row=2, col=1)
+    fig.update_xaxes(title_text="Price", row=n, col=1)
+    for row in range(1, n + 1):
+        fig.update_yaxes(title_text="Cumul. Size", row=row, col=1)
 
     return fig
 
 
 async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
-    """Compare order books between two CEX exchanges."""
+    """Compare order books across multiple CEX exchanges."""
     chat_id = context._chat_id if hasattr(context, "_chat_id") else None
     client = await get_client(chat_id, context=context)
 
     if not client:
         return "No server available. Configure servers in /config."
 
-    cex1 = config.cex_connector
-    cex2 = config.cex_connector_2
+    exchanges = _parse_exchanges(config.exchanges)
+    if len(exchanges) < 2:
+        return "Need at least 2 exchanges (comma-separated). Example: binance,kucoin,htx"
+
     pair = config.trading_pair
 
-    # Fetch everything in parallel
-    ob1, ob2, fill_buy1, fill_sell1, fill_buy2, fill_sell2 = await asyncio.gather(
-        _get_order_book(client, cex1, pair, config.ob_depth),
-        _get_order_book(client, cex2, pair, config.ob_depth),
-        _get_fill_price(client, cex1, pair, config.amount, True),
-        _get_fill_price(client, cex1, pair, config.amount, False),
-        _get_fill_price(client, cex2, pair, config.amount, True),
-        _get_fill_price(client, cex2, pair, config.amount, False),
-    )
+    # Fetch all order books and fill prices in parallel
+    tasks = []
+    for ex in exchanges:
+        tasks.append(_get_order_book(client, ex, pair, config.ob_depth))
+        tasks.append(_get_fill_price(client, ex, pair, config.amount, True))   # buy
+        tasks.append(_get_fill_price(client, ex, pair, config.amount, False))  # sell
 
-    if not ob1 and not ob2:
-        return f"Could not fetch order books from either {cex1} or {cex2}."
+    results = await asyncio.gather(*tasks)
 
-    # Parse order books
-    bids1, asks1 = _parse_ob_levels(ob1) if ob1 else ([], [])
-    bids2, asks2 = _parse_ob_levels(ob2) if ob2 else ([], [])
-    stats1 = _ob_stats(bids1, asks1) if ob1 else {}
-    stats2 = _ob_stats(bids2, asks2) if ob2 else {}
+    # Unpack: every 3 results = (ob, fill_buy, fill_sell) per exchange
+    ex_data = {}
+    for i, ex in enumerate(exchanges):
+        ob = results[i * 3]
+        fill_buy = results[i * 3 + 1]
+        fill_sell = results[i * 3 + 2]
+        bids, asks = _parse_ob_levels(ob) if ob else ([], [])
+        stats = _ob_stats(bids, asks) if ob else {}
+        ex_data[ex] = {
+            "ob": ob, "bids": bids, "asks": asks, "stats": stats,
+            "fill_buy": fill_buy, "fill_sell": fill_sell,
+        }
+
+    # Check at least some data came back
+    if not any(d["ob"] for d in ex_data.values()):
+        return f"Could not fetch order books from any exchange: {', '.join(exchanges)}"
 
     # Build text output
     lines = [
-        f"CEX-CEX Order Book Comparison: {pair}",
-        f"{cex1.upper()} vs {cex2.upper()} | Quote: {config.amount} {pair.split('-')[0]}",
+        f"CEX Order Book Comparison: {pair}",
+        f"Exchanges: {', '.join(e.upper() for e in exchanges)} | Quote: {config.amount} {pair.split('-')[0]}",
         "",
     ]
 
-    for name, stats, fill_buy, fill_sell in [
-        (cex1, stats1, fill_buy1, fill_sell1),
-        (cex2, stats2, fill_buy2, fill_sell2),
-    ]:
-        lines.append(f"--- {name.upper()} ---")
-        if stats:
-            lines.append(f"  Best Bid: {stats['best_bid']:.6f} | Best Ask: {stats['best_ask']:.6f}")
-            lines.append(f"  Mid: {stats['mid']:.6f} | Spread: {stats['spread_pct']:.4f}%")
-            lines.append(f"  Depth: Bid ${stats['bid_depth_usd']:,.0f} | Ask ${stats['ask_depth_usd']:,.0f} ({stats['n_bid_levels']}/{stats['n_ask_levels']} levels)")
-        if fill_buy:
-            lines.append(f"  Fill BUY  {config.amount} @ {fill_buy:.6f}")
-        if fill_sell:
-            lines.append(f"  Fill SELL {config.amount} @ {fill_sell:.6f}")
-        if not stats and not fill_buy:
+    for ex in exchanges:
+        d = ex_data[ex]
+        lines.append(f"--- {ex.upper()} ---")
+        if d["stats"]:
+            s = d["stats"]
+            lines.append(f"  Best Bid: {s['best_bid']:.6f} | Best Ask: {s['best_ask']:.6f}")
+            lines.append(f"  Mid: {s['mid']:.6f} | Spread: {s['spread_pct']:.4f}%")
+            lines.append(f"  Depth: Bid ${s['bid_depth_usd']:,.0f} | Ask ${s['ask_depth_usd']:,.0f} ({s['n_bid_levels']}/{s['n_ask_levels']} levels)")
+        if d["fill_buy"]:
+            lines.append(f"  Fill BUY  {config.amount} @ {d['fill_buy']:.6f}")
+        if d["fill_sell"]:
+            lines.append(f"  Fill SELL {config.amount} @ {d['fill_sell']:.6f}")
+        if not d["stats"] and not d["fill_buy"]:
             lines.append("  No data available")
         lines.append("")
 
-    # Arb analysis
-    lines.append("--- Arbitrage ---")
+    # Arb analysis across all pairs
+    lines.append("--- Arbitrage Matrix ---")
     opportunities = []
 
-    if fill_buy1 and fill_sell2:
-        s = _spread_pct(fill_buy1, fill_sell2)
-        profit = (fill_sell2 - fill_buy1) * config.amount
-        label = f"BUY {cex1} -> SELL {cex2}: {s:+.4f}% (${profit:.4f})"
-        (opportunities if s > 0 else lines).append(label)
+    for ex_a, ex_b in combinations(exchanges, 2):
+        da, db = ex_data[ex_a], ex_data[ex_b]
 
-    if fill_buy2 and fill_sell1:
-        s = _spread_pct(fill_buy2, fill_sell1)
-        profit = (fill_sell1 - fill_buy2) * config.amount
-        label = f"BUY {cex2} -> SELL {cex1}: {s:+.4f}% (${profit:.4f})"
-        (opportunities if s > 0 else lines).append(label)
+        # Buy on A, sell on B
+        if da["fill_buy"] and db["fill_sell"]:
+            s = _spread_pct(da["fill_buy"], db["fill_sell"])
+            profit = (db["fill_sell"] - da["fill_buy"]) * config.amount
+            label = f"BUY {ex_a.upper()} -> SELL {ex_b.upper()}: {s:+.4f}% (${profit:.4f})"
+            (opportunities if s > 0 else lines).append(label)
 
-    if stats1.get("mid") and stats2.get("mid"):
-        mid_diff = _spread_pct(stats1["mid"], stats2["mid"])
-        lines.append(f"Mid-price diff: {mid_diff:+.4f}% ({cex1}: {stats1['mid']:.6f}, {cex2}: {stats2['mid']:.6f})")
+        # Buy on B, sell on A
+        if db["fill_buy"] and da["fill_sell"]:
+            s = _spread_pct(db["fill_buy"], da["fill_sell"])
+            profit = (da["fill_sell"] - db["fill_buy"]) * config.amount
+            label = f"BUY {ex_b.upper()} -> SELL {ex_a.upper()}: {s:+.4f}% (${profit:.4f})"
+            (opportunities if s > 0 else lines).append(label)
+
+    # Mid-price diffs
+    mids = {ex: d["stats"]["mid"] for ex, d in ex_data.items() if d["stats"].get("mid")}
+    if len(mids) >= 2:
+        lines.append("")
+        for ex_a, ex_b in combinations(mids.keys(), 2):
+            diff = _spread_pct(mids[ex_a], mids[ex_b])
+            lines.append(f"Mid diff {ex_a.upper()} vs {ex_b.upper()}: {diff:+.4f}%")
 
     if opportunities:
         lines.append("")
         lines.append("OPPORTUNITIES FOUND:")
         lines.extend(opportunities)
     else:
+        lines.append("")
         lines.append("No profitable arbitrage at current depth.")
 
     # Generate report
     try:
         from condor.reports import ReportBuilder
 
-        builder = ReportBuilder(f"CEX Arb: {pair} ({cex1} vs {cex2})")
-        builder.source("routine", "arb_check").tags(["arbitrage", "cex-cex", pair, cex1, cex2])
+        ex_label = " vs ".join(e.upper() for e in exchanges)
+        builder = ReportBuilder(f"CEX Arb: {pair} ({ex_label})")
+        builder.source("routine", "arb_check").tags(["arbitrage", "cex-cex", pair] + exchanges)
         builder.manual_order()
 
-        # KPIs
-        if stats1.get("spread_pct") is not None:
-            builder.kpi(f"{cex1} Spread", f"{stats1['spread_pct']:.4f}%")
-        if stats2.get("spread_pct") is not None:
-            builder.kpi(f"{cex2} Spread", f"{stats2['spread_pct']:.4f}%")
-        if stats1.get("mid") and stats2.get("mid"):
-            md = _spread_pct(stats1["mid"], stats2["mid"])
-            builder.kpi("Mid-Price Diff", f"{md:+.4f}%", trend="up" if abs(md) > 0.05 else "neutral")
-        if fill_buy1 and fill_sell2:
-            s = _spread_pct(fill_buy1, fill_sell2)
-            builder.kpi(f"BUY {cex1} -> SELL {cex2}", f"{s:+.4f}%", trend="up" if s > 0 else "down")
-        if fill_buy2 and fill_sell1:
-            s = _spread_pct(fill_buy2, fill_sell1)
-            builder.kpi(f"BUY {cex2} -> SELL {cex1}", f"{s:+.4f}%", trend="up" if s > 0 else "down")
+        # KPIs - spreads per exchange
+        for ex in exchanges:
+            s = ex_data[ex]["stats"]
+            if s.get("spread_pct") is not None:
+                builder.kpi(f"{ex.upper()} Spread", f"{s['spread_pct']:.4f}%")
 
-        # Order book depth chart
-        if (bids1 or asks1) and (bids2 or asks2):
-            fig = _build_ob_chart(bids1, asks1, bids2, asks2, cex1, cex2, pair)
+        # KPIs - mid diffs
+        if len(mids) >= 2:
+            mid_vals = list(mids.values())
+            max_diff = max(mid_vals) - min(mid_vals)
+            max_diff_pct = (max_diff / min(mid_vals)) * 100
+            builder.kpi("Max Mid-Price Diff", f"{max_diff_pct:+.4f}%",
+                        trend="up" if max_diff_pct > 0.05 else "neutral")
+
+        # KPIs - arb opportunities
+        for ex_a, ex_b in combinations(exchanges, 2):
+            da, db = ex_data[ex_a], ex_data[ex_b]
+            if da["fill_buy"] and db["fill_sell"]:
+                s = _spread_pct(da["fill_buy"], db["fill_sell"])
+                builder.kpi(f"BUY {ex_a.upper()} -> SELL {ex_b.upper()}", f"{s:+.4f}%",
+                            trend="up" if s > 0 else "down")
+            if db["fill_buy"] and da["fill_sell"]:
+                s = _spread_pct(db["fill_buy"], da["fill_sell"])
+                builder.kpi(f"BUY {ex_b.upper()} -> SELL {ex_a.upper()}", f"{s:+.4f}%",
+                            trend="up" if s > 0 else "down")
+
+        # Order book depth chart (all exchanges stacked)
+        chart_data = [
+            (ex, ex_data[ex]["bids"], ex_data[ex]["asks"])
+            for ex in exchanges if ex_data[ex]["ob"]
+        ]
+        if len(chart_data) >= 2:
+            fig = _build_ob_chart(chart_data, pair)
             builder.plotly(fig)
 
         # Comparison table
         builder.markdown(f"## Order Book Comparison ({config.ob_depth} levels)")
         table_rows = []
-        for name, stats, fb, fs in [
-            (cex1, stats1, fill_buy1, fill_sell1),
-            (cex2, stats2, fill_buy2, fill_sell2),
-        ]:
-            row = {"Exchange": name.upper()}
-            if stats:
-                row["Best Bid"] = f"{stats['best_bid']:.6f}"
-                row["Best Ask"] = f"{stats['best_ask']:.6f}"
-                row["Mid Price"] = f"{stats['mid']:.6f}"
-                row["Spread"] = f"{stats['spread_pct']:.4f}%"
-                row["Bid Depth (USD)"] = f"${stats['bid_depth_usd']:,.0f}"
-                row["Ask Depth (USD)"] = f"${stats['ask_depth_usd']:,.0f}"
+        for ex in exchanges:
+            d = ex_data[ex]
+            row = {"Exchange": ex.upper()}
+            if d["stats"]:
+                s = d["stats"]
+                row["Best Bid"] = f"{s['best_bid']:.6f}"
+                row["Best Ask"] = f"{s['best_ask']:.6f}"
+                row["Mid Price"] = f"{s['mid']:.6f}"
+                row["Spread"] = f"{s['spread_pct']:.4f}%"
+                row["Bid Depth (USD)"] = f"${s['bid_depth_usd']:,.0f}"
+                row["Ask Depth (USD)"] = f"${s['ask_depth_usd']:,.0f}"
             else:
                 row["Best Bid"] = "N/A"
                 row["Best Ask"] = "N/A"
-            row[f"Fill BUY {config.amount}"] = f"{fb:.6f}" if fb else "N/A"
-            row[f"Fill SELL {config.amount}"] = f"{fs:.6f}" if fs else "N/A"
+            row[f"Fill BUY {config.amount}"] = f"{d['fill_buy']:.6f}" if d["fill_buy"] else "N/A"
+            row[f"Fill SELL {config.amount}"] = f"{d['fill_sell']:.6f}" if d["fill_sell"] else "N/A"
             table_rows.append(row)
         builder.table(table_rows)
 
+        # Arb matrix table
+        arb_rows = []
+        for ex_a, ex_b in combinations(exchanges, 2):
+            da, db = ex_data[ex_a], ex_data[ex_b]
+            row = {"Route": f"{ex_a.upper()} <-> {ex_b.upper()}"}
+            if da["fill_buy"] and db["fill_sell"]:
+                s = _spread_pct(da["fill_buy"], db["fill_sell"])
+                row[f"BUY {ex_a.upper()} SELL {ex_b.upper()}"] = f"{s:+.4f}%"
+            else:
+                row[f"BUY {ex_a.upper()} SELL {ex_b.upper()}"] = "N/A"
+            if db["fill_buy"] and da["fill_sell"]:
+                s = _spread_pct(db["fill_buy"], da["fill_sell"])
+                row[f"BUY {ex_b.upper()} SELL {ex_a.upper()}"] = f"{s:+.4f}%"
+            else:
+                row[f"BUY {ex_b.upper()} SELL {ex_a.upper()}"] = "N/A"
+            if da["stats"].get("mid") and db["stats"].get("mid"):
+                row["Mid Diff"] = f"{_spread_pct(da['stats']['mid'], db['stats']['mid']):+.4f}%"
+            arb_rows.append(row)
+        if arb_rows:
+            builder.markdown("## Arbitrage Matrix")
+            builder.table(arb_rows)
+
         # Top levels detail per exchange
-        for name, bids, asks in [(cex1, bids1, asks1), (cex2, bids2, asks2)]:
+        for ex in exchanges:
+            d = ex_data[ex]
+            bids, asks = d["bids"], d["asks"]
             n = min(10, max(len(bids), len(asks)))
-            builder.markdown(f"### {name.upper()} - Top {n} Levels")
+            if n == 0:
+                continue
+            builder.markdown(f"### {ex.upper()} - Top {n} Levels")
             levels = []
             for i in range(n):
                 row = {"#": i + 1}

--- a/routines/arb_check.py
+++ b/routines/arb_check.py
@@ -544,7 +544,7 @@ async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
             if levels:
                 builder.table(levels)
 
-        builder.save()
+        await builder.save()
     except Exception as e:
         logger.warning(f"Report generation failed: {e}")
 

--- a/routines/arb_check.py
+++ b/routines/arb_check.py
@@ -103,6 +103,22 @@ def _spread_pct(buy_price: float, sell_price: float) -> float:
     return ((sell_price - buy_price) / buy_price) * 100
 
 
+def _compute_arb_routes(valid_exchanges: list[str], ex_data: dict, amount: float) -> list[dict]:
+    """Compute all arb routes across exchange pairs. Returns list of dicts with route/spread/profit."""
+    routes = []
+    for ex_a, ex_b in combinations(valid_exchanges, 2):
+        da, db = ex_data[ex_a], ex_data[ex_b]
+        if da["fill_buy"] and db["fill_sell"]:
+            s = _spread_pct(da["fill_buy"], db["fill_sell"])
+            profit = (db["fill_sell"] - da["fill_buy"]) * amount
+            routes.append({"route": f"BUY {ex_a.upper()} → SELL {ex_b.upper()}", "spread": s, "profit": profit})
+        if db["fill_buy"] and da["fill_sell"]:
+            s = _spread_pct(db["fill_buy"], da["fill_sell"])
+            profit = (da["fill_sell"] - db["fill_buy"]) * amount
+            routes.append({"route": f"BUY {ex_b.upper()} → SELL {ex_a.upper()}", "spread": s, "profit": profit})
+    return routes
+
+
 def _filter_and_sort_exchanges(exchanges: list[str], ex_data: dict) -> tuple[list[str], list[tuple[str, str]]]:
     """Filter out exchanges with invalid data and sort by spread (smallest first).
 
@@ -389,23 +405,13 @@ async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
         lines.append("")
 
     # Arb analysis across valid pairs
+    all_arb_routes = _compute_arb_routes(valid_exchanges, ex_data, config.amount)
+
     lines.append("--- Arbitrage Matrix ---")
     opportunities = []
-
-    for ex_a, ex_b in combinations(valid_exchanges, 2):
-        da, db = ex_data[ex_a], ex_data[ex_b]
-
-        if da["fill_buy"] and db["fill_sell"]:
-            s = _spread_pct(da["fill_buy"], db["fill_sell"])
-            profit = (db["fill_sell"] - da["fill_buy"]) * config.amount
-            label = f"BUY {ex_a.upper()} -> SELL {ex_b.upper()}: {s:+.4f}% (${profit:.4f})"
-            (opportunities if s > 0 else lines).append(label)
-
-        if db["fill_buy"] and da["fill_sell"]:
-            s = _spread_pct(db["fill_buy"], da["fill_sell"])
-            profit = (da["fill_sell"] - db["fill_buy"]) * config.amount
-            label = f"BUY {ex_b.upper()} -> SELL {ex_a.upper()}: {s:+.4f}% (${profit:.4f})"
-            (opportunities if s > 0 else lines).append(label)
+    for r in all_arb_routes:
+        label = f"{r['route']}: {r['spread']:+.4f}% (${r['profit']:.4f})"
+        (opportunities if r["spread"] > 0 else lines).append(label)
 
     mids = {ex: d["stats"]["mid"] for ex, d in ex_data.items()
             if ex in valid_exchanges and d["stats"].get("mid")}
@@ -442,25 +448,8 @@ async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
             builder.kpi("Max Mid Diff", f"{max_diff_pct:+.4f}%",
                         trend="up" if max_diff_pct > 0.05 else "neutral")
 
-        # Find best arb opportunity for KPI
-        best_arb = None
-        all_arb_routes = []
-        for ex_a, ex_b in combinations(valid_exchanges, 2):
-            da, db = ex_data[ex_a], ex_data[ex_b]
-            if da["fill_buy"] and db["fill_sell"]:
-                s = _spread_pct(da["fill_buy"], db["fill_sell"])
-                profit = (db["fill_sell"] - da["fill_buy"]) * config.amount
-                route = {"route": f"BUY {ex_a.upper()} → SELL {ex_b.upper()}", "spread": s, "profit": profit}
-                all_arb_routes.append(route)
-                if best_arb is None or s > best_arb["spread"]:
-                    best_arb = route
-            if db["fill_buy"] and da["fill_sell"]:
-                s = _spread_pct(db["fill_buy"], da["fill_sell"])
-                profit = (da["fill_sell"] - db["fill_buy"]) * config.amount
-                route = {"route": f"BUY {ex_b.upper()} → SELL {ex_a.upper()}", "spread": s, "profit": profit}
-                all_arb_routes.append(route)
-                if best_arb is None or s > best_arb["spread"]:
-                    best_arb = route
+        # Find best arb opportunity for KPI (all_arb_routes computed above)
+        best_arb = max(all_arb_routes, key=lambda r: r["spread"]) if all_arb_routes else None
 
         if best_arb:
             builder.kpi("Best Route", f"{best_arb['route']}  {best_arb['spread']:+.4f}%",
@@ -518,8 +507,11 @@ async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
                     "Mid Diff": f"{diff:+.4f}%",
                     f"{ex_a.upper()} Mid": f"{mids[ex_a]:.6f}",
                     f"{ex_b.upper()} Mid": f"{mids[ex_b]:.6f}",
+                    "_diff_abs": abs(diff),
                 })
-            mid_rows.sort(key=lambda r: abs(float(r["Mid Diff"].replace("%", "").replace("+", ""))), reverse=True)
+            mid_rows.sort(key=lambda r: r["_diff_abs"], reverse=True)
+            for r in mid_rows:
+                del r["_diff_abs"]
             builder.markdown("## Mid-Price Differences")
             builder.table(mid_rows)
 

--- a/routines/error_test.py
+++ b/routines/error_test.py
@@ -1,0 +1,37 @@
+"""Routine that intentionally fails — for testing error display in the dashboard."""
+
+import random
+
+from pydantic import BaseModel, Field
+from telegram.ext import ContextTypes
+
+
+class Config(BaseModel):
+    """Test error handling in the web dashboard"""
+    fail_mode: str = Field(
+        default="exception",
+        description="Type of failure: exception, key_error, type_error, zero_division, timeout",
+    )
+    delay_sec: float = Field(default=1.0, description="Seconds to wait before failing")
+
+
+async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
+    import asyncio
+
+    await asyncio.sleep(config.delay_sec)
+
+    if config.fail_mode == "exception":
+        raise RuntimeError("This is a test error to verify dashboard error alerts work correctly")
+    elif config.fail_mode == "key_error":
+        data: dict = {}
+        return data["missing_key"]  # type: ignore
+    elif config.fail_mode == "type_error":
+        result = 42 + "not a number"  # type: ignore
+        return str(result)
+    elif config.fail_mode == "zero_division":
+        return str(1 / 0)
+    elif config.fail_mode == "timeout":
+        await asyncio.sleep(300)  # hang forever until cancelled
+        return "Should not reach here"
+    else:
+        raise ValueError(f"Unknown fail_mode: {config.fail_mode}")

--- a/routines/error_test.py
+++ b/routines/error_test.py
@@ -1,7 +1,5 @@
 """Routine that intentionally fails — for testing error display in the dashboard."""
 
-import random
-
 from pydantic import BaseModel, Field
 from telegram.ext import ContextTypes
 

--- a/routines/market_scanner.py
+++ b/routines/market_scanner.py
@@ -440,7 +440,7 @@ async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
         builder.table(_to_table(classified["mature"]))
         builder.markdown("### Degen Markets\nHigh volatility, spiky activity")
         builder.table(_to_table(classified["degen"]))
-        builder.save()
+        await builder.save()
     except Exception as e:
         logger.warning(f"Report generation failed: {e}")
 

--- a/routines/price_monitor.py
+++ b/routines/price_monitor.py
@@ -63,6 +63,20 @@ async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
     except Exception as e:
         logger.error(f"Failed to send start message: {e}")
 
+    # Live report setup
+    try:
+        from condor.reports import LiveReport
+
+        report = LiveReport(
+            f"Price Monitor: {config.trading_pair}",
+            source_name="price_monitor",
+            tags=["monitoring", "live"],
+        )
+    except Exception:
+        report = None
+
+    history = []
+
     try:
         # Main monitoring loop
         while True:
@@ -117,6 +131,35 @@ async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
 
                 # Update last price
                 state["last_price"] = current_price
+
+                # Update live report
+                if report:
+                    try:
+                        from datetime import datetime, timezone
+
+                        history.append({
+                            "Time": datetime.now(timezone.utc).strftime("%H:%M:%S"),
+                            "Price": f"${current_price:,.2f}",
+                            "Change": f"{change_from_last:+.2f}%",
+                        })
+
+                        elapsed = int(time.time() - state["start_time"])
+                        mins, secs = divmod(elapsed, 60)
+                        change_total = ((current_price - state["initial_price"]) / state["initial_price"]) * 100
+
+                        report.clear()
+                        report.builder.manual_order()
+                        report.builder.kpi("Current Price", f"${current_price:,.2f}")
+                        report.builder.kpi("High", f"${state['high_price']:,.2f}", trend="up")
+                        report.builder.kpi("Low", f"${state['low_price']:,.2f}", trend="down")
+                        report.builder.kpi("Change", f"{change_total:+.2f}%",
+                                           trend="up" if change_total > 0 else "down")
+                        report.builder.kpi("Runtime", f"{mins}m {secs}s")
+                        report.builder.kpi("Alerts", str(state["alerts_sent"]))
+                        report.builder.table(history[-50:])
+                        report.update()
+                    except Exception as e:
+                        logger.debug(f"Report update failed: {e}")
 
             except asyncio.CancelledError:
                 raise  # Re-raise to exit the loop

--- a/routines/price_monitor.py
+++ b/routines/price_monitor.py
@@ -81,6 +81,12 @@ async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
         # Main monitoring loop
         while True:
             try:
+                # Re-acquire client each iteration to avoid stale sessions
+                client = await get_client(chat_id, context=context)
+                if not client:
+                    await asyncio.sleep(config.interval_sec)
+                    continue
+
                 # Get current price
                 prices = await client.market_data.get_prices(
                     connector_name=config.connector, trading_pairs=config.trading_pair
@@ -157,7 +163,7 @@ async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
                         report.builder.kpi("Runtime", f"{mins}m {secs}s")
                         report.builder.kpi("Alerts", str(state["alerts_sent"]))
                         report.builder.table(history[-50:])
-                        report.update()
+                        await report.update()
                     except Exception as e:
                         logger.debug(f"Report update failed: {e}")
 

--- a/setup-environment.sh
+++ b/setup-environment.sh
@@ -470,6 +470,25 @@ if [ -n "${DEPLOY_HUMMINGBOT_API:-}" ]; then
         msg_ok "Hummingbot API already configured (skipped)"
     fi
 else
+    # Check if a Hummingbot API is already running on port 8000
+    existing_api=false
+    if curl -sf http://localhost:8000/docs >/dev/null 2>&1; then
+        existing_api=true
+        msg_warn "Hummingbot API already running on localhost:8000"
+        echo ""
+        prompt_visible "An API instance is already running. Override it? [y/N]" "N" "override_api"
+        if [[ "${override_api:-}" =~ ^[Yy]$ ]]; then
+            msg_info "Will reconfigure and restart the API."
+        else
+            echo "DEPLOY_HUMMINGBOT_API=false" >> "$ENV_FILE"
+            msg_ok "Keeping existing API instance"
+            hb_api_deployed=false
+            # Skip the rest of the API setup block
+            existing_api=skip
+        fi
+    fi
+
+    if [ "$existing_api" != "skip" ]; then
     msg_info "Condor connects to Hummingbot Backend API for trading."
     echo ""
     prompt_visible "Configure and launch local Hummingbot API with Docker? [Y/n]" "Y" "deploy_hb"
@@ -561,6 +580,7 @@ HBEOF
             hb_api_deployed=true
         fi
     fi
+    fi  # end existing_api != skip
 fi
 
 echo ""

--- a/uv.lock
+++ b/uv.lock
@@ -622,7 +622,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "faster-whisper" },
     { name = "geckoterminal-py" },
-    { name = "hummingbot-api-client", specifier = "==1.5.0" },
+    { name = "hummingbot-api-client", specifier = "==1.5.2" },
     { name = "isort", marker = "extra == 'dev'" },
     { name = "kaleido" },
     { name = "matplotlib", specifier = ">=3.10.8" },
@@ -1473,14 +1473,14 @@ wheels = [
 
 [[package]]
 name = "hummingbot-api-client"
-version = "1.5.0"
+version = "1.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/9b/0fde6347b9ad07c0573699bf0e4935d5d6079f3efce28f6826862aca3f9f/hummingbot_api_client-1.5.0.tar.gz", hash = "sha256:c048af635ecb5a0c59924d41a9818c0147174bf0ad3f080617015046670b690f", size = 40177, upload-time = "2026-05-13T19:02:06.712Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/641c722243621784c33d1c026316a85af61cf01272386eb9582bb33f8302/hummingbot_api_client-1.5.2.tar.gz", hash = "sha256:bb57a08838539a4c436b0d0d9800e54818176809422e1346734a8ea76a0844f9", size = 39357, upload-time = "2026-05-20T18:49:30.019Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/a7/69f14f09aa17deca7b4b2c9db0b21be865d7b4dd781f1df2041f6354ab14/hummingbot_api_client-1.5.0-py3-none-any.whl", hash = "sha256:27c296282582dc19aea86fde2a0ad40386f9bb8cca093612cfb3f8dc0c7d1d72", size = 47382, upload-time = "2026-05-13T19:02:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/79/82/f9e329a30fd5c76aa64e7c3b38e173ecb3ad701a8f902d6d824d51f497b6/hummingbot_api_client-1.5.2-py3-none-any.whl", hash = "sha256:828372d03c3f64302355e17bbedcce0f958fb1c395813c2c7b3c15ed54c7fc2c", size = 46485, upload-time = "2026-05-20T18:49:28.617Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -622,7 +622,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "faster-whisper" },
     { name = "geckoterminal-py" },
-    { name = "hummingbot-api-client", specifier = "==1.4.1" },
+    { name = "hummingbot-api-client", specifier = "==1.5.0" },
     { name = "isort", marker = "extra == 'dev'" },
     { name = "kaleido" },
     { name = "matplotlib", specifier = ">=3.10.8" },
@@ -1473,14 +1473,14 @@ wheels = [
 
 [[package]]
 name = "hummingbot-api-client"
-version = "1.4.1"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/75/31d281aa2482a28ff9b453cad294857326f2f3ddb3ddca15ae79f6f75784/hummingbot_api_client-1.4.1.tar.gz", hash = "sha256:6bbbb32f7db37016119110f3bd7e043e31d6e85b1a752a28ba850f9e63c25fa8", size = 38394, upload-time = "2026-04-21T04:01:14.315Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/9b/0fde6347b9ad07c0573699bf0e4935d5d6079f3efce28f6826862aca3f9f/hummingbot_api_client-1.5.0.tar.gz", hash = "sha256:c048af635ecb5a0c59924d41a9818c0147174bf0ad3f080617015046670b690f", size = 40177, upload-time = "2026-05-13T19:02:06.712Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/5a/74f51cf4daa1be38d205eec0b4f5a4744707b71238e16dd26b6a6ac2aa5a/hummingbot_api_client-1.4.1-py3-none-any.whl", hash = "sha256:37e8b442c15bc3a5cf42fa9f40e9efdd74ec1d8e40d39d0ee01264e0db94a4fe", size = 45031, upload-time = "2026-04-21T04:01:12.716Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a7/69f14f09aa17deca7b4b2c9db0b21be865d7b4dd781f1df2041f6354ab14/hummingbot_api_client-1.5.0-py3-none-any.whl", hash = "sha256:27c296282582dc19aea86fde2a0ad40386f9bb8cca093612cfb3f8dc0c7d1d72", size = 47382, upload-time = "2026-05-13T19:02:05.468Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -622,7 +622,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "faster-whisper" },
     { name = "geckoterminal-py" },
-    { name = "hummingbot-api-client", specifier = "==1.5.2" },
+    { name = "hummingbot-api-client", specifier = "==1.5.3" },
     { name = "isort", marker = "extra == 'dev'" },
     { name = "kaleido" },
     { name = "matplotlib", specifier = ">=3.10.8" },
@@ -1473,14 +1473,14 @@ wheels = [
 
 [[package]]
 name = "hummingbot-api-client"
-version = "1.5.2"
+version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/82/641c722243621784c33d1c026316a85af61cf01272386eb9582bb33f8302/hummingbot_api_client-1.5.2.tar.gz", hash = "sha256:bb57a08838539a4c436b0d0d9800e54818176809422e1346734a8ea76a0844f9", size = 39357, upload-time = "2026-05-20T18:49:30.019Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/c8/5c6c94f2a1498aa4b356d8a0e034b344085ec1a6bde58c4e04a993c871c5/hummingbot_api_client-1.5.3.tar.gz", hash = "sha256:2f5c7f4d57a151a6b529b58f18b735d31bb9f0858428d2141dfc1e743302b06c", size = 39417, upload-time = "2026-05-26T02:46:07.675Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/82/f9e329a30fd5c76aa64e7c3b38e173ecb3ad701a8f902d6d824d51f497b6/hummingbot_api_client-1.5.2-py3-none-any.whl", hash = "sha256:828372d03c3f64302355e17bbedcce0f958fb1c395813c2c7b3c15ed54c7fc2c", size = 46485, upload-time = "2026-05-20T18:49:28.617Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/05/f83142ff1bea7dd057f6bcfa523fee33cd973bac1d6afa1f8e42a35f5de2/hummingbot_api_client-1.5.3-py3-none-any.whl", hash = "sha256:856812ab1a28881b0b5bd36e2f783a07db0f38fa694c83ed263038fdc12ec730", size = 46555, upload-time = "2026-05-26T02:46:06.034Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## PR Summary: General Upgrade & GitHub Actions                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                         
What changed                                                                                                                                                                                                                                                                             
                                                                
Rate Oracle & Currency Display
- New rate oracle routes (/market/rates) for fetching exchange rates
- Currency selector component — users can switch display currency
- useRates and useDisplayCurrency hooks + unified formatters.ts for consistent currency formatting across Portfolio, Bots, and Executors pages

Agent Sessions — Per-Server Management
- Agent chat sessions are now scoped by server (not global)
- Fixed agent config handling and session lifecycle
- Improved agent frontend: session reviewer, controls, and detail page reworked

Routines & Reports
- Reports surfaced as base routines
- Report browser UI significantly expanded (full-screen viz support)
- Routine source code now viewable from the UI
- Schedule dropdown and instance management improvements

Arb Check Routine
- Upgraded to support CEX-CEX arbitrage (was DEX only)
- Major refactor (~464 lines changed)

MCP Server Improvements
- Server switching/management via MCP tools
- Improved skill descriptions
- Hummingbot API client updated, logging moved to warnings

Frontend Polish
- Chat panel and input reworked (WebSocket hook refactored)
- Executors page simplified
- Portfolio page enhanced with currency support
- Gateway settings cleanup

What to test

- Switch display currency on Portfolio/Bots/Executors — values should convert correctly
- /routines — run a report, view it full-screen, check source code tab
- Agent sessions: switch servers and verify sessions are isolated per server
- Arb check routine: run with CEX-CEX pairs
- MCP: change server via MCP tool, confirm it sticks
- Chat panel on web dashboard — send messages, verify WebSocket reconnects
- Schedule a one-shot routine, verify it persists across restart