### PR TITLE
Use OPENAI_API_KEY environment variable for OpenAIProvider when avail…

### DIFF
--- a/condor/acp/pydantic_ai_client.py
+++ b/condor/acp/pydantic_ai_client.py
@@ -197,7 +197,7 @@ class PydanticAIClient:
 
         # OpenAI with custom base_url (vLLM, TGI, etc.)
         if prefix == "openai" and base_url:
-            provider = OpenAIProvider(base_url=base_url, api_key="not-needed")
+            provider = OpenAIProvider(base_url=base_url, api_key=os.environ.get("OPENAI_API_KEY") or "not-needed")
             return OpenAIModel(model_id, provider=provider)
 
         # Standard pydantic-ai resolution (openai, groq, anthropic, google)


### PR DESCRIPTION
This change allows using the same code with Ollama (and other OpenAI-compatible endpoints) that require a real (or custom) API key