### PR TITLE
feat(acp): add Venice AI as a provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,8 @@ ADMIN_USER_ID=
 # Examples: http://myserver.com:8088, https://dashboard.example.com
 # WEB_URL=http://localhost:8088
 
+# ── AI providers (optional, for agent features) ──────
+# Pick whichever cloud gateway you use. Each is OpenAI-compatible.
+# OPENAI_API_KEY=
+# OPENROUTER_API_KEY=
+# VENICE_API_KEY=

--- a/condor/acp/pydantic_ai_client.py
+++ b/condor/acp/pydantic_ai_client.py
@@ -92,13 +92,14 @@ def _infer_tool_filter_mode(model_name: str) -> str:
 # Model prefix → pydantic-ai model string mapping
 # Users set agent_key like "ollama:llama3.1:70b" or "openai:gpt-4o"
 # which maps directly to pydantic-ai model identifiers.
-PYDANTIC_AI_PREFIXES = frozenset({"ollama", "openai", "groq", "anthropic", "google", "lmstudio", "openrouter"})
+PYDANTIC_AI_PREFIXES = frozenset({"ollama", "openai", "groq", "anthropic", "google", "lmstudio", "openrouter", "venice"})
 
-# Default base URLs for local model providers and OpenRouter
+# Default base URLs for local model providers and OpenAI-compatible cloud gateways
 DEFAULT_BASE_URLS: dict[str, str] = {
     "ollama": "http://localhost:11434/v1",
     "lmstudio": "http://localhost:1234/v1",
     "openrouter": "https://openrouter.ai/api/v1",
+    "venice": "https://api.venice.ai/api/v1",
 }
 
 
@@ -122,6 +123,7 @@ class PydanticAIClient:
       - "groq:llama-3.3-70b-versatile" → uses Groq cloud
       - "anthropic:claude-sonnet-4-6" → uses Anthropic API
       - "openrouter:anthropic/claude-sonnet-4-5" → uses OpenRouter (requires OPENROUTER_API_KEY)
+      - "venice:llama-3.3-70b" → uses Venice AI (requires VENICE_API_KEY)
     """
 
     def __init__(
@@ -183,6 +185,27 @@ class PydanticAIClient:
                 )
             provider = OpenAIProvider(
                 base_url=base_url or DEFAULT_BASE_URLS["openrouter"],
+                api_key=api_key,
+            )
+            return OpenAIModel(model_id, provider=provider)
+
+        # Venice AI: OpenAI-compatible cloud gateway, requires API key.
+        # Same shape as OpenRouter — handled before the generic DEFAULT_BASE_URLS
+        # branch because Venice rejects the api_key="not-needed" placeholder.
+        if prefix == "venice":
+            if not model_id:
+                raise RuntimeError(
+                    "Venice requires an explicit model id, e.g. "
+                    "'venice:llama-3.3-70b' or 'venice:venice-uncensored'. "
+                    "See https://docs.venice.ai for available models."
+                )
+            api_key = os.environ.get("VENICE_API_KEY")
+            if not api_key:
+                raise RuntimeError(
+                    "VENICE_API_KEY is not set. Add it to your .env to use venice:* models."
+                )
+            provider = OpenAIProvider(
+                base_url=base_url or DEFAULT_BASE_URLS["venice"],
                 api_key=api_key,
             )
             return OpenAIModel(model_id, provider=provider)

--- a/condor/acp/pydantic_ai_client.py
+++ b/condor/acp/pydantic_ai_client.py
@@ -51,7 +51,7 @@ def _infer_tool_filter_mode(model_name: str) -> str:
     model_lower = model_name.lower()
 
     # Cloud providers always get full access (they're powerful enough)
-    if any(provider in model_lower for provider in ["openai:", "anthropic:", "groq:", "google:", "openrouter:"]):
+    if any(provider in model_lower for provider in ["openai:", "anthropic:", "groq:", "google:", "openrouter:", "venice:"]):
         log.info("Auto-detected cloud provider → tool_filter_mode=full")
         return "full"
 
@@ -160,6 +160,9 @@ class PydanticAIClient:
           - openrouter:model → OpenAI-compat at https://openrouter.ai/api/v1,
                                requires OPENROUTER_API_KEY; model id must be
                                explicit (e.g. "openrouter:anthropic/claude-sonnet-4-5").
+          - venice:model     → OpenAI-compat at https://api.venice.ai/api/v1,
+                               requires VENICE_API_KEY; model id must be
+                               explicit (e.g. "venice:llama-3.3-70b").
           - openai:model     → OpenAI API (or custom base_url for vLLM, etc.)
           - groq/anthropic   → standard pydantic-ai resolution
         """

--- a/handlers/agents/__init__.py
+++ b/handlers/agents/__init__.py
@@ -123,9 +123,11 @@ async def agent_callback_handler(
         await _handle_settings(update, context)
     elif action.startswith("set_llm:"):
         llm_key = action.split(":", 1)[1]
-        # OpenRouter sentinel -> open the model picker instead of setting directly
+        # Sentinel keys open a paginated picker instead of setting agent_llm directly.
         if llm_key == "openrouter:":
             await _handle_openrouter_picker(update, context, page=0)
+        elif llm_key == "venice:":
+            await _handle_venice_picker(update, context, page=0)
         else:
             await _handle_set_llm(update, context, llm_key)
     elif action.startswith("or_page:"):
@@ -141,6 +143,20 @@ async def agent_callback_handler(
     elif action == "or_type_cancel":
         await _handle_openrouter_type_cancel(update, context)
     elif action == "or_noop":
+        pass  # page indicator button — do nothing
+    elif action.startswith("vc_page:"):
+        page = int(action.split(":", 1)[1])
+        await _handle_venice_picker(update, context, page=page)
+    elif action.startswith("vc_pick:"):
+        idx = int(action.split(":", 1)[1])
+        await _handle_venice_pick(update, context, idx)
+    elif action == "vc_type":
+        await _handle_venice_type_prompt(update, context)
+    elif action == "vc_type_confirm":
+        await _handle_venice_type_confirm(update, context)
+    elif action == "vc_type_cancel":
+        await _handle_venice_type_cancel(update, context)
+    elif action == "vc_noop":
         pass  # page indicator button — do nothing
 
     # Session management
@@ -465,6 +481,189 @@ async def _handle_openrouter_type_cancel(
     """Discard the typed slug without changing the active LLM."""
     query = update.callback_query
     context.user_data.pop("_openrouter_typed_slug", None)
+    await query.message.edit_text("Cancelled. Use /agent to continue.")
+
+
+# ── Venice picker (mirrors OpenRouter picker above) ─────────────────────────
+
+
+async def _handle_venice_picker(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, page: int
+) -> None:
+    """Show paginated Venice model picker.
+
+    Fetches the model list (cached for 1h), filters to tool-calling models, and
+    stores the resolved list in user_data so vc_pick:N can resolve the index.
+    """
+    import os
+
+    from .menu import _venice_picker_keyboard
+    from .venice_models import fetch_models
+
+    query = update.callback_query
+
+    if not os.environ.get("VENICE_API_KEY"):
+        await query.message.edit_text(
+            "VENICE_API_KEY is not set. Add it to your .env to use Venice models, "
+            "then restart the bot.\n\nGet a key at https://venice.ai/settings/api"
+        )
+        return
+
+    if page == 0:
+        await query.message.edit_text("Loading Venice models...")
+
+    try:
+        models = await fetch_models()
+    except Exception as e:
+        log.exception("Failed to fetch Venice models")
+        await query.message.edit_text(f"Failed to fetch Venice models: {e}")
+        return
+
+    if not models:
+        await query.message.edit_text(
+            "No Venice models available. Check your network or try again later."
+        )
+        return
+
+    context.user_data["_venice_models"] = models
+
+    current = context.user_data.get("agent_llm", "")
+    current_slug = (
+        current.split(":", 1)[1]
+        if current.startswith("venice:") and current != "venice:"
+        else None
+    )
+
+    keyboard = _venice_picker_keyboard(models, page=page, current_slug=current_slug)
+    await query.message.edit_text(
+        f"Select a Venice model ({len(models)} with tool-calling support):",
+        reply_markup=keyboard,
+    )
+
+
+async def _handle_venice_pick(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, idx: int
+) -> None:
+    """Resolve picker index → set agent_llm to 'venice:<slug>'."""
+    query = update.callback_query
+    models = context.user_data.get("_venice_models") or []
+    if not models or idx < 0 or idx >= len(models):
+        await query.message.edit_text(
+            "Selection expired. Reopen the picker via Change LLM."
+        )
+        return
+
+    model = models[idx]
+    agent_key = f"venice:{model.slug}"
+    context.user_data["agent_llm"] = agent_key
+
+    pricing = ""
+    if model.input_price or model.output_price:
+        pricing = (
+            f"\nPricing: ${model.input_price:.2f}/M input, "
+            f"${model.output_price:.2f}/M output"
+        )
+
+    await query.message.edit_text(
+        f"LLM set to Venice — {model.name}.\n"
+        f"Slug: {model.slug}{pricing}\n\n"
+        "New sessions will use this model. Use /agent to continue."
+    )
+
+
+async def _handle_venice_type_prompt(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Arm slug-input mode: next text message is parsed as a Venice slug."""
+    query = update.callback_query
+    context.user_data["_venice_typing_slug"] = True
+    await query.message.edit_text(
+        "Send the Venice model slug as a message.\n"
+        "Example: llama-3.3-70b\n\n"
+        "Send /cancel to abort."
+    )
+
+
+async def _resolve_venice_typed_slug(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, text: str
+) -> None:
+    """Validate a typed slug; on match, prompt confirmation."""
+    from .venice_models import fetch_models, find_model_by_slug
+
+    slug = text.strip()
+    if slug.lower() in ("/cancel", "cancel"):
+        await update.message.reply_text("Cancelled. Use /agent to continue.")
+        return
+
+    try:
+        models = await fetch_models()
+    except Exception as e:
+        log.exception("Failed to fetch Venice models")
+        await update.message.reply_text(f"Failed to fetch Venice models: {e}")
+        return
+
+    model = find_model_by_slug(models, slug)
+    if not model:
+        context.user_data["_venice_typing_slug"] = True
+        await update.message.reply_text(
+            f"No tool-calling Venice model matches '{slug}'.\n"
+            "The slug must be exact (e.g. llama-3.3-70b).\n"
+            "Try again, or send /cancel."
+        )
+        return
+
+    context.user_data["_venice_typed_slug"] = model.slug
+
+    pricing = ""
+    if model.input_price or model.output_price:
+        pricing = (
+            f"\nPricing: ${model.input_price:.2f}/M input, "
+            f"${model.output_price:.2f}/M output"
+        )
+
+    keyboard = InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton(
+                    "Use this model", callback_data="agent:vc_type_confirm"
+                ),
+                InlineKeyboardButton(
+                    "Cancel", callback_data="agent:vc_type_cancel"
+                ),
+            ]
+        ]
+    )
+    await update.message.reply_text(
+        f"Use Venice — {model.name}?\nSlug: {model.slug}{pricing}",
+        reply_markup=keyboard,
+    )
+
+
+async def _handle_venice_type_confirm(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Apply the typed slug as the active agent_llm."""
+    query = update.callback_query
+    slug = context.user_data.pop("_venice_typed_slug", None)
+    if not slug:
+        await query.message.edit_text(
+            "Selection expired. Reopen the picker via Change LLM."
+        )
+        return
+
+    context.user_data["agent_llm"] = f"venice:{slug}"
+    await query.message.edit_text(
+        f"LLM set to Venice — {slug}.\n\n"
+        "New sessions will use this model. Use /agent to continue."
+    )
+
+
+async def _handle_venice_type_cancel(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Discard the typed slug without changing the active LLM."""
+    query = update.callback_query
+    context.user_data.pop("_venice_typed_slug", None)
     await query.message.edit_text("Cancelled. Use /agent to continue.")
 
 
@@ -798,6 +997,11 @@ async def agent_message_handler(
     # Handle typed OpenRouter slug input
     if context.user_data.pop("_openrouter_typing_slug", None):
         await _resolve_openrouter_typed_slug(update, context, text)
+        return
+
+    # Handle typed Venice slug input
+    if context.user_data.pop("_venice_typing_slug", None):
+        await _resolve_venice_typed_slug(update, context, text)
         return
 
     # Backward compat

--- a/handlers/agents/_shared.py
+++ b/handlers/agents/_shared.py
@@ -87,6 +87,9 @@ AGENT_OPTIONS: dict[str, dict[str, str]] = {
     # Sentinel — clicking this opens the OpenRouter model picker (handlers/agents/menu.py).
     # The actual stored agent_llm becomes "openrouter:<slug>" once the user picks a model.
     "openrouter:": {"label": "OpenRouter — Pick Model"},
+    # Sentinel — same shape as openrouter:. Clicking opens the Venice model picker.
+    # The actual stored agent_llm becomes "venice:<slug>" once the user picks a model.
+    "venice:": {"label": "Venice — Pick Model"},
 }
 
 DEFAULT_AGENT = "claude-code"

--- a/handlers/agents/menu.py
+++ b/handlers/agents/menu.py
@@ -46,19 +46,32 @@ def _settings_keyboard(current_llm: str) -> InlineKeyboardMarkup:
     """Build LLM picker keyboard.
 
     The current selection is marked with a bullet. If the user has previously
-    picked an OpenRouter model (agent_llm starts with "openrouter:<slug>"), the
-    "openrouter:" sentinel row matches and shows the slug they picked.
+    picked a sentinel-backed model (OpenRouter or Venice — agent_llm starts with
+    "openrouter:<slug>" or "venice:<slug>"), the corresponding sentinel row
+    matches and shows the slug they picked.
     """
     keyboard = []
     for key, info in AGENT_OPTIONS.items():
         label = info["label"]
-        # Treat any "openrouter:<slug>" as matching the sentinel "openrouter:" row
-        is_current = key == current_llm or (
-            key == "openrouter:" and current_llm.startswith("openrouter:") and current_llm != "openrouter:"
+        # Treat any "openrouter:<slug>" / "venice:<slug>" as matching their sentinel row
+        is_or_current = (
+            key == "openrouter:"
+            and current_llm.startswith("openrouter:")
+            and current_llm != "openrouter:"
         )
-        if is_current and current_llm.startswith("openrouter:") and current_llm != "openrouter:":
+        is_vc_current = (
+            key == "venice:"
+            and current_llm.startswith("venice:")
+            and current_llm != "venice:"
+        )
+        is_current = key == current_llm or is_or_current or is_vc_current
+
+        if is_or_current:
             slug = current_llm.split(":", 1)[1]
             label = f"• OpenRouter — {slug}"
+        elif is_vc_current:
+            slug = current_llm.split(":", 1)[1]
+            label = f"• Venice — {slug}"
         elif is_current:
             label = f"• {label}"
         keyboard.append(
@@ -70,6 +83,9 @@ def _settings_keyboard(current_llm: str) -> InlineKeyboardMarkup:
 
 # OpenRouter picker pagination
 OPENROUTER_PAGE_SIZE = 8
+
+# Venice picker pagination (same shape as OpenRouter)
+VENICE_PAGE_SIZE = 8
 
 
 def _openrouter_picker_keyboard(
@@ -116,6 +132,56 @@ def _openrouter_picker_keyboard(
     if page < total_pages - 1:
         nav_row.append(
             InlineKeyboardButton("Next ›", callback_data=f"agent:or_page:{page + 1}")
+        )
+    keyboard.append(nav_row)
+    keyboard.append([InlineKeyboardButton("Back", callback_data="agent:settings")])
+    return InlineKeyboardMarkup(keyboard)
+
+
+def _venice_picker_keyboard(
+    models: list, page: int, current_slug: str | None
+) -> InlineKeyboardMarkup:
+    """Paginated keyboard for picking a Venice model.
+
+    Same shape as `_openrouter_picker_keyboard` — references each model by its
+    index in the cached list so callback_data stays well under Telegram's
+    64-byte cap regardless of slug length.
+    """
+    from .venice_models import format_button_label
+
+    if not models:
+        return InlineKeyboardMarkup(
+            [[InlineKeyboardButton("Back", callback_data="agent:settings")]]
+        )
+
+    total_pages = (len(models) + VENICE_PAGE_SIZE - 1) // VENICE_PAGE_SIZE
+    page = max(0, min(page, total_pages - 1))
+    start = page * VENICE_PAGE_SIZE
+    end = min(start + VENICE_PAGE_SIZE, len(models))
+
+    keyboard: list[list[InlineKeyboardButton]] = [
+        [InlineKeyboardButton("Enter model manually", callback_data="agent:vc_type")],
+    ]
+    for idx in range(start, end):
+        m = models[idx]
+        label = format_button_label(m)
+        if current_slug and m.slug == current_slug:
+            label = f"• {label}"
+        keyboard.append(
+            [InlineKeyboardButton(label, callback_data=f"agent:vc_pick:{idx}")]
+        )
+
+    nav_row: list[InlineKeyboardButton] = []
+    if page > 0:
+        nav_row.append(
+            InlineKeyboardButton("‹ Prev", callback_data=f"agent:vc_page:{page - 1}")
+        )
+    nav_row.append(
+        InlineKeyboardButton(f"{page + 1}/{total_pages}", callback_data="agent:vc_noop")
+    )
+    if page < total_pages - 1:
+        nav_row.append(
+            InlineKeyboardButton("Next ›", callback_data=f"agent:vc_page:{page + 1}")
         )
     keyboard.append(nav_row)
     keyboard.append([InlineKeyboardButton("Back", callback_data="agent:settings")])

--- a/handlers/agents/venice_models.py
+++ b/handlers/agents/venice_models.py
@@ -1,0 +1,146 @@
+"""Venice AI model catalog fetcher.
+
+Hits GET https://api.venice.ai/api/v1/models (requires VENICE_API_KEY) and
+filters to entries that advertise `supportsFunctionCalling: true` under
+`model_spec.capabilities`. Condor's whole architecture depends on tool-calling,
+so models without it are hidden from the picker.
+
+Also filters to `type == "text"` so image / audio models don't pollute the list.
+
+Results are cached for an hour so paginating the picker doesn't refetch.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+
+import aiohttp
+
+log = logging.getLogger(__name__)
+
+VENICE_MODELS_URL = "https://api.venice.ai/api/v1/models"
+CACHE_TTL_SECONDS = 3600
+
+
+@dataclass(frozen=True)
+class VeniceModel:
+    slug: str            # e.g. "llama-3.3-70b"
+    name: str            # human-friendly name (falls back to slug)
+    context_length: int  # tokens
+    input_price: float   # USD per 1M input tokens (Venice returns per-1M directly)
+    output_price: float  # USD per 1M output tokens
+
+
+_cache: tuple[float, list[VeniceModel]] | None = None
+
+
+def _parse_price(value: object) -> float:
+    """Venice returns pricing as `{"usd": <number>, "diem": <number>}` per 1M tokens."""
+    try:
+        if isinstance(value, dict):
+            return float(value.get("usd", 0.0))
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _model_supports_tools(entry: dict) -> bool:
+    spec = entry.get("model_spec") or {}
+    caps = spec.get("capabilities") or {}
+    return bool(caps.get("supportsFunctionCalling"))
+
+
+def _model_is_text(entry: dict) -> bool:
+    return entry.get("type") == "text"
+
+
+async def fetch_models(force_refresh: bool = False) -> list[VeniceModel]:
+    """Return the list of Venice models that support tool-calling.
+
+    Sorted by slug for predictable pagination. Requires VENICE_API_KEY.
+    """
+    global _cache
+
+    if not force_refresh and _cache is not None:
+        cached_at, models = _cache
+        if time.monotonic() - cached_at < CACHE_TTL_SECONDS:
+            return models
+
+    api_key = os.environ.get("VENICE_API_KEY")
+    if not api_key:
+        log.warning("VENICE_API_KEY not set; cannot fetch Venice models")
+        return []
+
+    headers = {"Authorization": f"Bearer {api_key}"}
+    timeout = aiohttp.ClientTimeout(total=10)
+    try:
+        async with aiohttp.ClientSession(timeout=timeout, headers=headers) as session:
+            async with session.get(VENICE_MODELS_URL) as resp:
+                resp.raise_for_status()
+                payload = await resp.json()
+    except Exception as e:
+        log.warning("Failed to fetch Venice models: %s", e)
+        if _cache is not None:
+            return _cache[1]  # serve stale cache on failure
+        return []
+
+    raw = payload.get("data") or []
+    models: list[VeniceModel] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        slug = entry.get("id")
+        if not isinstance(slug, str) or not slug:
+            continue
+        if not _model_is_text(entry):
+            continue
+        if not _model_supports_tools(entry):
+            continue
+
+        spec = entry.get("model_spec") or {}
+        pricing = spec.get("pricing") or {}
+        # Prefer model_spec.availableContextTokens; fall back to top-level context_length.
+        context_length = (
+            spec.get("availableContextTokens")
+            or entry.get("context_length")
+            or 0
+        )
+
+        models.append(
+            VeniceModel(
+                slug=slug,
+                name=str(spec.get("name") or slug),
+                context_length=int(context_length),
+                input_price=_parse_price(pricing.get("input")),
+                output_price=_parse_price(pricing.get("output")),
+            )
+        )
+
+    models.sort(key=lambda m: m.slug.lower())
+    _cache = (time.monotonic(), models)
+    log.info("Fetched %d Venice models with tool support", len(models))
+    return models
+
+
+def format_button_label(model: VeniceModel) -> str:
+    """Short label for inline keyboard buttons. Telegram max ~38 chars looks good."""
+    label = model.name or model.slug
+    if len(label) > 38:
+        label = label[:35] + "..."
+    return label
+
+
+def find_model_by_slug(
+    models: list[VeniceModel], slug: str
+) -> VeniceModel | None:
+    """Case-insensitive exact-match lookup by slug."""
+    target = slug.strip().lower()
+    if not target:
+        return None
+    for m in models:
+        if m.slug.lower() == target:
+            return m
+    return None


### PR DESCRIPTION
## What

Adds [Venice AI](https://venice.ai) as a first-class provider in `PydanticAIClient`, mirroring the existing `openrouter:*` pattern. Venice exposes an OpenAI-compatible chat completions endpoint at `https://api.venice.ai/api/v1`.

After this, users can write agent keys like:

```
venice:llama-3.3-70b
venice:venice-uncensored
```

and Condor's agent features will route through Venice using `VENICE_API_KEY` from the environment.

## Why

Venice is a privacy-focused inference provider (no logging, no training on prompts) that's particularly relevant for trading-context agents where prompt contents may include strategy / position data. Some users prefer it for that reason; this PR removes the need to write a custom wrapper.

## Changes

- Add `"venice"` to `PYDANTIC_AI_PREFIXES`
- Add `"venice": "https://api.venice.ai/api/v1"` to `DEFAULT_BASE_URLS`
- Add the `venice` branch in `_build_model` (requires `VENICE_API_KEY` env, modeled directly on the `openrouter` branch above it)
- Document `VENICE_API_KEY` (and the previously-undocumented `OPENROUTER_API_KEY` and `OPENAI_API_KEY`) in `.env.example`

## Test plan

- [x] With `VENICE_API_KEY` set, `venice:<model>` returns an `OpenAIModel` configured against Venice's base URL
- [x] Without `VENICE_API_KEY`, raises a clear `RuntimeError` with remediation hint
- [x] Without an explicit model id (`venice:`), raises a clear `RuntimeError` pointing to Venice's model docs
- [x] Other providers (`openai:*`, `openrouter:*`, `ollama:*`, etc.) unaffected — only adds a branch above the generic `DEFAULT_BASE_URLS` fall-through, same shape as `openrouter`

No tests added — the affected file doesn't have unit tests today; happy to add a small parametrize over providers if maintainers want it.