### PR TITLE
feat: silence httpx INFO logs to prevent Telegram bot token leakage

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,6 +28,14 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+# Suppress httpx INFO-level request logging — python-telegram-bot embeds the
+# bot token in the request path (api.telegram.org/bot<TOKEN>/getUpdates), and
+# httpx's default INFO logs the full URL on every call. With long-poll firing
+# every ~10s, the token ends up in every log handler (journald, files, etc.),
+# which makes safe log sharing impossible. Suppressing to WARNING preserves
+# real HTTP errors while removing the token leak.
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
 
 def _get_start_menu_keyboard(is_admin: bool = False) -> InlineKeyboardMarkup:
     """Build the start menu inline keyboard."""


### PR DESCRIPTION
## What

Add `logging.getLogger("httpx").setLevel(logging.WARNING)` after the existing `basicConfig` call in `main.py`. One-liner change.

## Why this matters (security)

`python-telegram-bot` embeds the bot token in the HTTP request *path*:

```
https://api.telegram.org/bot<TOKEN>/getUpdates
```

`httpx`'s default INFO logger logs the full URL on every call. With long-polling firing `getUpdates` every ~10s, the token ends up in:

- systemd journald (`journalctl -u condor`)
- Any log file or aggregator forwarding stdout/stderr
- Operator terminal scrollback when tailing logs
- Support transcripts where someone shares "the last few log lines"

Rotating the token via @BotFather doesn't help — the new token starts leaking on the very next poll.

## Real-world impact

During a recent migration of our deployment, the bot token leaked into a support transcript within minutes of bringing the service online. After rotation, the new token leaked again on the next `getUpdates` poll. The only way to avoid the leak today is to never share Condor logs anywhere — which conflicts with operating it in production.

## Fix

```python
logging.getLogger("httpx").setLevel(logging.WARNING)
```

This is the [recommended approach in python-telegram-bot's own docs](https://docs.python-telegram-bot.org/en/stable/telegram.ext.application.html) for noisy third-party loggers. Real HTTP errors (timeouts, 4xx, 5xx) still surface at WARNING+; only the request-flow INFO line is suppressed.

## Test plan

- [x] Service still starts cleanly
- [x] Telegram bot remains responsive
- [x] `journalctl -u condor.service` no longer contains the token after this change
- [x] HTTP errors (e.g. force a network blip) still surface in logs

## Trade-off

Loses the ability to see successful HTTP request flow at INFO level. For most operators this is a net positive — debug logging can be re-enabled with `LOG_LEVEL=DEBUG` or `logging.getLogger("httpx").setLevel(logging.DEBUG)` if needed.

If you'd prefer a stricter filter (e.g. only redacting the token in the URL while keeping the INFO line), happy to add a `RedactingFilter` instead. Let me know which direction you prefer.