### PR TITLE
feat: scrollable timeline + config formatting on project level

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{js,jsx,ts,tsx,json,yml,yaml,css,md}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "ms-python.black-formatter",
+    "ms-python.isort",
+    "dbaeumer.vscode-eslint"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,32 @@
+{
+  "editor.formatOnSave": true,
+  "editor.insertSpaces": true,
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit"
+    }
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "isort.check": true,
+  "prettier.requireConfig": true
+}

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,6 +34,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "prettier": "^3.8.1",
         "tailwindcss": "^4.2.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
@@ -4300,6 +4301,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/property-information": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -36,6 +38,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "prettier": "^3.8.1",
     "tailwindcss": "^4.2.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",

--- a/frontend/src/components/routines/ReportBrowser.tsx
+++ b/frontend/src/components/routines/ReportBrowser.tsx
@@ -41,12 +41,19 @@ export function ReportBrowser({
 }: ReportBrowserProps) {
   const { server } = useServer();
   const qc = useQueryClient();
-  const [sourceTypeFilter, setSourceTypeFilter] = useState<string>(initialSourceTypeFilter || "all");
+  const [sourceTypeFilter, setSourceTypeFilter] = useState<string>(
+    initialSourceTypeFilter || "all",
+  );
   const [isCompact, setIsCompact] = useState(false);
   const [showConfigPanel, setShowConfigPanel] = useState(false);
   const [reportTheme, setReportTheme] = useState<"dark" | "light">("dark");
   const sidebarRef = useRef<HTMLDivElement>(null);
+  const timelineRef = useRef<HTMLDivElement>(null);
+  const timelineContentRef = useRef<HTMLDivElement>(null);
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [canScrollTimelineLeft, setCanScrollTimelineLeft] = useState(false);
+  const [canScrollTimelineRight, setCanScrollTimelineRight] = useState(false);
+  const [timelineOverflow, setTimelineOverflow] = useState(false);
 
   // Fetch all routines for the sidebar
   const { data: routines = [] } = useQuery({
@@ -59,18 +66,18 @@ export function ReportBrowser({
   // Filter routines by source type
   const filteredRoutines = useMemo(() => {
     if (sourceTypeFilter === "all") return routines;
-    if (sourceTypeFilter === "routine") return routines.filter((r) => !r.source.startsWith("agent:"));
+    if (sourceTypeFilter === "routine")
+      return routines.filter((r) => !r.source.startsWith("agent:"));
     if (sourceTypeFilter === "agent") return routines.filter((r) => r.source.startsWith("agent:"));
     // Specific agent name
     return routines.filter((r) => r.source === `agent:${sourceTypeFilter}`);
   }, [routines, sourceTypeFilter]);
 
-  // Set initial source once routines load if not set — pick from filtered list
+  const effectiveActiveSource = activeSource || filteredRoutines[0]?.name || "";
+  const effectiveActiveSourceRef = useRef(effectiveActiveSource);
   useEffect(() => {
-    if (!activeSource && filteredRoutines.length > 0) {
-      setActiveSource(filteredRoutines[0].name);
-    }
-  }, [activeSource, filteredRoutines]);
+    effectiveActiveSourceRef.current = effectiveActiveSource;
+  }, [effectiveActiveSource]);
 
   // Unique source types for filter
   const hasAgents = routines.some((r) => r.source.startsWith("agent:"));
@@ -88,38 +95,44 @@ export function ReportBrowser({
 
   // Active routine info
   const activeRoutine = useMemo(
-    () => routines.find((r) => r.name === activeSource),
-    [routines, activeSource],
+    () => routines.find((r) => r.name === effectiveActiveSource),
+    [routines, effectiveActiveSource],
   );
   const isAgent = activeRoutine?.source.startsWith("agent:") ?? false;
 
   // Reports for active source
   const { data: reportsData, isLoading: loadingReports } = useQuery({
-    queryKey: ["routine-reports", activeSource],
-    queryFn: () => api.getRoutineReports(activeSource),
-    enabled: !!activeSource,
+    queryKey: ["routine-reports", effectiveActiveSource],
+    queryFn: () => api.getRoutineReports(effectiveActiveSource),
+    enabled: !!effectiveActiveSource,
   });
-  const reports = reportsData?.reports ?? [];
+  const reports = useMemo(() => reportsData?.reports ?? [], [reportsData?.reports]);
 
   const [selectedReportIdx, setSelectedReportIdx] = useState(0);
-  const selectedReport = reports[selectedReportIdx] ?? null;
-
-  // Reset report index when source changes
-  useEffect(() => {
+  const prevSourceForReportRef = useRef(effectiveActiveSource);
+  if (prevSourceForReportRef.current !== effectiveActiveSource) {
+    prevSourceForReportRef.current = effectiveActiveSource;
     setSelectedReportIdx(0);
-  }, [activeSource]);
+  }
+  const selectedReport = reports[selectedReportIdx] ?? null;
 
   // Active instances for current source
   const sourceInstances = useMemo(
-    () => instances.filter((i) => i.routine_name === activeSource && (i.status === "running" || i.status === "scheduled")),
-    [instances, activeSource],
+    () =>
+      instances.filter(
+        (i) =>
+          i.routine_name === effectiveActiveSource &&
+          (i.status === "running" || i.status === "scheduled"),
+      ),
+    [instances, effectiveActiveSource],
   );
 
   // Config state: prefer last-used config from instances, then defaults from routine fields
   const [configValues, setConfigValues] = useState<Record<string, unknown>>({});
-
-  useEffect(() => {
-    const lastInstance = instances.find((i) => i.routine_name === activeSource);
+  const configSourceRef = useRef<string | null>(null);
+  if (configSourceRef.current !== effectiveActiveSource) {
+    configSourceRef.current = effectiveActiveSource;
+    const lastInstance = instances.find((i) => i.routine_name === effectiveActiveSource);
     if (lastInstance && Object.keys(lastInstance.config || {}).length > 0) {
       setConfigValues({ ...lastInstance.config });
     } else if (activeRoutine) {
@@ -128,33 +141,38 @@ export function ReportBrowser({
         defaults[key] = field.default;
       }
       setConfigValues(defaults);
+    } else {
+      setConfigValues({});
     }
     setShowConfigPanel(false);
-  }, [activeSource, activeRoutine, instances]);
+  }
 
   // Track running instance to poll for completion
   const [pollingInstanceId, setPollingInstanceId] = useState<string | null>(null);
 
-  const { data: polledInstance } = useQuery({
+  useQuery({
     queryKey: ["routine-instance", pollingInstanceId],
     queryFn: () => api.getRoutineInstance(pollingInstanceId!),
     enabled: !!pollingInstanceId,
-    refetchInterval: 2000,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      if (status && status !== "running") {
+        queueMicrotask(() => {
+          setPollingInstanceId(null);
+          const source = effectiveActiveSourceRef.current;
+          qc.invalidateQueries({ queryKey: ["routine-reports", source] });
+          qc.invalidateQueries({ queryKey: ["reports-grouped"] });
+          qc.invalidateQueries({ queryKey: ["routines"] });
+          qc.invalidateQueries({ queryKey: ["routine-instances"] });
+        });
+        return false;
+      }
+      return 2000;
+    },
   });
 
-  // When polled instance completes, refresh reports
-  useEffect(() => {
-    if (polledInstance && polledInstance.status !== "running") {
-      setPollingInstanceId(null);
-      qc.invalidateQueries({ queryKey: ["routine-reports", activeSource] });
-      qc.invalidateQueries({ queryKey: ["reports-grouped"] });
-      qc.invalidateQueries({ queryKey: ["routines"] });
-      qc.invalidateQueries({ queryKey: ["routine-instances"] });
-    }
-  }, [polledInstance, activeSource, qc]);
-
   const runMutation = useMutation({
-    mutationFn: () => api.runRoutine(server!, activeSource, configValues),
+    mutationFn: () => api.runRoutine(server!, effectiveActiveSource, configValues),
     onSuccess: (data) => {
       setPollingInstanceId(data.instance_id);
       qc.invalidateQueries({ queryKey: ["routine-instances"] });
@@ -164,7 +182,7 @@ export function ReportBrowser({
 
   const scheduleMutation = useMutation({
     mutationFn: (intervalSec: number) =>
-      api.scheduleRoutine(server!, activeSource, configValues, intervalSec),
+      api.scheduleRoutine(server!, effectiveActiveSource, configValues, intervalSec),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["routine-instances"] });
       setShowConfigPanel(false);
@@ -183,7 +201,9 @@ export function ReportBrowser({
     onSuccess: (_, id) => {
       qc.invalidateQueries({ queryKey: ["reports"] });
       qc.invalidateQueries({ queryKey: ["reports-grouped"] });
-      qc.invalidateQueries({ queryKey: ["routine-reports", activeSource] });
+      qc.invalidateQueries({
+        queryKey: ["routine-reports", effectiveActiveSource],
+      });
       if (selectedReport?.id === id) {
         setSelectedReportIdx(Math.max(0, selectedReportIdx - 1));
       }
@@ -191,7 +211,10 @@ export function ReportBrowser({
   });
 
   // Run All state
-  const [runAllProgress, setRunAllProgress] = useState<{ current: number; total: number } | null>(null);
+  const [runAllProgress, setRunAllProgress] = useState<{
+    current: number;
+    total: number;
+  } | null>(null);
 
   const runAll = useCallback(async () => {
     if (!server || filteredRoutines.length === 0) return;
@@ -232,7 +255,7 @@ export function ReportBrowser({
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   // Keyboard navigation
-  const activeSourceIdx = filteredRoutines.findIndex((r) => r.name === activeSource);
+  const activeSourceIdx = filteredRoutines.findIndex((r) => r.name === effectiveActiveSource);
 
   const goSourceUp = useCallback(() => {
     if (activeSourceIdx > 0) {
@@ -256,12 +279,25 @@ export function ReportBrowser({
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || e.target instanceof HTMLSelectElement) return;
-      if (e.key === "ArrowUp") { goSourceUp(); e.preventDefault(); }
-      else if (e.key === "ArrowDown") { goSourceDown(); e.preventDefault(); }
-      else if (e.key === "ArrowLeft") { goPrevReport(); e.preventDefault(); }
-      else if (e.key === "ArrowRight") { goNextReport(); e.preventDefault(); }
-      else if (e.key === "Escape") {
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement ||
+        e.target instanceof HTMLSelectElement
+      )
+        return;
+      if (e.key === "ArrowUp") {
+        goSourceUp();
+        e.preventDefault();
+      } else if (e.key === "ArrowDown") {
+        goSourceDown();
+        e.preventDefault();
+      } else if (e.key === "ArrowLeft") {
+        goPrevReport();
+        e.preventDefault();
+      } else if (e.key === "ArrowRight") {
+        goNextReport();
+        e.preventDefault();
+      } else if (e.key === "Escape") {
         if (showConfigPanel) setShowConfigPanel(false);
         else onClose();
         e.preventDefault();
@@ -271,11 +307,57 @@ export function ReportBrowser({
     return () => window.removeEventListener("keydown", handler);
   }, [goSourceUp, goSourceDown, goPrevReport, goNextReport, onClose, showConfigPanel]);
 
+  const scrollTimeline = useCallback((direction: "left" | "right") => {
+    const el = timelineRef.current;
+    if (!el) return;
+    el.scrollBy({
+      left: direction === "left" ? -el.clientWidth * 0.6 : el.clientWidth * 0.6,
+      behavior: "smooth",
+    });
+  }, []);
+
   // Scroll active source into view
   useEffect(() => {
     const el = sidebarRef.current?.querySelector("[data-active-source]");
     el?.scrollIntoView({ block: "nearest", behavior: "smooth" });
-  }, [activeSource]);
+  }, [effectiveActiveSource]);
+
+  // Track timeline overflow for scroll arrows (setState only in event/callback handlers)
+  useEffect(() => {
+    const el = timelineRef.current;
+    const content = timelineContentRef.current;
+    if (!el) return;
+
+    const update = () => {
+      const overflow = el.scrollWidth > el.clientWidth + 1;
+      setTimelineOverflow(overflow);
+      setCanScrollTimelineLeft(el.scrollLeft > 0);
+      setCanScrollTimelineRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+    };
+
+    el.addEventListener("scroll", update, { passive: true });
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    if (content) ro.observe(content);
+
+    const raf = requestAnimationFrame(update);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      el.removeEventListener("scroll", update);
+      ro.disconnect();
+    };
+  }, [reports.length]);
+
+  // Scroll active report tab into view
+  useEffect(() => {
+    const el = timelineRef.current?.querySelector("[data-active-report]");
+    el?.scrollIntoView({
+      block: "nearest",
+      inline: "nearest",
+      behavior: "smooth",
+    });
+  }, [selectedReportIdx]);
 
   // Update view context for chat integration
   useEffect(() => {
@@ -283,14 +365,14 @@ export function ReportBrowser({
       setViewContext({
         filename: selectedReport.filename,
         title: selectedReport.title,
-        source_name: activeSource,
+        source_name: effectiveActiveSource,
       });
     }
     return () => setViewContext(null);
-  }, [selectedReport, activeSource]);
+  }, [selectedReport, effectiveActiveSource]);
 
   return (
-    <div className="fixed inset-0 z-50 flex bg-[var(--color-bg)]">
+    <div className="fixed inset-0 z-50 flex overflow-hidden bg-[var(--color-bg)]">
       {/* Left sidebar: routine list */}
       <div
         className={`flex flex-col border-r border-[var(--color-border)] bg-[var(--color-surface)] transition-all ${
@@ -308,7 +390,11 @@ export function ReportBrowser({
             onClick={() => setIsCompact(!isCompact)}
             className="rounded p-1 text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]"
           >
-            {isCompact ? <ChevronRight className="h-3.5 w-3.5" /> : <ChevronLeft className="h-3.5 w-3.5" />}
+            {isCompact ? (
+              <ChevronRight className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronLeft className="h-3.5 w-3.5" />
+            )}
           </button>
         </div>
 
@@ -366,9 +452,10 @@ export function ReportBrowser({
         {/* Routine list */}
         <div ref={sidebarRef} className="flex-1 overflow-y-auto scrollbar-thin">
           {filteredRoutines.map((r) => {
-            const isActive = r.name === activeSource;
+            const isActive = r.name === effectiveActiveSource;
             const hasActiveInstance = instances.some(
-              (i) => i.routine_name === r.name && (i.status === "running" || i.status === "scheduled"),
+              (i) =>
+                i.routine_name === r.name && (i.status === "running" || i.status === "scheduled"),
             );
             const isRoutineAgent = r.source.startsWith("agent:");
             const displayName = r.name.replace(/_/g, " ");
@@ -411,7 +498,9 @@ export function ReportBrowser({
                 }`}
               >
                 <div className="flex items-center justify-between gap-1">
-                  <span className={`truncate text-xs font-medium ${isActive ? "text-[var(--color-text)]" : "text-[var(--color-text-muted)]"}`}>
+                  <span
+                    className={`truncate text-xs font-medium ${isActive ? "text-[var(--color-text)]" : "text-[var(--color-text-muted)]"}`}
+                  >
                     {displayName}
                   </span>
                   <div className="flex items-center gap-1 shrink-0">
@@ -472,12 +561,12 @@ export function ReportBrowser({
       </div>
 
       {/* Main content */}
-      <div className="flex flex-1 flex-col">
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
         {/* Top bar */}
         <div className="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-2">
           <div className="flex items-center gap-3 min-w-0">
             <h2 className="truncate text-sm font-semibold text-[var(--color-text)]">
-              {activeSource.replace(/_/g, " ")}
+              {effectiveActiveSource.replace(/_/g, " ")}
             </h2>
             {isAgent && (
               <span className="flex items-center gap-0.5 rounded bg-purple-500/10 px-1.5 py-0.5 text-[9px] font-bold uppercase text-purple-400">
@@ -488,12 +577,16 @@ export function ReportBrowser({
             {sourceInstances.length > 0 && (
               <div className="flex items-center gap-2">
                 {sourceInstances.map((inst) => (
-                  <div key={inst.instance_id} className="flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2.5 py-1 text-[10px]">
+                  <div
+                    key={inst.instance_id}
+                    className="flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2.5 py-1 text-[10px]"
+                  >
                     <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
                     <span className="text-emerald-400 capitalize">{inst.status}</span>
                     {inst.schedule?.type === "interval" && (
                       <span className="text-[var(--color-text-muted)]">
-                        <Clock className="inline h-2.5 w-2.5" /> {inst.schedule.interval_sec as number}s
+                        <Clock className="inline h-2.5 w-2.5" />{" "}
+                        {inst.schedule.interval_sec as number}s
                       </span>
                     )}
                     <span className="text-[var(--color-text-muted)]">{inst.run_count} runs</span>
@@ -591,12 +684,15 @@ export function ReportBrowser({
               </>
             )}
             {/* Delete */}
-            {selectedReport && (
-              confirmDelete ? (
+            {selectedReport &&
+              (confirmDelete ? (
                 <div className="flex items-center gap-1 ml-2">
                   <span className="text-xs text-[var(--color-red)]">Delete?</span>
                   <button
-                    onClick={() => { deleteMutation.mutate(selectedReport.id); setConfirmDelete(false); }}
+                    onClick={() => {
+                      deleteMutation.mutate(selectedReport.id);
+                      setConfirmDelete(false);
+                    }}
                     className="rounded px-2 py-1 text-xs font-semibold text-white bg-[var(--color-red)] hover:bg-[var(--color-red)]/80"
                   >
                     Yes
@@ -616,8 +712,7 @@ export function ReportBrowser({
                 >
                   <Trash2 className="h-4 w-4" />
                 </button>
-              )
-            )}
+              ))}
             {/* Report theme toggle */}
             <button
               onClick={() => setReportTheme((t) => (t === "dark" ? "light" : "dark"))}
@@ -629,7 +724,13 @@ export function ReportBrowser({
             {/* Agent chat toggle */}
             <button
               onClick={() => {
-                window.dispatchEvent(new KeyboardEvent("keydown", { key: "k", metaKey: true, bubbles: true }));
+                window.dispatchEvent(
+                  new KeyboardEvent("keydown", {
+                    key: "k",
+                    metaKey: true,
+                    bubbles: true,
+                  }),
+                );
               }}
               className="ml-1 flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium bg-amber-500/15 text-amber-500 hover:bg-amber-500/25 border border-amber-500/30 transition-all"
               title="Agent (⌘K)"
@@ -654,7 +755,10 @@ export function ReportBrowser({
             <span>{selectedReport.title}</span>
             <span>{new Date(selectedReport.created_at).toLocaleString()}</span>
             {selectedReport.tags.map((tag) => (
-              <span key={tag} className="rounded bg-[var(--color-surface-hover)] px-1.5 py-0.5 text-[9px]">
+              <span
+                key={tag}
+                className="rounded bg-[var(--color-surface-hover)] px-1.5 py-0.5 text-[9px]"
+              >
                 #{tag}
               </span>
             ))}
@@ -694,31 +798,57 @@ export function ReportBrowser({
 
         {/* Report timeline strip at top */}
         {reports.length > 1 && (
-          <div className="flex items-center gap-1 border-b border-[var(--color-border)]/50 px-4 py-1.5 overflow-x-auto scrollbar-thin">
-            {reports.slice(0, 20).map((r, idx) => (
+          <div className="flex min-w-0 items-center overflow-hidden border-b border-[var(--color-border)]/50">
+            {timelineOverflow && (
               <button
-                key={r.id}
-                onClick={() => setSelectedReportIdx(idx)}
-                className={`shrink-0 rounded px-2 py-1 text-[10px] transition-all ${
-                  idx === selectedReportIdx
-                    ? "bg-[var(--color-primary)]/10 text-[var(--color-primary)] font-medium"
-                    : "text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]"
-                }`}
-                title={r.title}
+                type="button"
+                onClick={() => scrollTimeline("left")}
+                disabled={!canScrollTimelineLeft}
+                className="shrink-0 rounded p-1.5 text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] disabled:cursor-default disabled:opacity-30"
+                title="Scroll to newer runs"
               >
-                {formatAgo(r.created_at)}
+                <ChevronLeft className="h-3.5 w-3.5" />
               </button>
-            ))}
-            {reports.length > 20 && (
-              <span className="shrink-0 text-[9px] text-[var(--color-text-muted)]/50 px-1">
-                +{reports.length - 20} more
-              </span>
+            )}
+            <div
+              ref={timelineRef}
+              className="min-w-0 flex-1 overflow-x-auto overflow-y-hidden px-4 py-1.5 scrollbar-none"
+            >
+              <div ref={timelineContentRef} className="flex w-max items-center gap-1">
+                {reports.map((r, idx) => (
+                  <button
+                    key={r.id}
+                    type="button"
+                    onClick={() => setSelectedReportIdx(idx)}
+                    {...(idx === selectedReportIdx ? { "data-active-report": true } : {})}
+                    className={`shrink-0 rounded px-2 py-1 text-[10px] transition-all ${
+                      idx === selectedReportIdx
+                        ? "bg-[var(--color-primary)]/10 text-[var(--color-primary)] font-medium"
+                        : "text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]"
+                    }`}
+                    title={r.title}
+                  >
+                    {formatAgo(r.created_at)}
+                  </button>
+                ))}
+              </div>
+            </div>
+            {timelineOverflow && (
+              <button
+                type="button"
+                onClick={() => scrollTimeline("right")}
+                disabled={!canScrollTimelineRight}
+                className="shrink-0 rounded p-1.5 text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] disabled:cursor-default disabled:opacity-30"
+                title="Scroll to older runs"
+              >
+                <ChevronRight className="h-3.5 w-3.5" />
+              </button>
             )}
           </div>
         )}
 
         {/* Report content */}
-        <div className="relative flex-1">
+        <div className="relative min-h-0 flex-1">
           {loadingReports ? (
             <div className="flex h-full items-center justify-center">
               <Loader2 className="h-6 w-6 animate-spin text-[var(--color-text-muted)]" />
@@ -727,9 +857,7 @@ export function ReportBrowser({
             // No reports — prompt to run for the first time
             <div className="flex h-full flex-col items-center justify-center text-center px-8">
               <Zap className="mb-3 h-10 w-10 text-[var(--color-text-muted)]/20" />
-              <p className="text-sm font-medium text-[var(--color-text)]">
-                No reports yet
-              </p>
+              <p className="text-sm font-medium text-[var(--color-text)]">No reports yet</p>
               <p className="mt-1 text-xs text-[var(--color-text-muted)]">
                 {activeRoutine?.description ?? "Run this routine to generate your first report."}
               </p>


### PR DESCRIPTION
I've added a configuration for formatting files at the project level so that when everyone formats one file is gonna be always the same (so to avoid a milion changes for every time I change 1 line of code in a file I've never worked on).
Please @cardosofede @fengtality if you have in mind any different configuration just change it accordingly (but let's put one because I have format on save enabled and I'd like to keep it like that since it's a good thing).

Other than that I've introduce a scrollable timeline bar so that we are able to check older runs for our routines (in current main we can only check latest 20 runs).
This is the result:

<img width="1683" height="103" alt="image" src="https://github.com/user-attachments/assets/bc17bd04-5f6c-4a65-b7ed-cb8b2da6317c" />
