### PR TITLE
Fix enum-prefixed config values & admin notification escaping; add direct server assignment on approval

### DIFF
--- a/condor/web/routes/bots.py
+++ b/condor/web/routes/bots.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from config_manager import get_config_manager
 from condor.web.auth import get_current_user
+from handlers.bots._shared import clean_config_for_save
 import yaml
 
 from condor.web.models import (
@@ -735,8 +736,9 @@ async def create_controller_config(
 
     client = await cm.get_client(name)
     try:
-        # Strip internal fields like _config_name that cause Pydantic validation errors
-        clean_body = {k: v for k, v in body.items() if not k.startswith("_")}
+        # Strip internal fields like _config_name and normalize stringified enum
+        # values (e.g. "PositionMode.ONEWAY" -> "ONEWAY") before saving.
+        clean_body = clean_config_for_save(body)
         result = await client.controllers.create_or_update_controller_config(
             config_id, clean_body
         )

--- a/handlers/admin/__init__.py
+++ b/handlers/admin/__init__.py
@@ -10,6 +10,7 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import ContextTypes
 
 from config_manager import (
+    ServerPermission,
     UserRole,
     get_config_manager,
 )
@@ -113,6 +114,13 @@ async def admin_callback_handler(
     elif action.startswith("approve_"):
         user_id = int(action.replace("approve_", ""))
         await _approve_user(query, context, user_id)
+    elif action.startswith("grantdone_"):
+        user_id = int(action.replace("grantdone_", ""))
+        await _show_grant_servers_done(query, context, user_id)
+    elif action.startswith("grant_"):
+        rest = action.replace("grant_", "")
+        uid_str, idx_str = rest.rsplit("_", 1)
+        await _toggle_grant_server(query, context, int(uid_str), int(idx_str))
     elif action.startswith("reject_"):
         user_id = int(action.replace("reject_", ""))
         await _reject_user(query, context, user_id)
@@ -374,10 +382,110 @@ async def _approve_user(
             logger.warning(f"Failed to notify user {user_id} of approval: {e}")
 
         await query.answer("User approved!", show_alert=True)
+        # Let the admin grant server access right away
+        await _show_grant_servers(query, context, user_id)
     else:
         await query.answer("Failed to approve user", show_alert=True)
+        # Refresh pending list
+        await _show_pending_users(query, context)
 
-    # Refresh pending list
+
+async def _show_grant_servers(
+    query, context: ContextTypes.DEFAULT_TYPE, user_id: int
+) -> None:
+    """Show server access toggles for a freshly-approved user."""
+    cm = get_config_manager()
+    user = cm.get_user(user_id)
+    username = (user.get("username") if user else None) or "N/A"
+    servers = list(cm.list_servers().keys())
+
+    message = (
+        "🖥️ *Grant Server Access*\n\n"
+        f"`{user_id}` \\(@{escape_markdown_v2(username)}\\) is now approved\\.\n\n"
+    )
+
+    keyboard = []
+    if not servers:
+        message += (
+            "No servers are configured yet\\.\n"
+            "You can share servers with this user later via /servers\\."
+        )
+    else:
+        message += "Tap a server to toggle this user's access:"
+        for idx, name in enumerate(servers):
+            granted = cm.get_server_permission(user_id, name) is not None
+            mark = "✅" if granted else "⬜"
+            keyboard.append(
+                [
+                    InlineKeyboardButton(
+                        f"{mark} {name}",
+                        callback_data=f"admin:grant_{user_id}_{idx}",
+                    )
+                ]
+            )
+
+    keyboard.append(
+        [InlineKeyboardButton("✅ Done", callback_data=f"admin:grantdone_{user_id}")]
+    )
+
+    await query.edit_message_text(
+        message, parse_mode="MarkdownV2", reply_markup=InlineKeyboardMarkup(keyboard)
+    )
+
+
+async def _toggle_grant_server(
+    query, context: ContextTypes.DEFAULT_TYPE, user_id: int, index: int
+) -> None:
+    """Toggle a single server's access for a user, then re-render."""
+    cm = get_config_manager()
+    admin_id = query.from_user.id
+    servers = list(cm.list_servers().keys())
+
+    if index < 0 or index >= len(servers):
+        await query.answer("Server not found", show_alert=True)
+        await _show_grant_servers(query, context, user_id)
+        return
+
+    server_name = servers[index]
+    granted = cm.get_server_permission(user_id, server_name) is not None
+
+    if granted:
+        if cm.revoke_server_access(server_name, admin_id, user_id):
+            await query.answer(f"Revoked access to {server_name}")
+        else:
+            await query.answer("Failed to revoke access", show_alert=True)
+    else:
+        cm.ensure_server_registered(server_name, admin_id)
+        if cm.share_server(server_name, admin_id, user_id, ServerPermission.TRADER):
+            await query.answer(f"Granted access to {server_name}")
+        else:
+            await query.answer("Failed to grant access", show_alert=True)
+
+    await _show_grant_servers(query, context, user_id)
+
+
+async def _show_grant_servers_done(
+    query, context: ContextTypes.DEFAULT_TYPE, user_id: int
+) -> None:
+    """Finish the grant flow: notify the user of their server access and return."""
+    cm = get_config_manager()
+    accessible = cm.get_shared_servers(user_id)
+
+    if accessible:
+        names = ", ".join(escape_markdown_v2(name) for name, _ in accessible)
+        try:
+            await context.bot.send_message(
+                chat_id=user_id,
+                text=(
+                    "🖥️ *Server Access Granted*\n\n"
+                    f"You now have access to: {names}\n"
+                    "Use /servers to select your default server\\."
+                ),
+                parse_mode="MarkdownV2",
+            )
+        except Exception as e:
+            logger.warning(f"Failed to notify user {user_id} of server access: {e}")
+
     await _show_pending_users(query, context)
 
 

--- a/handlers/bots/_shared.py
+++ b/handlers/bots/_shared.py
@@ -11,6 +11,7 @@ Controller-specific code (defaults, fields, charts) is in handlers/bots/controll
 """
 
 import logging
+import re
 from typing import Any, Dict, List, Optional, Tuple
 
 from condor.cache import DEFAULT_CACHE_TTL
@@ -180,14 +181,46 @@ def set_controller_config(context, config: Dict[str, Any]) -> None:
     context.user_data["controller_config_params"] = config
 
 
+# Matches stringified enum values like "PositionMode.ONEWAY", "OrderType.LIMIT",
+# "TradeType.BUY" or the colon variant "PositionMode:ONEWAY". The class name is
+# PascalCase and the member starts with an uppercase letter, which avoids matching
+# legitimate values such as trading times ("09:30") or token symbols ("USDC.e").
+_ENUM_STR_RE = re.compile(r"^[A-Z][A-Za-z0-9_]*[.:][A-Z][A-Za-z0-9_]*$")
+
+
+def normalize_enum_value(value: Any) -> Any:
+    """Strip the enum-class prefix from stringified enum values.
+
+    Controller config templates expose enum defaults as strings like
+    "PositionMode.ONEWAY". Saving them verbatim breaks downstream controller
+    validation, which expects the plain member name ("ONEWAY"). This recurses
+    into dicts and lists so nested config values are normalized too.
+    """
+    if isinstance(value, str) and _ENUM_STR_RE.match(value):
+        return re.split(r"[.:]", value, maxsplit=1)[1]
+    if isinstance(value, dict):
+        return {k: normalize_enum_value(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [normalize_enum_value(v) for v in value]
+    return value
+
+
 def clean_config_for_save(config: Dict[str, Any]) -> Dict[str, Any]:
-    """Strip internal fields (e.g. _config_name) before saving to backend.
+    """Strip internal fields and normalize stringified enum values before saving.
 
     The backend adds _config_name to YAML files, but Pydantic models with
     extra='forbid' reject it on reload. Strip any underscore-prefixed keys
     that aren't part of the controller config schema.
+
+    Enum fields (e.g. position_mode, side, take_profit_order_type) can arrive as
+    prefixed strings like "PositionMode.ONEWAY"; normalize them to the plain
+    member name so deploy/backtest validation accepts them.
     """
-    return {k: v for k, v in config.items() if not k.startswith("_")}
+    return {
+        k: normalize_enum_value(v)
+        for k, v in config.items()
+        if not k.startswith("_")
+    }
 
 
 def init_new_controller_config(

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -24,10 +24,13 @@ async def _notify_admin_new_user(
         return
 
     try:
+        from utils.telegram_formatters import escape_markdown_v2
+
+        username_display = escape_markdown_v2(f"@{username}" if username else "N/A")
         message = (
             f"👤 *New Access Request*\n\n"
             f"User ID: `{user_id}`\n"
-            f"Username: @{username or 'N/A'}\n\n"
+            f"Username: {username_display}\n\n"
             f"Use /start \\> Admin Panel to approve or reject\\."
         )
         await context.bot.send_message(


### PR DESCRIPTION


Summary

This PR fixes two bugs and improves the access-request flow.

Fixes

#115 — Controller configs save enum-prefixed values that break deploy & backtesting
Enum fields were being saved with their type prefix (e.g. PositionMode:ONEWAY, OrderType.LIMIT, TradeType.BUY) instead of the plain value (ONEWAY). Because the controller template
defaults are stringified before reaching the UI, Condor saved them back verbatim, and downstream controller validation rejected them — causing deploys and backtests to fail. We now
normalize enum-style strings back to their plain value before saving config (handlers/bots/_shared.py, condor/web/routes/bots.py).

#116 — Admin notification fails when a new user's username contains an underscore
A pending user with a Markdown-sensitive character (e.g. _) in their Telegram username broke the admin alert with Can't parse entities: can't find end of italic entity. The username was
being injected into a MarkdownV2 message without escaping. We now escape special characters before composing the notification (utils/auth.py), so the admin reliably receives the access
request.

Improvement

Direct server access on approval — The admin can now grant access to specific servers directly when accepting a new user's access request, streamlining the approval flow so the user is
ready to trade without a separate sharing step (handlers/admin/__init__.py).
