### PR TITLE
feat(trade): rank pair selector by 24h volume, hide untraded markets

### DIFF
--- a/condor/web/routes/market.py
+++ b/condor/web/routes/market.py
@@ -153,6 +153,35 @@ async def get_trading_rules(
     return TradingRulesResponse(connector=connector, rules=rules)
 
 
+@router.get("/servers/{name}/market/pair-volumes")
+async def get_pair_volumes(
+    name: str,
+    connector: str = Query(...),
+    user: WebUser = Depends(get_current_user),
+):
+    """24h quote volume per trading pair, used to rank/curate the pair selector.
+
+    Returns {"connector": str, "volumes": {trading_pair: quote_volume_24h}}. A value of 0.0
+    marks a listed-but-untraded market. Only supported on some exchanges (hyperliquid, binance,
+    okx and their perp variants); returns an empty map for the rest so the caller falls back to
+    an alphabetical list.
+    """
+    cm = get_config_manager()
+    if not cm.has_server_access(user.id, name):
+        raise HTTPException(status_code=403, detail="No access")
+
+    client = await cm.get_client(name)
+    try:
+        result = await client.market_data.get_24h_volumes(connector)
+    except Exception as e:
+        # Unsupported connector (400) or upstream error — degrade to alphabetical ordering.
+        logger.info(f"pair-volumes unavailable for {connector}: {e}")
+        return {"connector": connector, "volumes": {}}
+
+    volumes = result.get("volumes", {}) if isinstance(result, dict) else {}
+    return {"connector": connector, "volumes": volumes}
+
+
 @router.get("/servers/{name}/market/order-book", response_model=OrderBookResponse)
 async def get_order_book(
     name: str,

--- a/frontend/src/components/market/PairSelector.tsx
+++ b/frontend/src/components/market/PairSelector.tsx
@@ -13,6 +13,25 @@ interface PairSelectorProps {
 
 const MAX_VISIBLE = 50;
 
+// Quote-asset display priority. Ranking by raw 24h volume alone mixes currencies (a fiat-quoted
+// pair like USDT-IDR has a huge numeric quote volume), so we group by quote first, then sort by
+// volume within each group. Single-quote exchanges (e.g. Hyperliquid, all USDC) become pure
+// volume ranking.
+const QUOTE_PRIORITY = ["USDT", "USDC", "USD", "BTC", "ETH"];
+
+function quoteRank(pair: string): number {
+  const q = pair.split("-").pop() ?? "";
+  const i = QUOTE_PRIORITY.indexOf(q);
+  return i === -1 ? QUOTE_PRIORITY.length : i;
+}
+
+function formatVolume(v: number): string {
+  if (v >= 1e9) return `${(v / 1e9).toFixed(1)}B`;
+  if (v >= 1e6) return `${(v / 1e6).toFixed(1)}M`;
+  if (v >= 1e3) return `${(v / 1e3).toFixed(0)}K`;
+  return `${Math.round(v)}`;
+}
+
 export function PairSelector({
   server,
   connector,
@@ -33,10 +52,37 @@ export function PairSelector({
     staleTime: 5 * 60 * 1000,
   });
 
-  const pairs = useMemo(
-    () => rulesData?.rules?.map((r) => r.trading_pair).sort() ?? [],
-    [rulesData],
-  );
+  // 24h quote volume per pair, for ranking + hiding untraded markets. Empty/unsupported → falls
+  // back to an alphabetical list.
+  const { data: volData } = useQuery({
+    queryKey: ["pair-volumes", server, connector],
+    queryFn: () => api.getPairVolumes(server, connector),
+    enabled: !!server && !!connector,
+    staleTime: 60 * 1000,
+  });
+
+  const pairs = useMemo(() => {
+    const all = rulesData?.rules?.map((r) => r.trading_pair) ?? [];
+    const volumes = volData?.volumes ?? {};
+    const hasVolume = Object.keys(volumes).length > 0;
+    if (!hasVolume) return [...all].sort();
+
+    return all
+      // Hide listed-but-untraded markets (24h volume exactly 0, e.g. Hyperliquid's tokenized
+      // equities like AAPL-USDC). Keep the active pair and any pair with unknown volume.
+      .filter((p) => volumes[p] !== 0 || p === value)
+      .sort((a, b) => {
+        const qr = quoteRank(a) - quoteRank(b);
+        if (qr !== 0) return qr;
+        // Unknown volume (not in the map, e.g. HIP-3 perps) sorts after known volume.
+        const va = volumes[a] ?? -1;
+        const vb = volumes[b] ?? -1;
+        if (vb !== va) return vb - va;
+        return a.localeCompare(b);
+      });
+  }, [rulesData, volData, value]);
+
+  const volumes = volData?.volumes ?? {};
 
   // Group pairs by quote asset
   const quoteGroups = useMemo(() => {
@@ -203,6 +249,11 @@ export function PairSelector({
                     }`}
                   >
                     <span><span className="font-medium">{base}</span><span className="text-[var(--color-text-muted)]">-{quote}</span></span>
+                    {volumes[p] > 0 && (
+                      <span className="ml-auto text-xs tabular-nums text-[var(--color-text-muted)]">
+                        {formatVolume(volumes[p])}
+                      </span>
+                    )}
                   </button>
                 );
               })

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -870,6 +870,11 @@ export const api = {
       `/api/v1/servers/${server}/market/trading-rules?connector=${connector}`,
     ),
 
+  getPairVolumes: (server: string, connector: string) =>
+    apiFetch<{ connector: string; volumes: Record<string, number> }>(
+      `/api/v1/servers/${server}/market/pair-volumes?connector=${connector}`,
+    ),
+
   getOrderBook: (
     server: string,
     connector: string,


### PR DESCRIPTION
## Summary

Ranks the trade-pair selector by **24h volume** and hides listed-but-untraded markets.

Motivation: the Hyperliquid spot connector exposes every market in `spotMeta.universe`, including hundreds of permissionless tokenized-equity listings (`AAPL-USDC`, `TSLA-USDC`, …) that have a market entry but never trade (`dayNtlVlm=0`). They polluted the selector, and there was no volume signal to order by.

## Changes

- **backend** `GET /servers/{name}/market/pair-volumes?connector=` — proxies the new hummingbot-api 24h-volume endpoint via `hummingbot_api_client`. Best-effort: returns an empty map for unsupported connectors / older SDK, so the UI degrades to an alphabetical list.
- **PairSelector**
  - ranks by volume and hides untraded pairs (volume `0`);
  - ranking is **quote-aware** (group by quote, then volume desc) so fiat-quoted pairs don't dominate by raw quote-volume; single-quote exchanges (Hyperliquid, all USDC) become a pure volume ranking;
  - keeps the active pair and unknown-volume pairs (e.g. HIP-3 perps) visible;
  - shows an abbreviated 24h volume per row.

## Dependencies

- hummingbot-api `GET /market-data/volumes/{connector}` — hummingbot/hummingbot-api PR #173.
- `hummingbot_api_client >= 1.5.4` (`get_24h_volumes`) — hummingbot/hummingbot-api-client PR #21. Degrades gracefully without it (no ranking, no crash).

Built to extend to more exchanges (the backend is connector-agnostic; coverage is driven by the hummingbot-api endpoint).

## Test plan

1. Trade → Hyperliquid spot: pairs rank `HYPE`, `UBTC`, `UZEC`, … matching the Hyperliquid UI; `AAPL-USDC` and other 0-volume pairs hidden.
2. `hyperliquid_perpetual`: HIP-3 pairs (`XYZ:CL-USD`, …) rank by their real volume.
3. Binance/OKX: `BTC-USDT`/`ETH-USDT` lead the USDT group (no fiat-quote pairs floating to the top).
4. An unsupported connector: selector falls back to the alphabetical list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)