### PR TITLE
fix / calculate agent drawdown from exposure

### DIFF
--- a/condor/trading_agent/engine.py
+++ b/condor/trading_agent/engine.py
@@ -258,7 +258,7 @@ class TickEngine:
             self._last_skill_data.get("total_exposure", 0.0) or 0.0
         )
 
-        if risk_state.is_blocked and not self.is_experiment and live_open_count == 0:
+        if risk_state.is_blocked and not self.is_experiment:
             self.journal.append_action(
                 self.journal.tick_count + 1,
                 "tick_blocked",

--- a/condor/trading_agent/engine.py
+++ b/condor/trading_agent/engine.py
@@ -251,8 +251,14 @@ class TickEngine:
 
         # 4. Get risk state (experiments pass None — returns clean state)
         risk_state = self.risk.get_state(self.journal or _NullTracker())
+        live_executors = self._last_skill_data.get("executors", [])
+        live_open_count = len(live_executors) if isinstance(live_executors, list) else 0
+        risk_state.executor_count = live_open_count
+        risk_state.total_exposure = float(
+            self._last_skill_data.get("total_exposure", 0.0) or 0.0
+        )
 
-        if risk_state.is_blocked and not self.is_experiment:
+        if risk_state.is_blocked and not self.is_experiment and live_open_count == 0:
             self.journal.append_action(
                 self.journal.tick_count + 1,
                 "tick_blocked",

--- a/condor/trading_agent/journal.py
+++ b/condor/trading_agent/journal.py
@@ -855,9 +855,13 @@ class JournalManager:
         pnls = [s.get("pnl", 0) for s in snapshots]
         peak = max(pnls)
         current = pnls[-1]
-        if peak <= 0:
+        drawdown = peak - current
+        if drawdown <= 0:
             return 0.0
-        return max(0, (peak - current) / peak * 100)
+        exposure = snapshots[-1].get("exposure", 0.0)
+        if exposure <= 0:
+            return 0.0
+        return drawdown / exposure * 100
 
     def get_pnl_series(self, hours: int = 24) -> list[dict]:
         return [

--- a/condor/trading_agent/performance.py
+++ b/condor/trading_agent/performance.py
@@ -77,16 +77,8 @@ def _executor_row(ex: dict) -> dict[str, Any]:
     amount = float(cfg.get("total_amount_quote") or cfg.get("amount") or 0)
     if amount <= 0:
         amount = float(
-            custom_info.get("total_value_quote") or ex.get("filled_amount_quote") or 0
+            custom_info.get("total_value_quote") or 0
         )
-    if amount <= 0:
-        base_amount = float(
-            custom_info.get("base_amount") or cfg.get("base_amount") or 0
-        )
-        quote_amount = float(
-            custom_info.get("quote_amount") or cfg.get("quote_amount") or 0
-        )
-        amount = quote_amount + (base_amount * current_price)
 
     return {
         "id": str(ex.get("id") or ex.get("executor_id") or ""),

--- a/condor/trading_agent/performance.py
+++ b/condor/trading_agent/performance.py
@@ -66,8 +66,27 @@ def _executor_row(ex: dict) -> dict[str, Any]:
 
     # current_price / close_price: top-level > custom_info
     _top_cur = float(ex.get("current_price") or 0)
+    _ci_cur = float(custom_info.get("current_price") or 0)
     _ci_close = float(custom_info.get("close_price") or 0)
-    current_price = _top_cur if _top_cur > 0 else (_ci_close if _ci_close > 0 else 0.0)
+    current_price = (
+        _top_cur
+        if _top_cur > 0
+        else (_ci_cur if _ci_cur > 0 else (_ci_close if _ci_close > 0 else 0.0))
+    )
+
+    amount = float(cfg.get("total_amount_quote") or cfg.get("amount") or 0)
+    if amount <= 0:
+        amount = float(
+            custom_info.get("total_value_quote") or ex.get("filled_amount_quote") or 0
+        )
+    if amount <= 0:
+        base_amount = float(
+            custom_info.get("base_amount") or cfg.get("base_amount") or 0
+        )
+        quote_amount = float(
+            custom_info.get("quote_amount") or cfg.get("quote_amount") or 0
+        )
+        amount = quote_amount + (base_amount * current_price)
 
     return {
         "id": str(ex.get("id") or ex.get("executor_id") or ""),
@@ -82,7 +101,7 @@ def _executor_row(ex: dict) -> dict[str, Any]:
         "fees": get_executor_fees(ex),
         "entry_price": entry_price,
         "current_price": current_price,
-        "amount": float(cfg.get("total_amount_quote") or cfg.get("amount") or 0),
+        "amount": amount,
         "timestamp": float(cfg.get("timestamp") or ex.get("timestamp") or 0),
         "close_timestamp": float(ex.get("close_timestamp") or 0),
         "controller_id": str(cfg.get("controller_id") or ex.get("controller_id") or ""),

--- a/condor/trading_agent/risk.py
+++ b/condor/trading_agent/risk.py
@@ -92,9 +92,6 @@ class RiskEngine:
         if action != "create":
             return True, ""
 
-        if current_state.is_blocked:
-            return False, current_state.block_reason or "Risk state is blocked"
-
         # Check executor count
         if current_state.executor_count >= self.limits.max_open_executors:
             return False, f"Max open executors ({self.limits.max_open_executors}) reached"

--- a/condor/trading_agent/risk.py
+++ b/condor/trading_agent/risk.py
@@ -92,6 +92,9 @@ class RiskEngine:
         if action != "create":
             return True, ""
 
+        if current_state.is_blocked:
+            return False, current_state.block_reason or "Risk state is blocked"
+
         # Check executor count
         if current_state.executor_count >= self.limits.max_open_executors:
             return False, f"Max open executors ({self.limits.max_open_executors}) reached"

--- a/tests/trading_agent/test_risk_drawdown.py
+++ b/tests/trading_agent/test_risk_drawdown.py
@@ -2,7 +2,6 @@ import pytest
 
 from condor.trading_agent.journal import JournalManager
 from condor.trading_agent.performance import _executor_row
-from condor.trading_agent.risk import RiskEngine, RiskLimits, RiskState
 
 
 def test_drawdown_uses_exposure_not_peak_profit(tmp_path):

--- a/tests/trading_agent/test_risk_drawdown.py
+++ b/tests/trading_agent/test_risk_drawdown.py
@@ -1,0 +1,57 @@
+import pytest
+
+from condor.trading_agent.journal import JournalManager
+from condor.trading_agent.performance import _executor_row
+from condor.trading_agent.risk import RiskEngine, RiskLimits, RiskState
+
+
+def test_drawdown_uses_exposure_not_peak_profit(tmp_path):
+    journal = JournalManager("agent_1", session_dir=tmp_path)
+    journal.record_snapshot(
+        total_pnl=0.00, total_volume=10, open_count=1, position_size=10
+    )
+    journal.record_snapshot(
+        total_pnl=0.05, total_volume=10, open_count=1, position_size=10
+    )
+    journal.record_snapshot(
+        total_pnl=0.03, total_volume=10, open_count=1, position_size=10
+    )
+
+    assert journal.get_drawdown_pct() == pytest.approx(0.2)
+
+
+def test_drawdown_is_zero_without_exposure(tmp_path):
+    journal = JournalManager("agent_1", session_dir=tmp_path)
+    journal.record_snapshot(
+        total_pnl=0.05, total_volume=10, open_count=1, position_size=0
+    )
+    journal.record_snapshot(
+        total_pnl=0.03, total_volume=10, open_count=1, position_size=0
+    )
+
+    assert journal.get_drawdown_pct() == 0.0
+
+
+def test_lp_executor_amount_uses_current_position_value():
+    row = _executor_row(
+        {
+            "status": "RUNNING",
+            "net_pnl_quote": 0.03,
+            "filled_amount_quote": 9.94,
+            "config": {"type": "lp_executor", "trading_pair": "Fartcoin-USDC"},
+            "custom_info": {"total_value_quote": 9.97, "current_price": 0.12},
+        }
+    )
+
+    assert row["amount"] == 9.97
+    assert row["current_price"] == 0.12
+
+
+def test_risk_block_prevents_new_executor_create():
+    state = RiskState(is_blocked=True, block_reason="Drawdown limit")
+    allowed, reason = RiskEngine(RiskLimits()).check_executor_action(
+        {"input": {"action": "create", "executor_config": {}}}, state
+    )
+
+    assert not allowed
+    assert reason == "Drawdown limit"

--- a/tests/trading_agent/test_risk_drawdown.py
+++ b/tests/trading_agent/test_risk_drawdown.py
@@ -36,8 +36,6 @@ def test_lp_executor_amount_uses_current_position_value():
     row = _executor_row(
         {
             "status": "RUNNING",
-            "net_pnl_quote": 0.03,
-            "filled_amount_quote": 9.94,
             "config": {"type": "lp_executor", "trading_pair": "Fartcoin-USDC"},
             "custom_info": {"total_value_quote": 9.97, "current_price": 0.12},
         }
@@ -45,13 +43,3 @@ def test_lp_executor_amount_uses_current_position_value():
 
     assert row["amount"] == 9.97
     assert row["current_price"] == 0.12
-
-
-def test_risk_block_prevents_new_executor_create():
-    state = RiskState(is_blocked=True, block_reason="Drawdown limit")
-    allowed, reason = RiskEngine(RiskLimits()).check_executor_action(
-        {"input": {"action": "create", "executor_config": {}}}, state
-    )
-
-    assert not allowed
-    assert reason == "Drawdown limit"


### PR DESCRIPTION
What changed

1. Agent drawdown accounting
- Drawdown now measures peak-to-current PnL retracement against current exposure instead of peak profit. This avoids false blocks on tiny profitable positions, e.g. $0.05 -> $0.03 PnL on $10 exposure is 0.2%, not 40%.

2. LP executor exposure
- LP executor rows now derive amount from current LP `total_value_quote` when total_amount_quote is absent. Journal snapshots can record nonzero exposure for LP positions.

3. Make sure executor_count and total_exposure are available in risk state
- Snapshots of agent are missing these metrics

4. Tests
- Added focused coverage for exposure-based drawdown, LP amount extraction.

---
Drawdown rationale

Standard drawdown is a peak-to-current decline in portfolio value. For a strategy with explicit NAV snapshots, that is `(peak_nav - current_nav) / peak_nav`.

Condor journal snapshots currently store PnL and exposure, not full NAV. The previous calculation used peak PnL as the denominator, so a profitable LP moving from `$0.05` PnL to `$0.03` PnL was reported as `40%` drawdown. That is a profit retracement, not a 40% capital drawdown.

This PR uses exposure as the capital-at-risk denominator: `(peak_pnl - current_pnl) / exposure`. For the same `$10` LP, `$0.05 -> $0.03` becomes `0.2%`, matching the practical NAV result of `(10.05 - 10.03) / 10.05 ~= 0.199%` and avoiding false risk blocks. When profits are large, exposure-based drawdown is slightly more conservative than NAV-based drawdown; when losses start from flat PnL, it matches NAV-based drawdown.

---
QA recommendations

- Run `PYTHONDONTWRITEBYTECODE=1 python -m pytest tests/trading_agent/test_risk_drawdown.py`.
- Start a fresh LP agent session and confirm snapshots show nonzero exposure and small profit retracements do not trigger false max-drawdown blocks.