### PR TITLE
chore(config): fix logic to separate config for WEB_URL and WEB_PORT

### DIFF
--- a/utils/config.py
+++ b/utils/config.py
@@ -33,10 +33,10 @@ _web_port_raw = os.environ.get("WEB_PORT", "").strip()
 if _web_url_raw:
     WEB_URL = _web_url_raw.rstrip("/")
     _parsed = urlparse(WEB_URL)
-   if _web_port_raw:
-       WEB_PORT = int(_web_port_raw)
-   else:
-       WEB_PORT = _parsed.port or (443 if _parsed.scheme == "https" else 80)
+    if _web_port_raw:
+        WEB_PORT = int(_web_port_raw)
+    else:
+        WEB_PORT = _parsed.port or (443 if _parsed.scheme == "https" else 80)
 else:
     WEB_PORT = int(_web_port_raw) if _web_port_raw else 8088
     WEB_URL = f"http://localhost:{WEB_PORT}"

--- a/utils/config.py
+++ b/utils/config.py
@@ -19,15 +19,24 @@ TELEGRAM_TOKEN = os.environ.get("TELEGRAM_TOKEN")
 
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 
-# Single WEB_URL param: full URL including port if needed (e.g. http://myserver.com:8088)
-# Falls back to WEB_PORT for backward compat, then default 8088
+# WEB_URL is the public URL used in links sent to users.
+# WEB_PORT is the local bind port for the web server.
+#
+# Resolution rules:
+# 1) If WEB_PORT is set, always use it for binding.
+# 2) Else if WEB_URL has an explicit port, use that port.
+# 3) Else infer 443 for https:// WEB_URL and 80 for http:// WEB_URL.
+# 4) If WEB_URL is not set, default WEB_PORT to 8088 and WEB_URL to localhost.
 _web_url_raw = os.environ.get("WEB_URL", "").strip()
 _web_port_raw = os.environ.get("WEB_PORT", "").strip()
 
 if _web_url_raw:
     WEB_URL = _web_url_raw.rstrip("/")
     _parsed = urlparse(WEB_URL)
-    WEB_PORT = _parsed.port or (443 if _parsed.scheme == "https" else 80)
+   if _web_port_raw:
+       WEB_PORT = int(_web_port_raw)
+   else:
+       WEB_PORT = _parsed.port or (443 if _parsed.scheme == "https" else 80)
 else:
     WEB_PORT = int(_web_port_raw) if _web_port_raw else 8088
     WEB_URL = f"http://localhost:{WEB_PORT}"


### PR DESCRIPTION
## Problem

`WEB_URL` currently does double duty as both the public URL used in links sent to users and the port source used to bind the web server. That works for a local value such as `http://localhost:8088`, but it breaks common reverse-proxy and Kubernetes deployments where the public URL is HTTPS while the application should still bind to an internal port such as `8088`.

### Reproduction

Configure Condor behind an ingress or reverse proxy with a public URL and an internal bind port:

```env
WEB_URL=https://condor.example.com
WEB_PORT=8088
```

Before this change, `utils.config` ignored `WEB_PORT` whenever `WEB_URL` was set and derived the bind port from the URL scheme instead:

```python
WEB_URL = "https://condor.example.com"
WEB_PORT = 443
```

That means links point to the right public host, but the local web server tries to bind to `443` instead of the intended internal port.

## Fix

Separate the two configuration concerns in `utils/config.py`:

- `WEB_URL` remains the public URL used in Telegram/web links.
- `WEB_PORT` is the local port used to bind the web server.
- If `WEB_PORT` is set, it always wins for binding.
- If `WEB_PORT` is not set, the existing fallback behavior remains: use the explicit port from `WEB_URL`, infer `443` for HTTPS, infer `80` for HTTP, or default to `http://localhost:8088`.

## Scope

- One file changed: `utils/config.py`.
- No new dependencies.
- Keeps existing local behavior for `WEB_URL=http://localhost:8088`.
- Keeps backward compatibility for deployments that only set `WEB_URL` or only set `WEB_PORT`.
- Adds explicit support for reverse-proxy/Kubernetes-style configuration where public URL and bind port differ.

## Validated

Targeted validation passed for the expected config matrix:

- `WEB_URL=https://condor.example.com`, `WEB_PORT=8088` -> public URL stays HTTPS, bind port is `8088`.
- `WEB_URL=http://localhost:8088` -> bind port remains `8088`.
- `WEB_URL=https://condor.example.com` without `WEB_PORT` -> bind port falls back to `443`.
- `WEB_PORT=9090` without `WEB_URL` -> public URL becomes `http://localhost:9090`.
- No web env vars -> default remains `http://localhost:8088` / `8088`.

Also validated:

- `py_compile` passed for `utils/config.py`.
- `git diff --check` passed.

Full-suite note: `uv run pytest` was attempted, but collection stops before test execution because `tests/trading_agent/test_risk_drawdown.py` imports `condor.trading_agent`, which is not present in this checkout. That failure is outside this one-file config change.
