### PR TITLE
Validate external MCP harnesses (Claude Code, OpenClaw) as first-class Condor clients; fix 3 bugs; add per-harness QA guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHELL := /bin/bash
 export PATH := $(HOME)/.local/bin:$(HOME)/.cargo/bin:$(PATH)
 
-.PHONY: help setup install run test lint build-frontend setup-chrome
+.PHONY: help setup install run test lint build-frontend setup-chrome register-mcp
 
 # Helper function to find node/npm via nvm or system
 define find_node
@@ -22,6 +22,7 @@ help:
 	@echo "  make run         - Run locally (dev)"
 	@echo "  make test        - Run tests"
 	@echo "  make lint        - Run black + isort"
+	@echo "  make register-mcp - Register MCP servers with OpenClaw (no-op if absent)"
 
 setup:
 	@chmod +x setup-environment.sh && ./setup-environment.sh
@@ -34,6 +35,11 @@ install: setup
 		cd frontend && npm install \
 	'
 	@$(MAKE) setup-chrome
+	@$(MAKE) register-mcp
+
+# Runs after uv sync: probing spawns the servers, so deps must be installed.
+register-mcp:
+	@chmod +x scripts/register-openclaw-mcp.sh && ./scripts/register-openclaw-mcp.sh
 
 setup-chrome:
 	@echo "Setting up Chrome for chart rendering..."

--- a/agents/market_making_expert/strategies/pmm_mister_operator/strategy.md
+++ b/agents/market_making_expert/strategies/pmm_mister_operator/strategy.md
@@ -178,7 +178,7 @@ Derive `config_name` and `bot_name` from `trading_pair` at runtime (see Naming c
 
 ### First deployment (no controller config exists):
 1. Create config: `manage_controllers(action="upsert", target="config", config_name="{config_name}", config_data={...})`
-2. Deploy bot: `manage_bots(action="deploy", bot_name="{bot_name}", controllers_config=["{config_name}"])`
+2. Deploy bot: `manage_bots(action="deploy", bot_name="{bot_name}", controllers_config=["{config_name}"], max_global_drawdown_quote=<max_position_size_quote from risk_limits>)` — the loss cap is required; deploys without it are blocked by the risk engine
 
 ### Update running controller:
 `manage_bots(action="update_config", bot_name="{bot_name}", config_name="{config_name}", config_data={...full config...}, confirm_override=true)`

--- a/agents/market_making_expert/strategies/pmm_mister_operator/strategy.md
+++ b/agents/market_making_expert/strategies/pmm_mister_operator/strategy.md
@@ -52,8 +52,7 @@ controllers. Your job is to:
 ### Step 1: Run routines
 Use the values from `[CURRENT CONFIG]` for all routine calls:
 - `market_analyzer` with `{"trading_pair": "<trading_pair>", "connector_name": "<connector_name>"}`
-- `portfolio_scanner` with `{"connector_name": "<connector_name>"}`
-- `bot_position_tracker` with `{"trading_pair": "<trading_pair>"}`
+- `mm_dashboard` with `{"connector_name": "<connector_name>", "trading_pair": "<trading_pair>"}`
 
 ### Step 2: Assess regime
 From market_analyzer output, extract:

--- a/condor/agents/consult.py
+++ b/condor/agents/consult.py
@@ -156,7 +156,9 @@ async def _run_agent_to_completion(
             agent_slug=slug,
         )
     else:
-        mcp_servers = build_mcp_servers_for_session(user_id, chat_id)
+        # Serverless agents still need their own memory/skill scope — without
+        # agent_slug the condor MCP tools would target the CHAT's stores.
+        mcp_servers = build_mcp_servers_for_session(user_id, chat_id, agent_slug=slug)
 
     # ``permission_callback`` is passed in: CONSULT routes dangerous-tool
     # confirmations to the user's Telegram chat; DELEGATE passes None so an ACP

--- a/condor/agents/engine.py
+++ b/condor/agents/engine.py
@@ -580,6 +580,7 @@ class TickEngine:
                 self.user_id,
                 self.chat_id,
                 execution_mode=mode,
+                agent_slug=self.agent.slug,
             )
         permission_cb = auto_approve_with_risk_check(
             self.risk, risk_state, execution_mode=mode

--- a/condor/agents/prompts.py
+++ b/condor/agents/prompts.py
@@ -29,8 +29,11 @@ BASE_PROMPT_DRY_RUN = """\
 You are an autonomous trading agent running inside Condor in 🧪 DRY RUN mode.
 
 RULES:
-- This is OBSERVATION ONLY. Do NOT create or stop executors.
-- manage_executors is available for read-only queries (performance_report).
+- This is OBSERVATION ONLY. Do NOT create or stop executors, and do NOT deploy,
+  stop, or update a controller-based bot (manage_bots with action="deploy",
+  "stop_bot", "stop_controllers", "start_controllers", or "update_config").
+- manage_executors and manage_bots are available for read-only queries
+  (performance_report; status/logs/get_config).
 - Analyze the market and describe what you WOULD do, but take NO trading action.
 
 DRY RUN MESSAGING:

--- a/condor/agents/prompts.py
+++ b/condor/agents/prompts.py
@@ -17,6 +17,9 @@ You are an autonomous trading agent running inside Condor.
 
 RULES:
 - Trade ONLY via manage_executors(action="create"). NEVER use place_order.
+- If your strategy deploys a controller-based bot, manage_bots(action="deploy")
+  MUST include max_global_drawdown_quote within your risk limits — deploys
+  without a declared loss cap are blocked by the risk engine.
 - Be conservative. When in doubt, hold and journal why.
 
 ERROR RECOVERY:

--- a/condor/agents/risk.py
+++ b/condor/agents/risk.py
@@ -173,7 +173,7 @@ def auto_approve_with_risk_check(
     execution_mode: str = "loop",
 ):
     """Build a permission callback that auto-approves safe tools and risk-checks dangerous ones."""
-    from handlers.agents._shared import is_dangerous_tool_call
+    from handlers.agents._shared import DANGEROUS_BOT_ACTIONS, is_dangerous_tool_call
 
     async def callback(tool_call: dict, options: list[dict]) -> dict:
         if is_dangerous_tool_call(tool_call):
@@ -187,6 +187,12 @@ def auto_approve_with_risk_check(
                     action = input_data.get("action", "")
                     if action in ("create", "stop"):
                         log.info("Dry-run mode: blocked manage_executors(%s)", action)
+                        return {"outcome": {"outcome": "cancelled"}}
+                elif tool_name == "manage_bots":
+                    input_data = tool_call.get("input", {})
+                    action = input_data.get("action", "")
+                    if action in DANGEROUS_BOT_ACTIONS:
+                        log.info("Dry-run mode: blocked manage_bots(%s)", action)
                         return {"outcome": {"outcome": "cancelled"}}
                 elif tool_name in (
                     "place_order",

--- a/condor/agents/risk.py
+++ b/condor/agents/risk.py
@@ -166,6 +166,47 @@ class RiskEngine:
 
         return True, ""
 
+    def check_bot_action(self, tool_call: dict) -> tuple[bool, str]:
+        """Check a manage_bots call against risk limits.
+
+        A bot's capital lives in saved controller configs on the API server,
+        so exposure can't be computed from the tool inputs alone. Instead,
+        bound the loss: a deploy must declare ``max_global_drawdown_quote``
+        (the platform-enforced kill switch) no larger than the strategy's
+        position limit. Stops are risk-reducing and always allowed; an
+        ``update_config`` is only gated when it declares a
+        ``total_amount_quote`` above the position limit.
+
+        Returns (allowed, reason).
+        """
+        input_data = tool_call.get("input", {})
+        action = input_data.get("action", "")
+
+        if action == "deploy":
+            cap = input_data.get("max_global_drawdown_quote")
+            if not cap:
+                return False, (
+                    "Bot deploy must declare max_global_drawdown_quote "
+                    f"(≤ ${self.limits.max_position_size_quote:.2f}) so the "
+                    "platform kill switch bounds the loss"
+                )
+            if float(cap) > self.limits.max_position_size_quote:
+                return False, (
+                    f"max_global_drawdown_quote ${float(cap):.2f} exceeds "
+                    f"position limit ${self.limits.max_position_size_quote:.2f}"
+                )
+        elif action == "update_config":
+            amount = float(
+                (input_data.get("config_data") or {}).get("total_amount_quote", 0) or 0
+            )
+            if amount > self.limits.max_position_size_quote:
+                return False, (
+                    f"update_config total_amount_quote ${amount:.2f} exceeds "
+                    f"position limit ${self.limits.max_position_size_quote:.2f}"
+                )
+
+        return True, ""
+
 
 def auto_approve_with_risk_check(
     risk_engine: RiskEngine,
@@ -217,6 +258,14 @@ def auto_approve_with_risk_check(
                 allowed, reason = risk_engine.check_executor_action(
                     tool_call, risk_state
                 )
+                if not allowed:
+                    log.warning("Risk engine blocked tool call: %s", reason)
+                    return {"outcome": {"outcome": "cancelled"}}
+
+            # Bot deploys place real capital via controllers — bound the loss
+            # (declared drawdown kill switch) since the amount isn't in the call
+            if tool_name == "manage_bots":
+                allowed, reason = risk_engine.check_bot_action(tool_call)
                 if not allowed:
                     log.warning("Risk engine blocked tool call: %s", reason)
                     return {"outcome": {"outcome": "cancelled"}}

--- a/condor/web/auth.py
+++ b/condor/web/auth.py
@@ -88,6 +88,19 @@ def decode_jwt(token: str) -> Optional[dict]:
     try:
         return jwt.decode(token, _jwt_secret(), algorithms=[_ALGORITHM])
     except JWTError:
+        pass
+    # The token may be signed with a secret a sibling process persisted to
+    # config.yml after our snapshot was loaded (main bot vs MCP subprocess).
+    # Refresh from disk once and retry before rejecting. Skipped when the
+    # env var pins the secret — there is nothing fresher to read.
+    if os.getenv("WEB_JWT_SECRET"):
+        return None
+    fresh = get_config_manager().reload_web_jwt_secret()
+    if not fresh:
+        return None
+    try:
+        return jwt.decode(token, fresh, algorithms=[_ALGORITHM])
+    except JWTError:
         return None
 
 

--- a/config_manager.py
+++ b/config_manager.py
@@ -536,6 +536,12 @@ class ConfigManager:
         role = self.get_user_role(user_id)
         return role in (UserRole.ADMIN, UserRole.USER)
 
+    def get_approved_users(self) -> list[int]:
+        """All user ids with an approved role (admin or user)."""
+        return [
+            uid for uid in self._data.get("users", {}) if self.is_approved(uid)
+        ]
+
     def register_pending(self, user_id: int, username: str = None) -> bool:
         """Register a new pending user."""
         users = self._data["users"]

--- a/config_manager.py
+++ b/config_manager.py
@@ -339,6 +339,15 @@ class ConfigManager:
         secret = self._data.get("web_jwt_secret")
         if secret:
             return secret
+        # Several processes share config.yml (main bot + each MCP subprocess),
+        # each with its own snapshot loaded at startup. A snapshot without the
+        # secret does NOT mean the file has none: another process may have
+        # generated one since. Adopt the on-disk value before minting — a
+        # second generation here clobbers the file via _save_config() and
+        # invalidates every JWT the other processes signed (opaque 401s).
+        on_disk = self.reload_web_jwt_secret()
+        if on_disk:
+            return on_disk
         secret = secrets.token_urlsafe(32)
         self._data["web_jwt_secret"] = secret
         self._save_config()
@@ -347,6 +356,23 @@ class ConfigManager:
             self.config_path,
         )
         return secret
+
+    def reload_web_jwt_secret(self) -> Optional[str]:
+        """Re-read ``web_jwt_secret`` from config.yml into the snapshot.
+
+        Returns the on-disk secret (or None). Lets a long-lived process pick up
+        a secret persisted by a sibling process after this one loaded its
+        snapshot, instead of diverging from it.
+        """
+        try:
+            with open(self.config_path, "r") as f:
+                on_disk = (yaml.safe_load(f) or {}).get("web_jwt_secret")
+        except Exception as e:
+            logger.error(f"Failed to re-read web JWT secret: {e}")
+            return self._data.get("web_jwt_secret")
+        if on_disk:
+            self._data["web_jwt_secret"] = on_disk
+        return on_disk
 
     async def get_client(self, name: str = None):
         """Get or create API client for a server."""

--- a/docs/architecture/mcp-harness-spike.md
+++ b/docs/architecture/mcp-harness-spike.md
@@ -1,23 +1,18 @@
-# Spike: validating Condor strategies via MCP from Claude Code / OpenClaw / Hermes
+# Spike: validating Condor strategies via MCP from external harnesses (Claude Code, OpenClaw)
 
-Companion to [`mcp-first-value-add.md`](../strategy/mcp-first-value-add.md) (the
-harness-agnostic thesis this spike tests empirically) and
-[`strategy-engine-and-shared-intelligence.md`](./strategy-engine-and-shared-intelligence.md)
-(§1.2's request-path walkthrough, which this spike is designed to confirm against
-real harnesses instead of just the code). **Scope note**: pluggable *scheduling*
-(OpenClaw/Hermes cron firing ticks, §1.5–1.6 of that doc) is deferred and out of
-scope here — this spike keeps Condor's own `TickEngine` as the sole scheduler
-throughout. It tests something narrower and already in-scope today: can
-OpenClaw, Hermes, and Claude Code be used as **Tier 1 interactive MCP clients** —
-starting, consulting, and stopping a strategy — in place of Condor's own
-Telegram bot or web dashboard.
+**Scope note**: pluggable *scheduling* (an external harness's cron firing
+ticks) is deferred and out of scope here — this spike keeps Condor's own
+`TickEngine` as the sole scheduler throughout. It tests something narrower
+and already in-scope today: can external harnesses (Claude Code, OpenClaw)
+be used as **Tier 1 interactive MCP clients** — starting, consulting, and
+stopping a strategy — in place of Condor's own Telegram bot or web dashboard.
 
 ## Goal
 
 Decide whether Telegram and the web dashboard can be genuinely deprioritized as
 Condor's interaction surface, by concretely validating: start the
-`market_making_expert` agent's `pmm_mister_operator` strategy from Claude Code,
-OpenClaw, or Hermes, and confirm it runs identically to starting it from
+`market_making_expert` agent's `pmm_mister_operator` strategy from Claude Code
+or OpenClaw, and confirm it runs identically to starting it from
 Condor's own Telegram bot — same tools, same running `TickEngine`, same
 journal, visible and controllable from any of these interchangeably.
 
@@ -49,7 +44,7 @@ None of step 3 reads anything about which harness issued the `start_agent`
 call in step 1. Once started, the strategy's actual market-making behavior —
 which model reasons about it, which tools it calls, how it's journaled — is
 **already guaranteed identical** regardless of whether a human typed
-`start_agent` from Telegram, Claude Code, OpenClaw, or Hermes. That part of
+`start_agent` from Telegram or any external harness. That part of
 "does it work the same" doesn't need a spike; it's a fact about the code.
 
 **What the spike actually needs to validate is narrower and lives entirely at
@@ -67,7 +62,7 @@ usage:
 3. Does the resulting running strategy show up identically in Condor's *own*
    tooling — `list_agents`, the web dashboard, a Telegram `/status` — proving
    Tier 2 state was never tied to the harness that started it (the concrete,
-   observable version of architecture doc §1.2's claim)?
+   observable version of the three-tier architecture's core claim)?
 
 ## Does `market_making_expert` / `pmm_mister_operator` need modification?
 
@@ -107,64 +102,19 @@ strategy was already broken":
 `trading_pair` — a strict superset of what the two retired routines took —
 so this is a one-line Step-1 edit, not a rewrite.)
 
-**One real, named non-parity gap (not a blocker, but sharper than first
-described once a TUI is in the picture): `send_notification`
+**One real, named non-parity gap (not a blocker): `send_notification`
 (`mcp_servers/condor/tools/notification.py`) is Telegram-only, hardcoded.**
 It POSTs directly to `api.telegram.org` using `settings.bot_token`/
 `settings.chat_id` — there is no branch for "notify via whatever harness is
-active." Originally this was framed as "fine as long as Telegram stays the
-alerting channel, only a gap if Telegram is later dropped entirely" — but
-that framing assumed whatever replaces Telegram is itself push-capable.
-**If the replacement interactive surface is a TUI — OpenClaw's TUI or Claude
-Code's terminal UI — that assumption doesn't hold, and not as an
-implementation gap but as a structural property of TUIs:**
-
-- Telegram (and any messaging-channel adapter — Discord, Slack, SMS) is
-  **persistent and push-capable**: a message can reach the user's phone at
-  3am with nothing already open on their end. A `TickEngine` tick alerting
-  on a stop-loss trigger needs exactly this, because most of the time
-  nobody has anything open — that's the entire point of an unattended,
-  24/7 strategy loop.
-- A TUI is **session-scoped and pull-based**: it only exists while a human
-  has a terminal window open, the same limitation already named for Claude
-  Code's `/loop` (session-scoped, dies on terminal exit) in the scheduling
-  research (`strategy-engine-and-shared-intelligence.md` §1.5). There is
-  no mechanism by which a background tick can make a TUI that isn't running
-  suddenly appear on someone's screen. A TUI is structurally never a valid
-  `send_notification` target, no matter how much engineering goes into it —
-  this isn't "not implemented yet," it's "there's nothing to dispatch to."
-
-**Decision: stick with Telegram as the alert channel for now** — nothing
-here needs to change today, and Telegram alone still carries every alert
-unmodified regardless of which harness starts or consults a strategy. The
-point worth carrying forward isn't "switch off Telegram," it's narrower and
-more specific than "make `send_notification` multi-channel across
-harnesses": **separate *interactive harness* from *alert channel* as two
-independent choices, not one**, and worth genericizing precisely *because*
-OpenClaw and Hermes already ship their own messaging adapters — the
-capability to dispatch elsewhere already exists on their side, it's
-Condor's own `send_notification` that's hardcoded to one channel. Route it
-to whichever **persistent, push-capable channel** is configured — which may
-or may not be the same thing as the interactive harness a user is currently
-typing into:
-- OpenClaw's TUI + OpenClaw's own Telegram/Discord/Slack adapter (OpenClaw
-  ships both, per the scheduling research) — TUI for hands-on sessions,
-  channel adapter for alerts, both under one harness.
-- Claude Code's terminal UI has no push-capable channel of its own at all —
-  if Claude Code's terminal is the interactive surface, *something else*
-  (Telegram, email, SMS) still has to carry alerts; there is no in-harness
-  substitute to fall back to.
-- Hermes-agent: same shape as OpenClaw — a cron/gateway process plus its own
-  messaging adapters, separate from however a human is interacting with it
-  at a given moment.
-
-This also reinforces, rather than undermines, `roadmap-v2.md` Phase 2's
-existing decision that Telegram is the hosted customer's access point: even
-in a world where the *interactive* choice moves to a TUI-based harness for
-power users, the *alerting* requirement doesn't move with it — some
-persistent channel is still needed underneath, for exactly the reason a
-hosted, unattended strategy can't rely on someone having a terminal open.
-**Not needed for this spike** — tracked as a `## Follow-ups` item instead.
+active." Alerts from an unattended 24/7 strategy need a **persistent,
+push-capable channel**: a stop-loss alert must reach the user's phone at 3am
+with nothing already open on their end. A terminal UI is structurally never
+that — it is session-scoped and pull-based, existing only while a human has
+it open — so the *interactive harness* and the *alert channel* are two
+independent choices, not one. **Decision: Telegram stays the alert channel
+for now**; it carries every alert unmodified regardless of which harness
+starts or consults a strategy. Genericizing `send_notification` to other
+persistent channels is a `## Follow-ups` item, **not needed for this spike**.
 
 **Routines are not a general blocker, already solved.** `mm_dashboard.py`
 imports `telegram.ext.ContextTypes` only as a type hint for its `run(config,
@@ -196,8 +146,8 @@ as a known limitation, not something this spike needs to touch.)
   `config_manager.get_server(name)`). For a first spike, use a paper-trading
   or testnet server config, not the live-capital one — an explicit safety
   gate, not implied by anything in the code itself.
-- **Per-harness MCP registration** — all three need the same two stdio MCP
-  servers Condor's own sessions already use
+- **Per-harness MCP registration** — every harness needs the same two stdio
+  MCP servers Condor's own sessions already use
   (`handlers/agents/_shared.py:305-440`), just registered through each
   harness's own config mechanism instead of Condor's dynamic
   `build_mcp_servers_for_*`:
@@ -212,13 +162,9 @@ as a known limitation, not something this spike needs to touch.)
     `claude mcp add`), with `args` including the flags above — same shape as
     this repo's own `.mcp.json`, just with explicit identity/server flags
     instead of relying on Condor's session code to inject them via env.
-  - **OpenClaw / Hermes**: same two stdio server definitions, registered
-    through each project's own MCP config surface. Exact config syntax for
-    each is an **open item to verify against their docs at implementation
-    time** — flagged here rather than assumed, consistent with how the
-    scheduling spike (`strategy-engine-and-shared-intelligence.md` §1.6,
-    Hermes' cron registration) already treats its own unverified integration
-    points.
+  - **OpenClaw**: same two stdio server definitions, registered through its
+    own MCP config surface (`openclaw mcp add`; see the QA instructions
+    below for the exact, tested invocation).
 
 ## Test protocol
 
@@ -248,7 +194,7 @@ as a known limitation, not something this spike needs to touch.)
    tools, same `tool_preload_hint` behavior for ACP-based harnesses per
    `build_initial_context`, `handlers/agents/_shared.py:487-519`).
 6. **Cross-harness check**: register the same two MCP servers in a *second*
-   harness (OpenClaw or Hermes), and from there call `list_agents`/`consult`/
+   harness (e.g. OpenClaw), and from there call `list_agents`/`consult`/
    `stop_agent`/`pause_agent` against the strategy **started in step 3 from
    Claude Code**. This is the test that most directly answers the spike's
    stated goal — if a strategy started from one harness is fully visible and
@@ -284,19 +230,9 @@ as a known limitation, not something this spike needs to touch.)
 
 - Genericize `send_notification` to dispatch via whichever **persistent,
   push-capable channel** is configured, not hardcoded to Telegram's Bot
-  API — worth doing *because* OpenClaw and Hermes already ship their own
-  Telegram/Discord/Slack adapters (the capability already exists on their
-  side; Condor's own tool is the thing hardcoded to one channel), not
-  because Telegram itself needs to go away. Telegram stays the channel for
-  now either way. Explicitly **not** the interactive TUI itself as a
-  target, since a TUI has no mechanism to receive a push when nothing is
-  open — if the interactive harness is Claude Code's terminal specifically,
-  there's no in-harness channel to fall back to at all, so some persistent
-  channel (Telegram or otherwise) is still required regardless of harness
-  choice.
-- If step 6 passes, this spike is the concrete evidence
-  `mcp-first-value-add.md`'s harness-agnostic pitch needs — worth a pointer
-  back from that doc once results are in.
+  API. Telegram stays the channel for now either way. A terminal UI is
+  explicitly **not** a valid target — it has no mechanism to receive a push
+  when nothing is open.
 
 ## Results (executed 2026-07-07)
 
@@ -475,7 +411,15 @@ question, not a harness question.
 ## Follow-ups discovered during execution, not planned in advance
 
 - **hummingbot/condor#151** (dry-run gap) — fixed and merged into this
-  branch's working tree during this spike; see above.
+  branch's working tree during this spike; see above. Its live-mode sibling
+  is fixed on this branch too: in `loop` mode, `manage_bots(deploy)` was
+  auto-approved with **no** risk-engine check (while `manage_executors
+  (create)` is exposure-gated). Since a bot's capital lives in saved
+  controller configs on the API server — not in the tool call — the gate
+  bounds the *loss* instead: a deploy must declare
+  `max_global_drawdown_quote` ≤ the strategy's `max_position_size_quote`,
+  and an `update_config` may not raise `total_amount_quote` above that
+  limit (`RiskEngine.check_bot_action`).
 - **~~RESTART THE MAIN CONDOR PROCESS to activate the #151 fix~~ — DONE
   (same day).** The `main.py` running since Jul 2 predated the fix and held
   the old `risk.py`/`prompts.py` in memory — visible in
@@ -548,13 +492,13 @@ zero persona. Layering:
 ### 3. Skills go harness-native; one canonical directory
 
 Condor's skill format (`<name>/SKILL.md`, `name`/`description`/
-`when_to_use` frontmatter) is already the same shape all three harnesses
+`when_to_use` frontmatter) is already the same shape the external harnesses
 use natively: Claude Code (`.claude/skills/`), OpenClaw (`openclaw skills
-install` from a local dir; ClawHub), Hermes (agentskills.io standard). So:
+install` from a local dir; ClawHub). So:
 
 - Keep **one canonical skills directory** in the repo; expose it natively
   per harness (symlink into `.claude/skills/`, `openclaw skills install
-  <path>`, drop-in for Hermes). Native progressive disclosure replaces the
+  <path>`). Native progressive disclosure replaces the
   "call `manage_skill(action='read')` before known flows" instruction and
   is a strictly better UX.
 - Skill→routine linkage survives untouched: skill bodies instruct MCP calls
@@ -613,7 +557,12 @@ When the MCP server starts with no identity (no `--user-id`/`--chat-id`
 args, no `CONDOR_USER_ID`/`CONDOR_CHAT_ID` env) and `config.yml` has
 **exactly one approved user**, bind to it and log the choice
 (`settings.ensure_identity()`, called at server startup and defensively
-from `call_main_api`). Resolution order: CLI args > env vars > auto-bind.
+from `call_main_api` and the memory tools — memory resolves its store from
+`user_id` directly, so an unresolved identity errors instead of silently
+targeting user 0's store). The probe never *creates* a `config.yml` (it
+checks for the file first — `ConfigManager` would otherwise write a default
+one into whatever cwd the harness launched from). Resolution order: CLI
+args > env vars > auto-bind.
 
 - Zero setup for the dominant case (single-user local install): any harness
   pointed at the repo just works — no env vars, no 403.
@@ -642,8 +591,8 @@ box until then.
 
 ### Tier C — MCP OAuth 2.1 (only when Tier 2 leaves the machine)
 
-**Yes — Tier C is specifically for the hosted/cloud deployment** (the
-roadmap's Phase 0 hosted box), or any topology where the harness and the
+**Yes — Tier C is specifically for a hosted/cloud deployment**, or any
+topology where the harness and the
 Condor main process are on different machines. That's the first point where
 a network boundary — and therefore real authentication — exists. The MCP
 transport becomes HTTP, and the MCP authorization spec (OAuth 2.1) is the
@@ -655,9 +604,8 @@ matter how many harnesses they use.
 
 ### Net
 
-Identity becomes harness-independent at every tier — Telegram, Claude Code,
-OpenClaw, Codex, Hermes all resolve the same Condor account through the
-same chain (explicit args > env > credential file (B) > auto-bind (A)), and
+Identity becomes harness-independent at every tier — Telegram and every
+external harness resolve the same Condor account through the same chain (explicit args > env > credential file (B) > auto-bind (A)), and
 each tier is added only when the trust situation it addresses actually
 appears: A now (UX, no security pretense), B at multi-user-on-one-box, C at
 remote/hosted.
@@ -784,15 +732,6 @@ args = ["run", "--directory", "/path/to/condor", "python", "-m", "mcp_servers.hu
 Then run `codex` and drive the same checklist below. Check Codex's MCP
 request timeout — if configurable and < 240s, raise it (same consult issue
 as OpenClaw). Record results in this doc.
-
-### Hermes — NOT yet tested, expected shape
-
-Hermes-agent has first-class MCP client support (auto-reconnect, per-server
-timeouts — see fork-vs-build.md); registration is a one-block
-`mcp_servers:` entry in its config using the same command/args shape as the
-table above (use `uv run --directory /path/to/condor ...` if its config has
-no cwd field). Set its per-server timeout ≥ 240s. Consult Hermes docs for
-the exact config schema; record results in this doc.
 
 ### The QA checklist (same for every harness)
 

--- a/docs/architecture/mcp-harness-spike.md
+++ b/docs/architecture/mcp-harness-spike.md
@@ -585,6 +585,83 @@ multi-brain sync problem and no reason for a memory taxonomy:
   facts with `manage_memory`" — the same nudge the tick prompt already
   contains.
 
+## Identity across harnesses: the tiered plan (Tier A ships in this PR)
+
+QA hit the identity problem in the wild: a stock `claude` session using the
+repo's identity-less `.mcp.json` got an opaque `403 Access denied` on every
+consult/delegate — the MCP server defaulted to user id 0 and minted a JWT
+for a nonexistent account. Fixing that properly forced the question: how
+should identity work when we can't depend on Telegram to assert it?
+
+**The grounding fact that shapes everything below**: the JWT signing secret
+lives in `config.yml` on the same filesystem (`condor/web/auth.py`), so
+anyone who can read the repo can mint a JWT for *any* user id. The numeric
+user id was never a credential — Telegram just asserts it honestly. Locally
+there is no security boundary to defend; the design goal is picking the
+right identity *automatically*, and introducing a real credential only
+where a real boundary exists.
+
+**Rejected: harness-level identity (e.g. "use the OpenClaw id").** In local
+mode a harness's identity is itself just self-declared ambient state — zero
+security gain over an env var — and it couples Condor to one harness's
+identity model, against the harness-agnostic thesis. The harness should
+*carry a Condor-issued identity/credential*, not substitute its own.
+
+### Tier A — single-user auto-bind (✅ this PR)
+
+When the MCP server starts with no identity (no `--user-id`/`--chat-id`
+args, no `CONDOR_USER_ID`/`CONDOR_CHAT_ID` env) and `config.yml` has
+**exactly one approved user**, bind to it and log the choice
+(`settings.ensure_identity()`, called at server startup and defensively
+from `call_main_api`). Resolution order: CLI args > env vars > auto-bind.
+
+- Zero setup for the dominant case (single-user local install): any harness
+  pointed at the repo just works — no env vars, no 403.
+- No trust change: the OS user launching the harness already holds every
+  secret on disk. Auto-bind is a *selector*, not authentication.
+- With zero or multiple approved users, nothing is bound and the fail-fast
+  error (also this PR) names the exact fix — a multi-user box must say who
+  it is explicitly.
+
+### Tier B — `condor init` pairing with a stored credential (later: when one box genuinely has multiple users)
+
+The `gh auth login`/`aws configure` pattern: a one-time command generates a
+random token, stores it at `~/.condor/credentials` (0600, outside the repo
+so it can't be committed), and registers it against a user in `config.yml`.
+The MCP server reads it as another resolution-order step; the main API
+verifies the **token**, not just a self-minted JWT — the first point at
+which per-user identity on a shared box becomes real (distinct secrets,
+revocable). Telegram ids become linked aliases of the account rather than
+the primary key.
+
+**Trigger to build it**: the first genuine multi-user-on-one-machine need —
+a shared team box, or Portal-style onboarding that registers more than one
+user. Not before: for single-user installs it's pure ceremony on top of
+Tier A, and the env-var escape hatch already covers the rare multi-user
+box until then.
+
+### Tier C — MCP OAuth 2.1 (only when Tier 2 leaves the machine)
+
+**Yes — Tier C is specifically for the hosted/cloud deployment** (the
+roadmap's Phase 0 hosted box), or any topology where the harness and the
+Condor main process are on different machines. That's the first point where
+a network boundary — and therefore real authentication — exists. The MCP
+transport becomes HTTP, and the MCP authorization spec (OAuth 2.1) is the
+ecosystem-standard mechanism: the harness pops a browser, the user logs
+into Condor's portal, and a scoped token is issued. Claude Code and peers
+already do this dance natively for remote MCP servers, so the UX is
+*better* than env vars, not worse. Local installs never need Tier C, no
+matter how many harnesses they use.
+
+### Net
+
+Identity becomes harness-independent at every tier — Telegram, Claude Code,
+OpenClaw, Codex, Hermes all resolve the same Condor account through the
+same chain (explicit args > env > credential file (B) > auto-bind (A)), and
+each tier is added only when the trust situation it addresses actually
+appears: A now (UX, no security pretense), B at multi-user-on-one-box, C at
+remote/hosted.
+
 ## QA instructions: reproducing this spike per harness
 
 Everything below assumes the QA machine has the condor repo checked out and
@@ -627,21 +704,23 @@ should visibly follow.
 ### Claude Code — tested ✅
 
 Interactive: `cd /path/to/condor && claude` — the repo's own `.mcp.json`
-registers both servers (identity then comes from `CONDOR_CHAT_ID`/
-`CONDOR_USER_ID` env vars, so **export those first** — put them in your
-shell profile; the MCP subprocess inherits Claude Code's environment):
+registers both servers. Identity: on a **single-user install** (one
+approved user in `config.yml`) nothing is needed — Tier A auto-bind picks
+that user. On a multi-user box, export your registered id first (shell
+profile; the MCP subprocess inherits Claude Code's environment):
 
 ```bash
 export CONDOR_USER_ID=<your registered user id>   # e.g. config.yml's admin_id
 export CONDOR_CHAT_ID=<same id>
 ```
 
-**Known failure without them** (hit in QA): `consult`/`delegate`/lifecycle
-calls fail — formerly an opaque `403 Access denied` (the server minted a
-JWT for the default user id 0, which isn't a registered account; same auth
-as the web dashboard). `call_main_api` now fails fast with an error naming
-these env vars. Note this is Condor-user identity, unrelated to the
-hummingbot-api's admin/admin credentials.
+**Known failure mode** (hit in QA, pre-Tier-A): `consult`/`delegate`/
+lifecycle calls failed with an opaque `403 Access denied` — the server
+minted a JWT for the default user id 0, which isn't a registered account
+(same auth as the web dashboard). Now: single-user installs auto-bind;
+ambiguous configs fail fast with an error naming these env vars. Note this
+is Condor-user identity, unrelated to the hummingbot-api's admin/admin
+credentials.
 
 Headless / isolated (what this spike used — avoids touching repo state):
 write the two servers into a scratch `qa-mcp.json` (identity as explicit

--- a/docs/architecture/mcp-harness-spike.md
+++ b/docs/architecture/mcp-harness-spike.md
@@ -1,0 +1,586 @@
+# Spike: validating Condor strategies via MCP from Claude Code / OpenClaw / Hermes
+
+Companion to [`mcp-first-value-add.md`](../strategy/mcp-first-value-add.md) (the
+harness-agnostic thesis this spike tests empirically) and
+[`strategy-engine-and-shared-intelligence.md`](./strategy-engine-and-shared-intelligence.md)
+(§1.2's request-path walkthrough, which this spike is designed to confirm against
+real harnesses instead of just the code). **Scope note**: pluggable *scheduling*
+(OpenClaw/Hermes cron firing ticks, §1.5–1.6 of that doc) is deferred and out of
+scope here — this spike keeps Condor's own `TickEngine` as the sole scheduler
+throughout. It tests something narrower and already in-scope today: can
+OpenClaw, Hermes, and Claude Code be used as **Tier 1 interactive MCP clients** —
+starting, consulting, and stopping a strategy — in place of Condor's own
+Telegram bot or web dashboard.
+
+## Goal
+
+Decide whether Telegram and the web dashboard can be genuinely deprioritized as
+Condor's interaction surface, by concretely validating: start the
+`market_making_expert` agent's `pmm_mister_operator` strategy from Claude Code,
+OpenClaw, or Hermes, and confirm it runs identically to starting it from
+Condor's own Telegram bot — same tools, same running `TickEngine`, same
+journal, visible and controllable from any of these interchangeably.
+
+## The key finding, grounded in the code: this is a narrower test than it sounds
+
+Reading `condor/agents/engine.py`'s actual `_create_client()`
+(`engine.py:552-620`) settles the central question before any spike is run:
+**a running strategy's tick execution is already harness-invariant by
+construction.** Walk the call chain:
+
+1. Any harness calls `mcp__condor__manage_trading_agent(action="start_agent",
+   strategy_id="market_making_expert.pmm_mister_operator", config={...})`
+   (`mcp_servers/condor/tools/trading_agent.py:337-385`).
+2. That handler does nothing agent-specific — it resolves the strategy, then
+   `POST`s to Tier 2's own REST API,
+   `/agents/{agent_slug}/strategies/{sslug}/start`, passing
+   `settings.chat_id`/`settings.user_id` (identity carried by the *calling*
+   MCP subprocess, not by the strategy).
+3. Tier 2 creates a `TickEngine` inside its own persistent process. From this
+   point on, `_loop()`/`_tick()`/`_create_client()` run **entirely inside
+   Tier 2**, on Tier 2's own schedule, spawning Tier 2's own ACP/PydanticAI
+   client each tick (`engine.py:552-620`) — calling
+   `build_mcp_servers_for_agent`/`build_mcp_servers_for_session`
+   (`handlers/agents/_shared.py:305-440`) itself, and resolving
+   `agent_key: claude-acp:sonnet` to the `claude-agent-acp` bridge command via
+   `resolve_acp()` (`condor/acp/client.py:168-206`) itself.
+
+None of step 3 reads anything about which harness issued the `start_agent`
+call in step 1. Once started, the strategy's actual market-making behavior —
+which model reasons about it, which tools it calls, how it's journaled — is
+**already guaranteed identical** regardless of whether a human typed
+`start_agent` from Telegram, Claude Code, OpenClaw, or Hermes. That part of
+"does it work the same" doesn't need a spike; it's a fact about the code.
+
+**What the spike actually needs to validate is narrower and lives entirely at
+the Tier 1 boundary**, none of which is exercised by today's Telegram/web-only
+usage:
+
+1. Can each harness be configured with a Condor MCP server pointed at valid
+   identity (chat_id/user_id/server_name), the same way
+   `build_mcp_servers_for_agent` configures it today for Condor's own
+   sessions?
+2. Does each harness successfully call `start_agent`, `consult`, `delegate`,
+   `trading_agent_journal_read`, `stop_agent` end-to-end — no harness-specific
+   quirk (tool-call formatting, auto-approval/permission prompts blocking an
+   unattended call, timeout handling) breaks the flow?
+3. Does the resulting running strategy show up identically in Condor's *own*
+   tooling — `list_agents`, the web dashboard, a Telegram `/status` — proving
+   Tier 2 state was never tied to the harness that started it (the concrete,
+   observable version of architecture doc §1.2's claim)?
+
+## Does `market_making_expert` / `pmm_mister_operator` need modification?
+
+**Agent-level (`AGENT.md`): no.** `agent_key: claude-acp:sonnet`, the `tools:`
+allowlist, and `server_name: moneymaker` are all resolved by Tier 2 code paths
+(`_create_client`, `_resolve_server`) the same way regardless of which harness
+is consulting/delegating to it or which harness started its strategy. Nothing
+here is Telegram- or dashboard-specific.
+
+**Strategy-level: yes, one pre-existing bug should be fixed first, unrelated
+to the harness question.** `pmm_mister_operator/strategy.md`'s Step 1 calls
+three routines every tick: `market_analyzer`, `portfolio_scanner`, and
+`bot_position_tracker`. Checking the actual routines directory
+(`agents/market_making_expert/routines/`) and a repo-wide search for those
+filenames turns up only `market_analyzer.py` and `mm_dashboard.py` —
+`mm_dashboard.py`'s own docstring says it **"Consolidates three former
+routines... portfolio_scanner ... mm_bot_report ... bot_position_tracker
+(superseded)"**. `portfolio_scanner` and `bot_position_tracker` no longer
+exist as routines anywhere in the repo (routine names resolve from filename
+stems, per `discover_routines_from_path`, `routines/base.py:242-280`) — so
+every tick today calls two routine names that resolve to
+`{"error": "Routine '...' not found"}`, **regardless of scheduler or
+harness**. This isn't a harness-compatibility issue; it's a stale reference
+left over from the `mm_dashboard` consolidation. Fix before running the
+spike, or the spike will conflate "the harness doesn't work" with "the
+strategy was already broken":
+
+```diff
+- `market_analyzer` with `{"trading_pair": "<trading_pair>", "connector_name": "<connector_name>"}`
+- `portfolio_scanner` with `{"connector_name": "<connector_name>"}`
+- `bot_position_tracker` with `{"trading_pair": "<trading_pair>"}`
++ `market_analyzer` with `{"trading_pair": "<trading_pair>", "connector_name": "<connector_name>"}`
++ `mm_dashboard` with `{"connector_name": "<connector_name>", "trading_pair": "<trading_pair>"}`
+```
+
+(`mm_dashboard.Config` already accepts both `connector_name` and
+`trading_pair` — a strict superset of what the two retired routines took —
+so this is a one-line Step-1 edit, not a rewrite.)
+
+**One real, named non-parity gap (not a blocker, but sharper than first
+described once a TUI is in the picture): `send_notification`
+(`mcp_servers/condor/tools/notification.py`) is Telegram-only, hardcoded.**
+It POSTs directly to `api.telegram.org` using `settings.bot_token`/
+`settings.chat_id` — there is no branch for "notify via whatever harness is
+active." Originally this was framed as "fine as long as Telegram stays the
+alerting channel, only a gap if Telegram is later dropped entirely" — but
+that framing assumed whatever replaces Telegram is itself push-capable.
+**If the replacement interactive surface is a TUI — OpenClaw's TUI or Claude
+Code's terminal UI — that assumption doesn't hold, and not as an
+implementation gap but as a structural property of TUIs:**
+
+- Telegram (and any messaging-channel adapter — Discord, Slack, SMS) is
+  **persistent and push-capable**: a message can reach the user's phone at
+  3am with nothing already open on their end. A `TickEngine` tick alerting
+  on a stop-loss trigger needs exactly this, because most of the time
+  nobody has anything open — that's the entire point of an unattended,
+  24/7 strategy loop.
+- A TUI is **session-scoped and pull-based**: it only exists while a human
+  has a terminal window open, the same limitation already named for Claude
+  Code's `/loop` (session-scoped, dies on terminal exit) in the scheduling
+  research (`strategy-engine-and-shared-intelligence.md` §1.5). There is
+  no mechanism by which a background tick can make a TUI that isn't running
+  suddenly appear on someone's screen. A TUI is structurally never a valid
+  `send_notification` target, no matter how much engineering goes into it —
+  this isn't "not implemented yet," it's "there's nothing to dispatch to."
+
+**Decision: stick with Telegram as the alert channel for now** — nothing
+here needs to change today, and Telegram alone still carries every alert
+unmodified regardless of which harness starts or consults a strategy. The
+point worth carrying forward isn't "switch off Telegram," it's narrower and
+more specific than "make `send_notification` multi-channel across
+harnesses": **separate *interactive harness* from *alert channel* as two
+independent choices, not one**, and worth genericizing precisely *because*
+OpenClaw and Hermes already ship their own messaging adapters — the
+capability to dispatch elsewhere already exists on their side, it's
+Condor's own `send_notification` that's hardcoded to one channel. Route it
+to whichever **persistent, push-capable channel** is configured — which may
+or may not be the same thing as the interactive harness a user is currently
+typing into:
+- OpenClaw's TUI + OpenClaw's own Telegram/Discord/Slack adapter (OpenClaw
+  ships both, per the scheduling research) — TUI for hands-on sessions,
+  channel adapter for alerts, both under one harness.
+- Claude Code's terminal UI has no push-capable channel of its own at all —
+  if Claude Code's terminal is the interactive surface, *something else*
+  (Telegram, email, SMS) still has to carry alerts; there is no in-harness
+  substitute to fall back to.
+- Hermes-agent: same shape as OpenClaw — a cron/gateway process plus its own
+  messaging adapters, separate from however a human is interacting with it
+  at a given moment.
+
+This also reinforces, rather than undermines, `roadmap-v2.md` Phase 2's
+existing decision that Telegram is the hosted customer's access point: even
+in a world where the *interactive* choice moves to a TUI-based harness for
+power users, the *alerting* requirement doesn't move with it — some
+persistent channel is still needed underneath, for exactly the reason a
+hosted, unattended strategy can't rely on someone having a terminal open.
+**Not needed for this spike** — tracked as a `## Follow-ups` item instead.
+
+**Routines are not a general blocker, already solved.** `mm_dashboard.py`
+imports `telegram.ext.ContextTypes` only as a type hint for its `run(config,
+context)` signature — `manage_routines`'s `run_routine` handler already
+constructs a `MCPContext` mock (`mcp_servers/condor/tools/routines.py:146-`
+`162`) instead of a real python-telegram-bot `Context`, using an HTTP-fallback
+bot for any message delivery. This already works identically from any MCP
+caller today — nothing to fix. (Continuous routines *can't* run via MCP at
+all — an explicit `{"error": "... use the Telegram /routines command"}` —
+but `pmm_mister_operator` uses none, so this doesn't affect the spike; noted
+as a known limitation, not something this spike needs to touch.)
+
+## Setup prerequisites
+
+- **Identity — reuse an existing authorized user, don't invent one.**
+  `config_manager`'s permission model (`get_server_permission`/
+  `get_accessible_servers`, `config_manager.py:699-732, 802`) is keyed by
+  `user_id`; an arbitrary new id has no `server_access` entry and
+  `start_agent`'s fallback (`trading_agent.py:367-370`) would resolve to *no*
+  accessible server, silently starting the strategy with no exchange
+  connectivity. Use the same identity already on these files (`created_by:
+  481175164` in both `AGENT.md` and `strategy.md`) as the `--chat-id`/
+  `--user-id` passed to the MCP subprocess.
+- **Server — point at paper/testnet, not `moneymaker` (production).**
+  `pmm_mister_operator`'s default `server_name` resolves to whatever
+  `--server-name` is passed at MCP-server-spawn time (mirroring
+  `build_mcp_servers_for_agent`, `handlers/agents/_shared.py:384-440`, which
+  resolves a server's host/port/username/password via
+  `config_manager.get_server(name)`). For a first spike, use a paper-trading
+  or testnet server config, not the live-capital one — an explicit safety
+  gate, not implied by anything in the code itself.
+- **Per-harness MCP registration** — all three need the same two stdio MCP
+  servers Condor's own sessions already use
+  (`handlers/agents/_shared.py:305-440`), just registered through each
+  harness's own config mechanism instead of Condor's dynamic
+  `build_mcp_servers_for_*`:
+  ```
+  condor:          uv run python -m mcp_servers.condor \
+                     --chat-id <id> --user-id <id> --server-name <paper-server>
+  mcp-hummingbot:  uv run python -m mcp_servers.hummingbot_api \
+                     --url <paper-server-url> --username <u> --password <p> \
+                     --server-name <paper-server>
+  ```
+  - **Claude Code**: add both as `mcpServers` entries (project `.mcp.json` or
+    `claude mcp add`), with `args` including the flags above — same shape as
+    this repo's own `.mcp.json`, just with explicit identity/server flags
+    instead of relying on Condor's session code to inject them via env.
+  - **OpenClaw / Hermes**: same two stdio server definitions, registered
+    through each project's own MCP config surface. Exact config syntax for
+    each is an **open item to verify against their docs at implementation
+    time** — flagged here rather than assumed, consistent with how the
+    scheduling spike (`strategy-engine-and-shared-intelligence.md` §1.6,
+    Hermes' cron registration) already treats its own unverified integration
+    points.
+
+## Test protocol
+
+1. **Fix the stale routine references** in `pmm_mister_operator/strategy.md`
+   (above) before anything else.
+2. **Register both MCP servers** in one harness (start with Claude Code, the
+   easiest to configure) per Setup, pointed at the paper/testnet server.
+3. **Start the strategy in `dry_run` or paper mode**, not `loop` against real
+   capital:
+   ```
+   manage_trading_agent(action="start_agent",
+     strategy_id="market_making_expert.pmm_mister_operator",
+     config={"trading_pair": "SOL-USDT", "connector_name": "<paper-connector>",
+             "execution_mode": "dry_run"})
+   ```
+4. **Verify Tier 2 statehood, the single most important assertion**: close
+   the harness's session/terminal entirely, then reopen it (or open a
+   *second*, independent harness — see step 6) and call `list_agents` /
+   `trading_agent_journal_read` — confirm the strategy is still ticking and
+   its journal has advanced. This is the concrete, observable proof of
+   architecture doc §1.2's claim: Tier 2 state was never tied to the harness
+   that started it.
+5. **Consult and delegate**: from the same harness, `consult(agent=
+   "market_making_expert", task="what's the current regime and inventory
+   status?")` — verify the answer matches what Condor's own Telegram bot
+   would produce for the identical question (same agent definition, same
+   tools, same `tool_preload_hint` behavior for ACP-based harnesses per
+   `build_initial_context`, `handlers/agents/_shared.py:487-519`).
+6. **Cross-harness check**: register the same two MCP servers in a *second*
+   harness (OpenClaw or Hermes), and from there call `list_agents`/`consult`/
+   `stop_agent`/`pause_agent` against the strategy **started in step 3 from
+   Claude Code**. This is the test that most directly answers the spike's
+   stated goal — if a strategy started from one harness is fully visible and
+   controllable from a completely different one, the three-tier
+   architecture's core claim is validated end-to-end, not just in code.
+7. **Stop cleanly**: `stop_agent`/`shutdown_agent` from whichever harness is
+   convenient — verify it matches what the web dashboard's stop button or a
+   Telegram `/stop` does today (same MCP tool, same Tier 2 endpoint
+   underneath — nothing harness-specific to check here beyond "it returns
+   the same way").
+8. **Only after steps 3–7 pass cleanly on paper/dry-run**, consider a short,
+   minimal-size live-capital run as an explicit go/no-go decision — not
+   implied by a clean paper-mode pass. Treat this as a separate approval
+   gate, given real capital is involved.
+
+## Success criteria
+
+- Steps 3–7 all pass with no harness-specific failure (auth, tool-call
+  formatting, timeout, or permission-prompt issues).
+- Step 6 (cross-harness visibility/control) is the load-bearing result: if
+  it passes, Telegram and the web dashboard are demonstrably no longer
+  required for either starting or operating a strategy — only for the
+  interactive-chat and alerting conveniences named in the non-parity gap
+  above.
+- If step 6 fails for a reason **not** explained by this doc's identified
+  gaps (stale routines, Telegram-only notifications), that's a real,
+  previously-unknown parity gap — write it up as a new, concretely-described
+  finding rather than working around it silently, since the point of this
+  spike is to find these before they're discovered by a real hosted
+  customer.
+
+## Follow-ups (not blockers for this spike)
+
+- Genericize `send_notification` to dispatch via whichever **persistent,
+  push-capable channel** is configured, not hardcoded to Telegram's Bot
+  API — worth doing *because* OpenClaw and Hermes already ship their own
+  Telegram/Discord/Slack adapters (the capability already exists on their
+  side; Condor's own tool is the thing hardcoded to one channel), not
+  because Telegram itself needs to go away. Telegram stays the channel for
+  now either way. Explicitly **not** the interactive TUI itself as a
+  target, since a TUI has no mechanism to receive a push when nothing is
+  open — if the interactive harness is Claude Code's terminal specifically,
+  there's no in-harness channel to fall back to at all, so some persistent
+  channel (Telegram or otherwise) is still required regardless of harness
+  choice.
+- If step 6 passes, this spike is the concrete evidence
+  `mcp-first-value-add.md`'s harness-agnostic pitch needs — worth a pointer
+  back from that doc once results are in.
+
+## Results (executed 2026-07-07)
+
+**Safety gate found and fixed before running anything.** Checking this
+environment before starting the strategy: it has exactly one configured
+Hummingbot server (`local`, `config.yml`), and `get_portfolio_overview`
+(read-only) showed it holds **real capital** — ~$1019 across Hyperliquid and
+Backpack, with real open orders. Re-checking `execution_mode="dry_run"`'s
+actual enforcement (`condor/agents/risk.py`, `handlers/agents/_shared.py`)
+against that fact surfaced a real gap: dry-run blocked `manage_executors`/
+`place_order`/gateway actions, but not `manage_bots(deploy)` —
+`pmm_mister_operator`'s actual deployment path — because `manage_bots` wasn't
+in `DANGEROUS_TOOLS` at all. Fixed (`DANGEROUS_BOT_ACTIONS` added, dry-run
+block extended, `BASE_PROMPT_DRY_RUN` updated for defense in depth,
+4 new tests added, all 197 repo tests pass) and filed as
+[hummingbot/condor#151](https://github.com/hummingbot/condor/issues/151)
+before proceeding — this was a prerequisite the spike surfaced, not
+something the spike was looking for.
+
+**Claude Code: fully executed.** A headless `claude -p` session, given a
+scratch `--mcp-config`/`--strict-mcp-config` (kept separate from this repo's
+own `.mcp.json` so the live production bot's config wasn't touched) with
+explicit `--chat-id`/`--user-id 456181693`/`--server-name local`, successfully:
+called `list_agents` against the **live, already-running** Tier 2 backend
+(the same process backing the user's real Telegram bot); started
+`market_making_expert.pmm_mister_operator` with `execution_mode="dry_run"`;
+observed it as `status: "running"` via `list_agents`; and produced a full
+tick transcript (`dry_runs/experiment_1.md`) confirming the routine fix from
+issue #150 actually works end-to-end (`"Running market_analyzer and
+mm_dashboard routines in parallel"`) and that the model behaved correctly —
+narrating "🧪 Would deploy bot `sol-mm`..." conditionally rather than
+attempting a real deploy, consistent with (though, since it never attempted
+the call, not itself proof of) the new dry-run gate above.
+
+**Correction to this doc's own test protocol, discovered empirically**:
+`dry_run`/`run_once` are **one-shot experiment modes**, not persistent loops
+— confirmed by the strategy disappearing from `list_agents` entirely after
+its single tick completed (`engine.py`'s `is_experiment` framing implies
+this, but the spike's step 4, "close the harness, confirm it's still
+ticking," implicitly assumed a persistent strategy). That means step 4's
+actual cross-process-statehood assertion needs `execution_mode="loop"` (or
+a real non-experiment strategy), not `dry_run` — which reintroduces the real-
+capital question above and needs its own explicit go/no-go, not a rerun of
+this same dry-run test.
+
+**OpenClaw: fully executed (second pass, same day).** The first attempt was
+blocked by two local-install issues, both fixed in place: the gateway
+LaunchAgent was installed by an older OpenClaw (2026.3.13 plist vs 2026.6.11
+CLI) and not loaded — `openclaw doctor --repair` bootstrapped it and
+`openclaw gateway install` rewrote the stale plist (status now clean:
+running, probe ok, versions matched); and the earlier
+`ProviderAuthError: No API key found for provider "anthropic"` disappeared
+after the doctor repair migrated the auth profiles into the `main` agent's
+store (`openclaw models status` now shows `anthropic:default static` +
+`google:default static`). The Anthropic profile then failed on **billing**
+(claude.ai "out of extra usage"), so the live turns ran on
+`--model google/gemini-2.5-pro` — incidentally a nice extra data point:
+the Tier 1 harness *and* its model are both swappable without Condor
+noticing. With that, `openclaw agent --local` turns completed the full
+protocol: `list_agents` returned the identical response Claude Code got;
+`start_agent` launched `market_making_expert.pmm_mister_operator_e2` in
+dry_run (observed `status: "running"` in the same turn); and the tick
+completed and wrote `dry_runs/experiment_2.md`, ending with "No executors
+were created (dry run)".
+
+**Cross-harness handoff (step 6): executed and passed.** An agent started
+from headless Claude Code (`..._e4`, session 4) was stopped from OpenClaw
+mid-tick (`stop_agent` → `{"stopped": true}`, then `list_agents` → empty).
+Session numbers interleaved across harnesses within the same backend
+(1 = Claude Code, 2 = OpenClaw, 3 = Claude Code, 4 = Claude Code
+started / OpenClaw stopped) — shared Tier 2 state across harnesses is
+demonstrated, not just argued.
+
+**Architectural correction discovered while verifying who ran the tick**:
+`start_agent`/`stop_agent`/`list_agents` in the Condor MCP server do NOT
+host the TickEngine in the per-harness MCP subprocess — they delegate to
+the persistent main process over its web API
+(`mcp_servers/condor/tools/trading_agent.py`'s `_agent_lifecycle` →
+`call_main_api("POST", "/agents/.../start")`). The engine registry lives in
+`main.py`'s process. This is *stronger* than the doc's original
+harness-invariance argument (ticks are identical across harnesses because
+they all run in the same process, full stop), and it's why the OpenClaw CLI
+exiting mid-tick didn't matter. Two practical consequences: (a) an external
+harness needs the Condor main process up — MCP tools alone don't carry
+Tier 2; (b) **code fixes don't reach Tier 2 until the main process
+restarts** — see follow-ups.
+
+**Consult path (running the market_making_expert as a domain agent):
+executed from OpenClaw and equivalent by construction.** `consult` is the
+same shape as `start_agent`: the MCP tool just forwards to the main process
+(`consult.py` → `call_main_api("POST", "/agents/{agent}/consult")`), so the
+worker runs in `main.py` with the agent's own configured model
+(`claude-acp:sonnet` from AGENT.md), memory, and skills — the calling
+harness's model (gemini in this test) never leaks into the domain agent. A
+live `consult(agent="market_making_expert", ...)` from OpenClaw returned a
+full regime read (ranging, moderate-quieting vol, symmetric 0.05%/0.10%
+spreads, TP floor above round-trip fees) and correctly honored advisory
+mode ("No deployment action warranted") per AGENT.md's consulted-mode
+contract. One integration finding: **OpenClaw's default per-request MCP
+timeout (~60s) is too short for consult/delegate-class tools** (a consult
+runs a full worker session, 1–3 min; the tool's own budget is 180s) — the
+first attempt died with `MCP error -32001: Request timed out`. Fixed by
+registering with `openclaw mcp add condor ... --timeout 240`. This belongs
+in the harness integration guide: long-running Condor tools need the
+client-side MCP timeout raised above 180s.
+
+**Creating agents from OpenClaw (the full agent_builder loop): executed
+and passed.** Beyond running pre-existing agents, the spike's key question —
+can a user *create and run* trading agents from OpenClaw — was validated
+end-to-end with a brand-new agent, entirely via `openclaw agent` turns on
+gemini-2.5-pro:
+
+1. `create_agent` → `funding_rate_watcher` written to
+   `agents/funding_rate_watcher/AGENT.md` with correct frontmatter and
+   `created_by: 456181693` (the MCP identity carried through creation).
+2. `consult(agent="funding_rate_watcher", ...)` → alive on first try:
+   fetched real Hyperliquid funding data and returned a correct
+   domain assessment per its instructions (the agent_builder skill's
+   "prove it's alive" step).
+3. `create_strategy` → `funding_rate_watcher.funding_snapshot`, then
+   `start_agent` with `execution_mode="dry_run"` → observed
+   `status: "running"` with `server_name: "local"`, tick completed,
+   `dry_runs/experiment_1.md` written.
+4. **Routine authoring via the routine_builder agent works from OpenClaw
+   too**: `consult(agent="routine_builder", task="Create a routine named
+   funding_check ...")` produced
+   `agents/funding_rate_watcher/routines/funding_check.py` — the builder
+   read existing routines for patterns, wrote the file, and *tested it
+   itself* before answering. A follow-up
+   `manage_routines(action="run", name="funding_check", ...)` from OpenClaw
+   executed it live (rate −0.0007%/8h, NEUTRAL). The routing rule's
+   "routine authoring goes through routine_builder" contract holds across
+   harnesses because consult itself does.
+
+One model-behavior note, not a Condor issue: in a multi-step turn, gemini
+misread the one-shot dry_run agent's expected self-stop ("agent gone from
+list_agents") as instability and abandoned its remaining steps — worth
+remembering that experiment modes' disappear-after-one-tick behavior can
+confuse a harness model that was told to operate on the agent afterward.
+Single precise-instruction turns had no such problem.
+
+**Second real pre-existing bug found by the spike (harness-independent):
+serverless agent consults/ticks lose their memory/skill scope
+([hummingbot/condor#152](https://github.com/hummingbot/condor/issues/152)).** The
+routine_builder consult above answered "The cookbook skill isn't available"
+— yet `agents/routine_builder/skills/routine_cookbook/` exists and
+`SkillStore('routine_builder')` reads it fine. Root cause:
+`consult.py` passes `agent_slug` to the MCP config only on the
+served branch; the serverless branch (`server_required: false`, which is
+exactly routine_builder) called `build_mcp_servers_for_session()`, which
+had no `agent_slug` parameter at all — so the worker's condor MCP
+subprocess ran with empty `settings.agent_slug` and `manage_skill`/
+`manage_memory` silently resolved to the **chat condor's stores**: the
+agent can't see its own skills, and anything it writes pollutes the chat's
+memory. Same gap in `TickEngine._create_client()` for strategies without
+`server_name`. Fixed: `build_mcp_servers_for_session()` gained an
+`agent_slug` param, both serverless branches now pass the slug, and
+`test_session_mcp_servers_carry_agent_slug` locks it in (also asserting
+chat sessions still get no `--agent-slug`). 201 tests pass. Like the
+routine-name bug (#150), this predates the spike and bites every harness
+including Telegram — the spike just made it visible because the
+routine_builder consult's answer narrated the failed skill read. Verified
+live after a main-process restart: the identical consult that errored with
+"Skill 'routine_cookbook' not found" now reads the skill successfully.
+
+**Hermes: correctly out of scope** — not installed, not attempted, per
+scoping direction partway through this spike.
+
+**Net**: the core claim — Tier 1 harness swap works, Tier 2 execution is
+unaffected — is now validated **end-to-end for both Claude Code and
+OpenClaw**, including the cross-harness handoff, on two different frontier
+models. Nothing Condor-side blocked any step. The remaining open item is
+the `loop`-mode persistence test (below), which is a real-capital go/no-go
+question, not a harness question.
+
+## Follow-ups discovered during execution, not planned in advance
+
+- **hummingbot/condor#151** (dry-run gap) — fixed and merged into this
+  branch's working tree during this spike; see above.
+- **~~RESTART THE MAIN CONDOR PROCESS to activate the #151 fix~~ — DONE
+  (same day).** The `main.py` running since Jul 2 predated the fix and held
+  the old `risk.py`/`prompts.py` in memory — visible in
+  `experiment_2.md`/`experiment_3.md`, whose system prompts show the
+  pre-fix `BASE_PROMPT_DRY_RUN` text (both ticks verified clean — no
+  mutating calls attempted). The user restarted it; a verification dry-run
+  tick (`experiment_4.md`) confirms the new prompt text (and therefore the
+  new code) is live in the backend. Lesson kept for ops: a code fix on disk
+  does not reach Tier 2 until the main process restarts.
+- **The OpenClaw `main` agent's Anthropic auth profile is present but out of
+  claude.ai usage quota** (billing, not a credential gap — the earlier
+  `ProviderAuthError` was resolved by `openclaw doctor --repair`). Turns
+  work on the Google profile; top up or switch the default model if
+  Anthropic-backed OpenClaw turns are wanted. Not a Condor-side task.
+- **A `loop`-mode (or real non-experiment) test still needs to happen** to
+  validate persistent cross-process statehood (this doc's original step 4)
+  — `dry_run`/`run_once` being one-shot means they can't exercise that
+  assertion. Needs its own real-capital-safe design (e.g. a genuinely
+  paper-safe connector, or an explicit tiny-size go/no-go per step 8),
+  separate from the dry-run work done here.
+
+## Proposed redesign (from this spike's findings — NOT implemented, deliberately deferred)
+
+The spike's results suggest a set of architecture changes about what the
+"Condor assistant" even *is* once external harnesses are first-class.
+**Status: proposal only.** Implementation was explicitly deferred — the
+`assistants/` consolidation touches too many surfaces (Telegram handlers,
+web routes, memory paths, the main-process watcher) to bundle with the
+spike, and the spike's key questions don't depend on it.
+
+### 1. The coordinator is not an agent — dissolve `assistants/` into `CONDOR.md`
+
+`agents/` is for agents users build (`market_making_expert` is an example,
+`_defaults` the template). The coordinator is neither consultable nor
+delegatable, holds no strategies, and — as this spike demonstrated —
+ceases to exist entirely on external harnesses, where the harness's own
+main agent plays that role. Modeling it as an agent would mean permanent
+carve-outs (excluded from consult routing, from `manage_trading_agent`,
+from agent_builder flows). Instead:
+
+- **`CONDOR.md` at the repo root** becomes the single source for the
+  coordinator persona. The name is deliberate: `CLAUDE.md`/`AGENTS.md` are
+  harness workspace-instruction conventions and would possess *development*
+  sessions in this repo with the trading persona ("Do NOT explore the
+  codebase" is exactly wrong for a dev session). `CONDOR.md` is loaded only
+  where Condor's own code chooses to load it.
+- **Delete the `assistants/` subsystem**: `discover_assistants`,
+  `_assistant_cache`, `AGENT_MODES`/`normalize_mode`, the separate
+  `main.py` watcher path, and the `paths.py` special case all exist to
+  serve exactly one folder (FEAT-004 already collapsed the modes).
+- "Condor the assistant" = **this repo + its MCP servers, opened from any
+  harness**. The coordinator is emergent behavior, not a runtime object.
+
+### 2. The harness owns the persona; MCP instructions carry only mechanics
+
+`CONDOR.md`'s full persona must NOT ride the MCP server instructions.
+External harnesses have their own identities (OpenClaw's `IDENTITY.md`/
+`SOUL.md`, Claude Code's own persona) and injecting "You are Condor" would
+fight the host. The spike proved the split empirically: gemini-on-OpenClaw
+executed the full protocol correctly having received only the routing rule,
+zero persona. Layering:
+
+- **MCP server instructions** (`_build_instructions()`): coordination
+  mechanics only — routing rule (skill → agent → raw tools),
+  consult/delegate contract, safety rules. Harness-agnostic, identity-free.
+- **`CONDOR.md`**: full persona, loaded only by first-party surfaces
+  (Telegram/web system prompt via `_build_system_prompt()`), where there is
+  no host persona to defer to.
+
+### 3. Skills go harness-native; one canonical directory
+
+Condor's skill format (`<name>/SKILL.md`, `name`/`description`/
+`when_to_use` frontmatter) is already the same shape all three harnesses
+use natively: Claude Code (`.claude/skills/`), OpenClaw (`openclaw skills
+install` from a local dir; ClawHub), Hermes (agentskills.io standard). So:
+
+- Keep **one canonical skills directory** in the repo; expose it natively
+  per harness (symlink into `.claude/skills/`, `openclaw skills install
+  <path>`, drop-in for Hermes). Native progressive disclosure replaces the
+  "call `manage_skill(action='read')` before known flows" instruction and
+  is a strictly better UX.
+- Skill→routine linkage survives untouched: skill bodies instruct MCP calls
+  (`manage_routines(action="run", ...)`), which this spike proved work from
+  any harness.
+- `manage_skill` remains only for surfaces with no native mechanism:
+  first-party Telegram chat and domain agents ticking inside `main.py`
+  (whose agent-scoped skill stores are separate and unaffected).
+
+### 4. One memory store, Condor's — harness-native memory is not Condor's concern
+
+Telegram is just a gateway into whichever brain the user runs (OpenClaw's
+Telegram channel, or Condor's bot fronting `main.py`) — one brain, multiple
+doors, all on the local filesystem where the process runs. So there is no
+multi-brain sync problem and no reason for a memory taxonomy:
+
+- **`manage_memory` stays as the single Condor memory store.** Its
+  consumers are structural, not preference: tick prompts inject it fresh
+  each tick in `main.py`, `get_user_context` serves it, Telegram
+  first-party chat reads it. It is the trading system's memory and lives
+  where the trading system runs. Its home moves out of `assistants/` with
+  the consolidation (repo-root `store/` or `.condor/`).
+- **Harness-native memory is left completely alone** — not integrated, not
+  fought, not documented as a tier. Harnesses jot their own session notes
+  regardless; that's their working memory, invisible to Condor and
+  harmless.
+- One line in the MCP instructions does the routing: "save durable trading
+  facts with `manage_memory`" — the same nudge the tick prompt already
+  contains.

--- a/docs/architecture/mcp-harness-spike.md
+++ b/docs/architecture/mcp-harness-spike.md
@@ -628,7 +628,20 @@ should visibly follow.
 
 Interactive: `cd /path/to/condor && claude` — the repo's own `.mcp.json`
 registers both servers (identity then comes from `CONDOR_CHAT_ID`/
-`CONDOR_USER_ID` env vars, so export those first).
+`CONDOR_USER_ID` env vars, so **export those first** — put them in your
+shell profile; the MCP subprocess inherits Claude Code's environment):
+
+```bash
+export CONDOR_USER_ID=<your registered user id>   # e.g. config.yml's admin_id
+export CONDOR_CHAT_ID=<same id>
+```
+
+**Known failure without them** (hit in QA): `consult`/`delegate`/lifecycle
+calls fail — formerly an opaque `403 Access denied` (the server minted a
+JWT for the default user id 0, which isn't a registered account; same auth
+as the web dashboard). `call_main_api` now fails fast with an error naming
+these env vars. Note this is Condor-user identity, unrelated to the
+hummingbot-api's admin/admin credentials.
 
 Headless / isolated (what this spike used — avoids touching repo state):
 write the two servers into a scratch `qa-mcp.json` (identity as explicit

--- a/docs/architecture/mcp-harness-spike.md
+++ b/docs/architecture/mcp-harness-spike.md
@@ -584,3 +584,168 @@ multi-brain sync problem and no reason for a memory taxonomy:
 - One line in the MCP instructions does the routing: "save durable trading
   facts with `manage_memory`" — the same nudge the tick prompt already
   contains.
+
+## QA instructions: reproducing this spike per harness
+
+Everything below assumes the QA machine has the condor repo checked out and
+working (`uv sync` done, `config.yml` present). All harnesses connect to the
+same two stdio MCP servers, launched **from the repo directory** — `uv run`
+resolves the project venv from the cwd, so either open the harness in the
+repo dir or use `uv run --directory /path/to/condor ...` in the server args.
+
+### Prerequisites (all harnesses)
+
+1. **The Condor main process must be running** (`make run` in the repo dir).
+   Tier 2 lives there: `start_agent`/`stop_agent`/`list_agents`/`consult`
+   all forward to its web API on `127.0.0.1:8088` (`WEB_PORT`). Without it,
+   lifecycle calls return API errors — MCP tools alone do not carry Tier 2.
+   **Corollary: after pulling code changes, restart it** — fixes on disk do
+   not reach the running process (learned twice in this spike).
+2. **A Hummingbot API server** reachable (default `localhost:8000`) and
+   registered in `config.yml`.
+3. **Identity values** — you need three, all from `config.yml`:
+   - `CHAT_ID` / `USER_ID`: a registered user id (e.g. `admin_id`)
+   - `SERVER_NAME`: a server entry name the user can access (e.g. `local`)
+4. ⚠️ **Capital check before anything else**: run a read-only
+   `get_portfolio_overview` and look at what the configured server holds.
+   If it's a live account, use `execution_mode="dry_run"` ONLY, and never
+   `loop`/`run_once`. The dry-run gate blocks `manage_executors`,
+   `manage_bots` mutations, `place_order`, and gateway swaps — but treat it
+   as a seatbelt, not an invitation.
+
+The two servers, in the shape every harness needs (adjust identity):
+
+| server | command | args |
+|---|---|---|
+| `condor` | `uv` | `run python -m mcp_servers.condor --chat-id <CHAT_ID> --user-id <USER_ID> --server-name <SERVER_NAME>` |
+| `mcp-hummingbot` | `uv` | `run python -m mcp_servers.hummingbot_api --url http://localhost:8000 --username <U> --password <P> --server-name <SERVER_NAME>` |
+
+Expected on connect: **12 tools each**. The condor server also delivers
+routing instructions (skill → agent → raw tools) that the harness's agent
+should visibly follow.
+
+### Claude Code — tested ✅
+
+Interactive: `cd /path/to/condor && claude` — the repo's own `.mcp.json`
+registers both servers (identity then comes from `CONDOR_CHAT_ID`/
+`CONDOR_USER_ID` env vars, so export those first).
+
+Headless / isolated (what this spike used — avoids touching repo state):
+write the two servers into a scratch `qa-mcp.json` (identity as explicit
+`--chat-id`/... args), then:
+
+```bash
+claude -p --mcp-config qa-mcp.json --strict-mcp-config \
+  --allowedTools "mcp__condor__manage_trading_agent" \
+  "Call manage_trading_agent with action='list_agents' and report the raw JSON."
+```
+
+### OpenClaw — tested ✅
+
+```bash
+openclaw mcp add condor --command uv \
+  --arg run --arg python --arg -m --arg mcp_servers.condor \
+  --arg --chat-id --arg <CHAT_ID> --arg --user-id --arg <USER_ID> \
+  --arg --server-name --arg <SERVER_NAME> \
+  --cwd /path/to/condor --timeout 240
+openclaw mcp add mcp-hummingbot --command uv \
+  --arg run --arg python --arg -m --arg mcp_servers.hummingbot_api \
+  --arg --url --arg http://localhost:8000 \
+  --arg --username --arg <U> --arg --password --arg <P> \
+  --arg --server-name --arg <SERVER_NAME> \
+  --cwd /path/to/condor --timeout 240
+openclaw mcp probe    # expect: condor: 12 tools; mcp-hummingbot: 12 tools
+openclaw agent --local --agent main --session-key condor-qa \
+  -m "Call manage_trading_agent action='list_agents' and report the raw JSON."
+```
+
+**`--timeout 240` is required, not optional**: OpenClaw's default
+per-request MCP timeout (~60s) kills `consult`/`delegate`-class tools
+(a consult runs a full worker session, 1–3 min; the tool's own budget is
+180s) with `MCP error -32001: Request timed out`.
+
+Gotchas hit during this spike: the `main` agent needs a working model
+credential in its own auth store (`openclaw models status` to check;
+`openclaw doctor --repair` fixed a migration gap here); the gateway
+LaunchAgent may need `openclaw doctor --repair` + `openclaw gateway
+install` after a CLI upgrade (though `--local` embedded runs work without
+the gateway).
+
+### Codex — NOT yet tested, expected shape
+
+Codex reads MCP servers from `~/.codex/config.toml`. There is no per-server
+cwd, so use `uv --directory` to pin the project:
+
+```toml
+[mcp_servers.condor]
+command = "uv"
+args = ["run", "--directory", "/path/to/condor", "python", "-m", "mcp_servers.condor",
+        "--chat-id", "<CHAT_ID>", "--user-id", "<USER_ID>", "--server-name", "<SERVER_NAME>"]
+
+[mcp_servers.mcp-hummingbot]
+command = "uv"
+args = ["run", "--directory", "/path/to/condor", "python", "-m", "mcp_servers.hummingbot_api",
+        "--url", "http://localhost:8000", "--username", "<U>", "--password", "<P>",
+        "--server-name", "<SERVER_NAME>"]
+```
+
+Then run `codex` and drive the same checklist below. Check Codex's MCP
+request timeout — if configurable and < 240s, raise it (same consult issue
+as OpenClaw). Record results in this doc.
+
+### Hermes — NOT yet tested, expected shape
+
+Hermes-agent has first-class MCP client support (auto-reconnect, per-server
+timeouts — see fork-vs-build.md); registration is a one-block
+`mcp_servers:` entry in its config using the same command/args shape as the
+table above (use `uv run --directory /path/to/condor ...` if its config has
+no cwd field). Set its per-server timeout ≥ 240s. Consult Hermes docs for
+the exact config schema; record results in this doc.
+
+### The QA checklist (same for every harness)
+
+Run these in order; each step's expected result is exact:
+
+1. **Connectivity**: both servers connect, 12 tools each.
+2. **Read state**: `manage_trading_agent(action="list_agents")` → valid
+   JSON (`{"agents": [], "message": "No agents running"}` if idle).
+3. **Start**: `action="start_agent"`,
+   `strategy_id="market_making_expert.pmm_mister_operator"`,
+   `config={"execution_mode": "dry_run"}` → `{"started": true,
+   "agent_id": "..._eN"}`. Note: `strategy_id` must be the **full
+   `agent.strategy` key** — a bare `pmm_mister_operator` returns
+   "not found".
+4. **Observe**: immediate `list_agents` → the agent with
+   `status: "running"`, `execution_mode: "dry_run"`. Dry-run is
+   **one-shot**: after ~2–3 min the tick completes, the agent disappears
+   from `list_agents` (this is expected, not instability), and
+   `agents/market_making_expert/strategies/pmm_mister_operator/dry_runs/experiment_N.md`
+   exists, ending with "No executors were created (dry run)".
+5. **Cross-harness**: start another dry_run from harness A, then within
+   ~2 min from harness B: `list_agents` shows it; `stop_agent` with its
+   agent_id → `{"stopped": true}`. (The window is short — script harness
+   A's start so B fires immediately.)
+6. **Consult**: `consult(agent="market_making_expert", task="quick regime
+   read for <pair> on <connector>, advisory only")` → a domain analysis
+   that takes no deploy action. Requires client MCP timeout ≥ 240s.
+7. **Create loop**: `create_agent` (any test slug) → `consult` it (alive?)
+   → `create_strategy` → `start_agent` dry_run → snapshot written under
+   the new agent's dir. Clean up with `delete_strategy`/`delete_agent`.
+8. **Routine authoring**: `consult(agent="routine_builder", task="create a
+   routine named <x> for agent <slug> that ...")` → file appears under
+   `agents/<slug>/routines/`, and the builder's answer shows it read its
+   `routine_cookbook` skill (if it says the cookbook is unavailable, you
+   are running pre-#152 code — restart the main process). Then
+   `manage_routines(action="run", name="<x>",
+   strategy_id="<slug>.<strategy>")` executes it.
+9. **Safety spot-check** (dry_run integrity): during any dry-run tick,
+   `manage_bots(action="status")` before vs after shows no new bot;
+   portfolio unchanged. The tick prompt (visible in the `experiment_N.md`
+   snapshot header) must contain the manage_bots blocking language — if it
+   shows only "Do NOT create or stop executors", the backend is running
+   pre-#151 code; restart it.
+
+**Prompting tip for weaker/looser models**: give one precise tool call per
+turn ("Call manage_trading_agent with EXACTLY these params ... report the
+raw response"). In this spike, a multi-step turn led gemini to misread the
+one-shot agent's expected self-stop as instability and abandon its steps.

--- a/handlers/agents/_shared.py
+++ b/handlers/agents/_shared.py
@@ -228,6 +228,18 @@ BLOCKED_TOOLS: set[str] = set()
 # Actions within manage_executors that require confirmation
 DANGEROUS_EXECUTOR_ACTIONS = {"create", "stop"}
 
+# Actions within manage_bots that deploy/mutate a live bot (status/logs/get_config
+# are read-only and excluded). manage_controllers itself is excluded entirely — it
+# only writes controller templates/saved configs, never a running bot (see its own
+# tool docstring: "Does NOT affect running bots").
+DANGEROUS_BOT_ACTIONS = {
+    "deploy",
+    "stop_bot",
+    "stop_controllers",
+    "start_controllers",
+    "update_config",
+}
+
 # Actions within manage_gateway_swaps that require confirmation
 DANGEROUS_SWAP_ACTIONS = {"execute"}
 
@@ -262,6 +274,13 @@ def is_dangerous_tool_call(tool_call: dict[str, Any]) -> bool:
         input_data = tool_call.get("input", {})
         action = input_data.get("action", "")
         return action in DANGEROUS_EXECUTOR_ACTIONS
+
+    # manage_bots with deploy/stop/update actions (a bot deploy places real
+    # capital via a controller, a different path than manage_executors)
+    if tool_name == "manage_bots":
+        input_data = tool_call.get("input", {})
+        action = input_data.get("action", "")
+        return action in DANGEROUS_BOT_ACTIONS
 
     return False
 
@@ -308,6 +327,7 @@ def build_mcp_servers_for_session(
     user_data: dict | None = None,
     execution_mode: str = "loop",
     server_name: str | None = None,
+    agent_slug: str | None = None,
 ) -> list[dict[str, Any]]:
     """Build dynamic MCP server configs for an agent session.
 
@@ -315,6 +335,13 @@ def build_mcp_servers_for_session(
     that override the static .mcp.json entries by name.
     Always includes the condor MCP server; hummingbot is added when a valid
     server can be resolved for the user.
+
+    ``agent_slug`` scopes the condor MCP tools' memory/skills to that Agent's
+    own stores (``agents/{slug}/``). Without it the tools target the chat
+    condor's stores — correct for chat sessions, wrong for an Agent run: a
+    serverless consult/tick would silently read and write the CHAT's memory
+    and skills instead of the Agent's own (e.g. routine_builder unable to
+    find its routine_cookbook skill).
     """
     from config_manager import get_config_manager, get_effective_server
 
@@ -333,7 +360,7 @@ def build_mcp_servers_for_session(
         "name": "condor",
         "command": "uv",
         "args": ["run", "python", "-m", "mcp_servers.condor"]
-        + _condor_mcp_args(chat_id, user_id, server_name=server_name),
+        + _condor_mcp_args(chat_id, user_id, agent_slug, server_name=server_name),
         "env": [],
     }
 

--- a/handlers/agents/confirmation.py
+++ b/handlers/agents/confirmation.py
@@ -47,6 +47,17 @@ def _format_tool_summary(tool_call: dict[str, Any]) -> str:
             return f"Stop executor {exec_id[:12]}..."
         return f"Executor: {action}"
 
+    if tool_name == "manage_bots":
+        action = input_data.get("action", "?")
+        bot_name = input_data.get("bot_name", "?")
+        if action == "deploy":
+            controllers = input_data.get("controllers_config", [])
+            return f"Deploy bot '{bot_name}' with controllers {controllers}"
+        if action == "update_config":
+            config_name = input_data.get("config_name", "?")
+            return f"Update config '{config_name}' on bot '{bot_name}'"
+        return f"Bot '{bot_name}': {action}"
+
     if tool_name == "manage_gateway_swaps":
         action = input_data.get("action", "?")
         pair = input_data.get("trading_pair", "?")

--- a/mcp_servers/condor/__main__.py
+++ b/mcp_servers/condor/__main__.py
@@ -1,3 +1,10 @@
 from mcp_servers.condor.server import mcp
+from mcp_servers.condor.settings import ensure_identity
+
+# Tier A auto-bind: a harness that registers this server without identity args
+# (e.g. a stock `claude` session using the repo .mcp.json) binds to the sole
+# approved user before any tool call — so memory scoping and main-API auth see
+# the resolved identity from the start.
+ensure_identity()
 
 mcp.run()

--- a/mcp_servers/condor/condor_client.py
+++ b/mcp_servers/condor/condor_client.py
@@ -5,7 +5,7 @@ import re
 import aiohttp
 
 from mcp_servers.condor.exceptions import APIError
-from mcp_servers.condor.settings import settings
+from mcp_servers.condor.settings import ensure_identity, settings
 
 
 async def call_main_api(
@@ -26,15 +26,16 @@ async def call_main_api(
 
     # Without an identity the JWT below is minted for user 0, which is not a
     # registered account — the main process then 403s deep inside the call
-    # (consult/delegate/lifecycle) with an opaque "Access denied". Fail fast
-    # with the actual fix instead.
-    if not settings.user_id:
+    # (consult/delegate/lifecycle) with an opaque "Access denied". Try the
+    # single-user auto-bind first (Tier A), then fail fast with the actual fix.
+    if not settings.user_id and not ensure_identity():
         raise APIError(
-            "Condor MCP server was started without an identity: set the "
-            "CONDOR_USER_ID and CONDOR_CHAT_ID env vars (or pass --user-id/"
-            "--chat-id args) to your registered Condor user id — the same id "
-            "your Telegram bot / web dashboard login uses — then restart the "
-            "MCP session."
+            "Condor MCP server was started without an identity, and auto-bind "
+            "could not resolve one (zero or multiple approved users in "
+            "config.yml): set the CONDOR_USER_ID and CONDOR_CHAT_ID env vars "
+            "(or pass --user-id/--chat-id args) to your registered Condor "
+            "user id — the same id your Telegram bot / web dashboard login "
+            "uses — then restart the MCP session."
         )
 
     url = f"http://127.0.0.1:{WEB_PORT}/api/v1{path}"

--- a/mcp_servers/condor/condor_client.py
+++ b/mcp_servers/condor/condor_client.py
@@ -24,6 +24,19 @@ async def call_main_api(
     from condor.web.auth import create_jwt
     from utils.config import WEB_PORT
 
+    # Without an identity the JWT below is minted for user 0, which is not a
+    # registered account — the main process then 403s deep inside the call
+    # (consult/delegate/lifecycle) with an opaque "Access denied". Fail fast
+    # with the actual fix instead.
+    if not settings.user_id:
+        raise APIError(
+            "Condor MCP server was started without an identity: set the "
+            "CONDOR_USER_ID and CONDOR_CHAT_ID env vars (or pass --user-id/"
+            "--chat-id args) to your registered Condor user id — the same id "
+            "your Telegram bot / web dashboard login uses — then restart the "
+            "MCP session."
+        )
+
     url = f"http://127.0.0.1:{WEB_PORT}/api/v1{path}"
     token = create_jwt(settings.user_id, role="user")
     headers = {"Authorization": f"Bearer {token}"}

--- a/mcp_servers/condor/settings.py
+++ b/mcp_servers/condor/settings.py
@@ -33,3 +33,38 @@ def _parse_settings() -> Settings:
 
 
 settings = _parse_settings()
+
+
+def ensure_identity() -> bool:
+    """Tier A identity auto-bind: resolve a missing identity to the sole
+    approved user in config.yml.
+
+    Resolution order for identity is: CLI args > env vars > this auto-bind.
+    On a single-user install the OS user launching the harness already holds
+    every secret on disk (config.yml, JWT signing secret), so binding to the
+    one approved user adds convenience without changing the trust model — the
+    user id is an identifier here, not a credential. With zero or multiple
+    approved users nothing is bound and callers fail fast with instructions
+    (see ``call_main_api``); a multi-user box must say who it is explicitly.
+
+    Returns True when ``settings`` has an identity after the call.
+    """
+    if settings.user_id:
+        return True
+    try:
+        from config_manager import get_config_manager
+
+        approved = get_config_manager().get_approved_users()
+    except Exception:
+        return False
+    if len(approved) != 1:
+        return False
+    settings.user_id = approved[0]
+    if not settings.chat_id:
+        settings.chat_id = approved[0]
+    import logging
+
+    logging.getLogger(__name__).info(
+        "No identity configured; auto-bound to sole approved user %s", approved[0]
+    )
+    return True

--- a/mcp_servers/condor/settings.py
+++ b/mcp_servers/condor/settings.py
@@ -35,6 +35,14 @@ def _parse_settings() -> Settings:
 settings = _parse_settings()
 
 
+def _config_present() -> bool:
+    """ConfigManager creates a default config.yml when none exists — don't let
+    an identity probe drop a stray config file in an arbitrary cwd."""
+    from pathlib import Path
+
+    return Path("config.yml").exists()
+
+
 def ensure_identity() -> bool:
     """Tier A identity auto-bind: resolve a missing identity to the sole
     approved user in config.yml.
@@ -51,6 +59,8 @@ def ensure_identity() -> bool:
     """
     if settings.user_id:
         return True
+    if not _config_present():
+        return False
     try:
         from config_manager import get_config_manager
 

--- a/mcp_servers/condor/tools/memory.py
+++ b/mcp_servers/condor/tools/memory.py
@@ -6,7 +6,7 @@ LLM never has to report who is writing.
 """
 
 from condor.memory import MemoryStore
-from mcp_servers.condor.settings import settings
+from mcp_servers.condor.settings import ensure_identity, settings
 
 
 def _source() -> str:
@@ -27,6 +27,17 @@ async def manage_memory(
     query: str | None = None,
     max_entries: int = 30,
 ) -> dict:
+    # Memory is resolved by user_id directly (no main-API call to fail on),
+    # so an unresolved identity would silently read/write user 0's store.
+    if not settings.user_id and not ensure_identity():
+        return {
+            "error": "Condor MCP server has no identity, and auto-bind could "
+            "not resolve one (zero or multiple approved users in config.yml) — "
+            "memory would silently target user 0's store. Set the "
+            "CONDOR_USER_ID and CONDOR_CHAT_ID env vars (or pass "
+            "--user-id/--chat-id args) to your registered Condor user id, "
+            "then restart the MCP session."
+        }
     store = _store()
 
     if action == "write":

--- a/scripts/register-openclaw-mcp.sh
+++ b/scripts/register-openclaw-mcp.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+#
+# Register Condor's MCP servers with OpenClaw, if OpenClaw is installed.
+#
+# Run after `uv sync` — `openclaw mcp probe` spawns the servers for real, so
+# the Python deps must already be present.
+#
+# Idempotent: `openclaw mcp set` overwrites an existing entry, unlike `add`
+# which fails when the name is taken.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! command -v openclaw &>/dev/null; then
+    echo "OpenClaw not found on PATH — skipping MCP registration."
+    exit 0
+fi
+
+if [ -f "$REPO_ROOT/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$REPO_ROOT/.env"
+    set +a
+fi
+
+if [ -z "${ADMIN_USER_ID:-}" ] || [ -z "${TELEGRAM_TOKEN:-}" ]; then
+    echo "ADMIN_USER_ID or TELEGRAM_TOKEN unset — run setup-environment.sh first."
+    echo "Skipping MCP registration."
+    exit 0
+fi
+
+echo "Registering Condor MCP servers with OpenClaw..."
+
+# Build the JSON with json.dumps rather than interpolating into a heredoc: a bot
+# token containing a quote or backslash would otherwise corrupt the config.
+#
+# The condor server derives chat_id/user_id per-conversation when Condor spawns
+# it. OpenClaw has no conversation to derive from, so pin it to the admin, whose
+# Telegram DM chat_id equals their user_id.
+condor_json=$(python3 -c '
+import json, sys
+root, admin, token = sys.argv[1:4]
+print(json.dumps({
+    "command": "uv",
+    "args": ["run", "python", "-m", "mcp_servers.condor"],
+    "cwd": root,
+    "env": {
+        "CONDOR_CHAT_ID": admin,
+        "CONDOR_USER_ID": admin,
+        "TELEGRAM_BOT_TOKEN": token,
+    },
+}))' "$REPO_ROOT" "$ADMIN_USER_ID" "$TELEGRAM_TOKEN")
+
+hb_json=$(python3 -c '
+import json, sys
+print(json.dumps({
+    "command": "uv",
+    "args": ["run", "python", "-m", "mcp_servers.hummingbot_api"],
+    "cwd": sys.argv[1],
+    "env": {},
+}))' "$REPO_ROOT")
+
+openclaw mcp set condor "$condor_json"
+openclaw mcp set mcp-hummingbot "$hb_json"
+
+# OpenClaw's claude-cli backend spawns `claude -p` with a hardcoded
+# `--allowedTools mcp__openclaw__*`. That is an exclusive filter, not a
+# permission gate: every mcp__condor__* / mcp__mcp-hummingbot__* tool is
+# stripped from the model's toolset, so a correctly registered server looks
+# like it simply never connected. Widen the allowlist through the supported
+# override at agents.defaults.cliBackends.claude-cli.
+#
+# Upstream fix (openclaw): derive the allowlist from the servers OpenClaw
+# itself bundled into the --mcp-config it generates, instead of the literal.
+widen_allowlist() {
+    local cfg
+    cfg="$(openclaw config file 2>/dev/null || true)"
+    cfg="${cfg/#\~/$HOME}"  # `openclaw config file` prints a ~-prefixed path
+
+    if [ -z "$cfg" ] || [ ! -f "$cfg" ]; then
+        echo "! Could not locate OpenClaw's config — skipping allowlist widening."
+        return 0
+    fi
+
+    local patch rc
+    patch=$(python3 -c '
+import json, os, sys
+
+cfg_path = os.path.expanduser(sys.argv[1])
+WANT = ["mcp__condor__*", "mcp__mcp-hummingbot__*"]
+
+# Launch flags OpenClaw ships for the claude-cli backend. Its mergeBackendConfig
+# does `args: override.args ?? base.args` -- a full replacement, not a merge --
+# so an override has to restate them in full.
+BASE_ARGS = [
+    "-p", "--output-format", "stream-json", "--include-partial-messages",
+    "--verbose", "--setting-sources", "user",
+    "--allowedTools", "mcp__openclaw__*",
+    "--disallowedTools",
+    "ScheduleWakeup,CronCreate,Bash(run_in_background:true),Monitor",
+]
+BASE_RESUME_ARGS = BASE_ARGS + ["--resume", "{sessionId}"]
+
+with open(cfg_path) as fh:
+    cfg = json.load(fh)
+
+backends = cfg.get("agents", {}).get("defaults", {}).get("cliBackends", {})
+override = {}
+for key, entry in backends.items():
+    if key.lower().replace("_", "-") == "claude-cli" and isinstance(entry, dict):
+        override = entry
+        break
+
+def widen(args, base):
+    """Append the Condor patterns to --allowedTools, preserving everything else."""
+    args = list(args) if args else list(base)
+    try:
+        i = args.index("--allowedTools")
+    except ValueError:
+        return None, False
+    if i + 1 >= len(args):
+        return None, False
+    patterns = [p for p in args[i + 1].split(",") if p]
+    added = [p for p in WANT if p not in patterns]
+    if not added:
+        return args, False
+    args[i + 1] = ",".join(patterns + added)
+    return args, True
+
+pinned = not override.get("args")
+new_args, changed_a = widen(override.get("args"), BASE_ARGS)
+new_resume, changed_r = widen(override.get("resumeArgs"), BASE_RESUME_ARGS)
+
+if new_args is None or new_resume is None:
+    sys.exit(2)          # unrecognized override -- do not guess
+if not (changed_a or changed_r):
+    sys.exit(3)          # already widened
+
+# `command` is required by the cliBackends schema even when only args change.
+entry = {"command": override.get("command", "claude"),
+         "args": new_args, "resumeArgs": new_resume}
+print(json.dumps({"agents": {"defaults": {"cliBackends": {"claude-cli": entry}}}}))
+
+# 4 = we had to write the base args wholesale, pinning them.
+sys.exit(4 if pinned else 0)
+' "$cfg" 2>/dev/null) && rc=0 || rc=$?
+
+    if [ "$rc" -eq 3 ]; then
+        echo "OpenClaw already allows Condor's MCP tools."
+        return 0
+    fi
+    if { [ "$rc" -ne 0 ] && [ "$rc" -ne 4 ]; } || [ -z "$patch" ]; then
+        echo "! Could not widen OpenClaw's MCP tool allowlist — Condor's tools may not be callable."
+        echo "  Inspect agents.defaults.cliBackends.claude-cli in $cfg"
+        return 0
+    fi
+    if printf '%s' "$patch" | openclaw config patch --stdin >/dev/null 2>&1; then
+        echo "Widened OpenClaw's MCP tool allowlist for Condor."
+        if [ "$rc" -eq 4 ]; then
+            echo "! This pins claude-cli's launch flags — re-run this script after an OpenClaw upgrade."
+        fi
+    else
+        echo "! Could not write OpenClaw's config — Condor's MCP tools may not be callable."
+    fi
+}
+
+widen_allowlist
+
+if openclaw mcp probe condor && openclaw mcp probe mcp-hummingbot; then
+    echo "Registered. Restart the OpenClaw gateway to load the tools."
+else
+    echo "Registered, but at least one server failed to probe. Check 'openclaw mcp doctor'."
+fi

--- a/scripts/register-openclaw-mcp.sh
+++ b/scripts/register-openclaw-mcp.sh
@@ -35,6 +35,12 @@ echo "Registering Condor MCP servers with OpenClaw..."
 # Build the JSON with json.dumps rather than interpolating into a heredoc: a bot
 # token containing a quote or backslash would otherwise corrupt the config.
 #
+# `uv run` must locate the condor project. The `cwd` field alone is not enough:
+# `openclaw mcp probe` honors it, but the claude CLI ignores it when spawning
+# stdio servers from `--mcp-config`, so uv falls back to its managed interpreter
+# and the server dies with `No module named 'mcp_servers'`. `--directory` pins
+# the project regardless of the spawning process's cwd.
+#
 # The condor server derives chat_id/user_id per-conversation when Condor spawns
 # it. OpenClaw has no conversation to derive from, so pin it to the admin, whose
 # Telegram DM chat_id equals their user_id.
@@ -43,7 +49,7 @@ import json, sys
 root, admin, token = sys.argv[1:4]
 print(json.dumps({
     "command": "uv",
-    "args": ["run", "python", "-m", "mcp_servers.condor"],
+    "args": ["run", "--directory", root, "python", "-m", "mcp_servers.condor"],
     "cwd": root,
     "env": {
         "CONDOR_CHAT_ID": admin,
@@ -54,10 +60,11 @@ print(json.dumps({
 
 hb_json=$(python3 -c '
 import json, sys
+root = sys.argv[1]
 print(json.dumps({
     "command": "uv",
-    "args": ["run", "python", "-m", "mcp_servers.hummingbot_api"],
-    "cwd": sys.argv[1],
+    "args": ["run", "--directory", root, "python", "-m", "mcp_servers.hummingbot_api"],
+    "cwd": root,
     "env": {},
 }))' "$REPO_ROOT")
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -658,3 +658,34 @@ def test_normalize_mode_coerces_legacy_and_unknown():
     # The default mode itself is always valid and preserved.
     assert DEFAULT_MODE in AGENT_MODES
     assert normalize_mode(DEFAULT_MODE) == DEFAULT_MODE
+
+
+def test_session_mcp_servers_carry_agent_slug(monkeypatch):
+    """Serverless agent runs (consult/tick without server_name) must scope the
+    condor MCP tools to the agent's own memory/skills via --agent-slug —
+    without it, routine_builder-style agents silently read/write the CHAT's
+    stores (e.g. 'routine_cookbook not found')."""
+    import config_manager
+
+    from handlers.agents._shared import build_mcp_servers_for_session
+
+    class _NoServers:
+        def get_accessible_servers(self, user_id):
+            return []
+
+        def get_server(self, name):
+            return None
+
+    monkeypatch.setattr(config_manager, "get_config_manager", lambda: _NoServers())
+    monkeypatch.setattr(config_manager, "get_effective_server", lambda *a, **k: None)
+
+    servers = build_mcp_servers_for_session(42, 42, agent_slug="routine_builder")
+    condor = next(s for s in servers if s["name"] == "condor")
+    args = condor["args"]
+    assert "--agent-slug" in args
+    assert args[args.index("--agent-slug") + 1] == "routine_builder"
+
+    # Chat sessions (no agent_slug) keep the chat scope: no --agent-slug arg.
+    servers = build_mcp_servers_for_session(42, 42)
+    condor = next(s for s in servers if s["name"] == "condor")
+    assert "--agent-slug" not in condor["args"]

--- a/tests/test_condor_client.py
+++ b/tests/test_condor_client.py
@@ -25,6 +25,7 @@ def test_call_main_api_fails_fast_without_identity(monkeypatch):
     'Access denied' (the exact failure a stock `claude` session hits with the
     repo's identity-less .mcp.json)."""
     monkeypatch.setattr(condor_client.settings, "user_id", 0)
+    monkeypatch.setattr(settings_module, "_config_present", lambda: True)
     monkeypatch.setattr(
         config_manager, "get_config_manager", lambda: _StubCM([111, 222])
     )
@@ -38,6 +39,7 @@ def test_ensure_identity_auto_binds_sole_approved_user(monkeypatch):
     (user_id and, when unset, chat_id)."""
     monkeypatch.setattr(settings_module.settings, "user_id", 0)
     monkeypatch.setattr(settings_module.settings, "chat_id", 0)
+    monkeypatch.setattr(settings_module, "_config_present", lambda: True)
     monkeypatch.setattr(
         config_manager, "get_config_manager", lambda: _StubCM([456181693])
     )
@@ -50,6 +52,7 @@ def test_ensure_identity_auto_binds_sole_approved_user(monkeypatch):
 def test_ensure_identity_refuses_ambiguous_or_empty(monkeypatch):
     """Zero or multiple approved users: no bind — a multi-user box must say
     who it is explicitly."""
+    monkeypatch.setattr(settings_module, "_config_present", lambda: True)
     for approved in ([], [111, 222]):
         monkeypatch.setattr(settings_module.settings, "user_id", 0)
         monkeypatch.setattr(
@@ -57,6 +60,35 @@ def test_ensure_identity_refuses_ambiguous_or_empty(monkeypatch):
         )
         assert settings_module.ensure_identity() is False
         assert settings_module.settings.user_id == 0
+
+
+def test_ensure_identity_never_creates_a_config_file(monkeypatch):
+    """With no config.yml in cwd, the identity probe must not touch
+    ConfigManager at all — instantiating it would CREATE a default config.yml
+    as a side effect."""
+
+    def _boom():
+        raise AssertionError("ConfigManager must not be instantiated")
+
+    monkeypatch.setattr(settings_module.settings, "user_id", 0)
+    monkeypatch.setattr(settings_module, "_config_present", lambda: False)
+    monkeypatch.setattr(config_manager, "get_config_manager", _boom)
+
+    assert settings_module.ensure_identity() is False
+
+
+def test_manage_memory_fails_fast_without_identity(monkeypatch):
+    """Memory tools resolve the store from user_id directly (no main-API call
+    to 403), so an unresolved identity must return an actionable error instead
+    of silently reading/writing user 0's store."""
+    from mcp_servers.condor.tools.memory import manage_memory
+
+    monkeypatch.setattr(settings_module.settings, "user_id", 0)
+    monkeypatch.setattr(settings_module, "_config_present", lambda: True)
+    monkeypatch.setattr(config_manager, "get_config_manager", lambda: _StubCM([]))
+
+    result = asyncio.run(manage_memory(action="list"))
+    assert "CONDOR_USER_ID" in result["error"]
 
 
 def test_ensure_identity_keeps_explicit_identity(monkeypatch):

--- a/tests/test_condor_client.py
+++ b/tests/test_condor_client.py
@@ -1,0 +1,19 @@
+"""Tests for the MCP-server → main-process HTTP client."""
+
+import asyncio
+
+import pytest
+
+from mcp_servers.condor import condor_client
+from mcp_servers.condor.exceptions import APIError
+
+
+def test_call_main_api_fails_fast_without_identity(monkeypatch):
+    """An MCP server started with no --user-id/CONDOR_USER_ID must raise a
+    clear, actionable error instead of minting a JWT for user 0 and letting
+    the main process 403 with an opaque 'Access denied' (the exact failure a
+    stock `claude` session hits with the repo's identity-less .mcp.json)."""
+    monkeypatch.setattr(condor_client.settings, "user_id", 0)
+
+    with pytest.raises(APIError, match="CONDOR_USER_ID"):
+        asyncio.run(condor_client.call_main_api("GET", "/agents"))

--- a/tests/test_condor_client.py
+++ b/tests/test_condor_client.py
@@ -1,19 +1,69 @@
-"""Tests for the MCP-server → main-process HTTP client."""
+"""Tests for the MCP-server → main-process HTTP client and identity auto-bind."""
 
 import asyncio
 
 import pytest
 
+import config_manager
 from mcp_servers.condor import condor_client
+from mcp_servers.condor import settings as settings_module
 from mcp_servers.condor.exceptions import APIError
 
 
+class _StubCM:
+    def __init__(self, approved):
+        self._approved = approved
+
+    def get_approved_users(self):
+        return self._approved
+
+
 def test_call_main_api_fails_fast_without_identity(monkeypatch):
-    """An MCP server started with no --user-id/CONDOR_USER_ID must raise a
-    clear, actionable error instead of minting a JWT for user 0 and letting
-    the main process 403 with an opaque 'Access denied' (the exact failure a
-    stock `claude` session hits with the repo's identity-less .mcp.json)."""
+    """With no identity AND an ambiguous config (multiple approved users),
+    call_main_api must raise a clear, actionable error instead of minting a
+    JWT for user 0 and letting the main process 403 with an opaque
+    'Access denied' (the exact failure a stock `claude` session hits with the
+    repo's identity-less .mcp.json)."""
     monkeypatch.setattr(condor_client.settings, "user_id", 0)
+    monkeypatch.setattr(
+        config_manager, "get_config_manager", lambda: _StubCM([111, 222])
+    )
 
     with pytest.raises(APIError, match="CONDOR_USER_ID"):
         asyncio.run(condor_client.call_main_api("GET", "/agents"))
+
+
+def test_ensure_identity_auto_binds_sole_approved_user(monkeypatch):
+    """Tier A: exactly one approved user in config.yml → bind identity to it
+    (user_id and, when unset, chat_id)."""
+    monkeypatch.setattr(settings_module.settings, "user_id", 0)
+    monkeypatch.setattr(settings_module.settings, "chat_id", 0)
+    monkeypatch.setattr(
+        config_manager, "get_config_manager", lambda: _StubCM([456181693])
+    )
+
+    assert settings_module.ensure_identity() is True
+    assert settings_module.settings.user_id == 456181693
+    assert settings_module.settings.chat_id == 456181693
+
+
+def test_ensure_identity_refuses_ambiguous_or_empty(monkeypatch):
+    """Zero or multiple approved users: no bind — a multi-user box must say
+    who it is explicitly."""
+    for approved in ([], [111, 222]):
+        monkeypatch.setattr(settings_module.settings, "user_id", 0)
+        monkeypatch.setattr(
+            config_manager, "get_config_manager", lambda a=approved: _StubCM(a)
+        )
+        assert settings_module.ensure_identity() is False
+        assert settings_module.settings.user_id == 0
+
+
+def test_ensure_identity_keeps_explicit_identity(monkeypatch):
+    """An explicitly configured identity is never overridden by auto-bind."""
+    monkeypatch.setattr(settings_module.settings, "user_id", 999)
+    monkeypatch.setattr(
+        config_manager, "get_config_manager", lambda: _StubCM([456181693])
+    )
+    assert settings_module.ensure_identity() is True
+    assert settings_module.settings.user_id == 999

--- a/tests/test_confirmation.py
+++ b/tests/test_confirmation.py
@@ -1,0 +1,29 @@
+"""Unit tests for the human-readable confirmation-prompt formatter."""
+
+from handlers.agents.confirmation import _format_tool_summary
+
+
+def _bot_call(action: str, **extra) -> dict:
+    return {"tool": "manage_bots", "input": {"action": action, **extra}}
+
+
+def test_format_manage_bots_deploy():
+    summary = _format_tool_summary(
+        _bot_call("deploy", bot_name="mm-bot", controllers_config=["cfg_a"])
+    )
+    assert "mm-bot" in summary
+    assert "cfg_a" in summary
+
+
+def test_format_manage_bots_update_config():
+    summary = _format_tool_summary(
+        _bot_call("update_config", bot_name="mm-bot", config_name="cfg_a")
+    )
+    assert "mm-bot" in summary
+    assert "cfg_a" in summary
+
+
+def test_format_manage_bots_stop_bot():
+    summary = _format_tool_summary(_bot_call("stop_bot", bot_name="mm-bot"))
+    assert "mm-bot" in summary
+    assert "stop_bot" in summary

--- a/tests/test_jwt_secret_multiprocess.py
+++ b/tests/test_jwt_secret_multiprocess.py
@@ -1,0 +1,79 @@
+"""Cross-process web JWT secret consistency (config_manager + condor/web/auth).
+
+Several processes share config.yml — the main bot plus each MCP subprocess —
+and each holds its own ConfigManager snapshot loaded at startup. These tests
+cover the split-brain failure where a process whose snapshot predates the
+secret generated its own and clobbered the file, invalidating every JWT the
+sibling processes signed (surfaced as opaque 401 "Invalid token" on consult).
+"""
+
+import pytest
+from jose import jwt
+
+import condor.web.auth as auth
+from config_manager import ConfigManager
+
+
+@pytest.fixture
+def two_managers(tmp_path, monkeypatch):
+    """Two ConfigManager instances over the same config file — one per
+    simulated process. ``stale`` loads its snapshot before the file has a
+    secret; ``fresh`` is used to interact with the file afterwards."""
+    monkeypatch.delenv("WEB_JWT_SECRET", raising=False)
+    path = tmp_path / "config.yml"
+    path.write_text("users: {}\n")
+    stale = ConfigManager(str(path))
+    fresh = ConfigManager(str(path))
+    yield stale, fresh
+    ConfigManager.reset_instance()
+
+
+def test_get_or_create_adopts_secret_persisted_by_sibling(two_managers):
+    """A snapshot without the secret must adopt the on-disk one, not mint a
+    second secret and clobber the sibling's via _save_config."""
+    stale, fresh = two_managers
+
+    sibling_secret = fresh.get_or_create_web_jwt_secret()
+    assert sibling_secret
+
+    assert stale.get_or_create_web_jwt_secret() == sibling_secret
+
+
+def test_get_or_create_still_generates_when_disk_has_none(two_managers):
+    """First-ever caller still generates and persists a secret."""
+    stale, fresh = two_managers
+
+    secret = stale.get_or_create_web_jwt_secret()
+    assert secret
+    # Persisted: the other snapshot adopts it rather than generating anew.
+    assert fresh.get_or_create_web_jwt_secret() == secret
+
+
+def test_decode_jwt_heals_from_stale_snapshot_secret(two_managers, monkeypatch):
+    """decode_jwt must accept a token signed with the on-disk secret even when
+    this process's snapshot holds an outdated one (refresh-and-retry)."""
+    stale, fresh = two_managers
+
+    # This process cached secret A; a sibling later rotated the file to B and
+    # signed its tokens with B.
+    stale._data["web_jwt_secret"] = "secret-A-cached-before-rotation"
+    fresh._data["web_jwt_secret"] = None
+    rotated = fresh.get_or_create_web_jwt_secret()
+    token = jwt.encode({"sub": "1"}, rotated, algorithm=auth._ALGORITHM)
+
+    monkeypatch.setattr(auth, "get_config_manager", lambda: stale)
+    payload = auth.decode_jwt(token)
+    assert payload is not None and payload["sub"] == "1"
+    # The refresh also repaired the snapshot for future create_jwt calls.
+    assert stale._data["web_jwt_secret"] == rotated
+
+
+def test_decode_jwt_still_rejects_garbage(two_managers, monkeypatch):
+    """The refresh-and-retry path must not turn invalid tokens into valid ones."""
+    stale, _fresh = two_managers
+    stale.get_or_create_web_jwt_secret()
+
+    monkeypatch.setattr(auth, "get_config_manager", lambda: stale)
+    assert auth.decode_jwt("not-a-jwt") is None
+    wrong = jwt.encode({"sub": "1"}, "wrong-secret", algorithm=auth._ALGORITHM)
+    assert auth.decode_jwt(wrong) is None

--- a/tests/test_risk_gate.py
+++ b/tests/test_risk_gate.py
@@ -202,9 +202,15 @@ def test_dry_run_allows_manage_bots_status():
     assert result["outcome"]["outcome"] == "selected"
 
 
-def test_loop_mode_still_auto_approves_manage_bots_deploy():
-    """Outside dry_run, manage_bots(deploy) is unaffected by this fix (pre-existing
-    behavior — no risk-engine coverage for bot deploys yet, tracked separately)."""
+# ---------------------------------------------------------------------------
+# loop mode: manage_bots(deploy) is risk-gated on a declared loss cap — the
+# capital lives in saved controller configs on the API server, so the deploy
+# must carry a max_global_drawdown_quote bounded by the position limit.
+# ---------------------------------------------------------------------------
+
+
+def test_loop_mode_blocks_bot_deploy_without_loss_cap():
+    """A deploy with no declared max_global_drawdown_quote is blocked."""
     engine = RiskEngine(RiskLimits())
     state = RiskState()
     callback = auto_approve_with_risk_check(engine, state, execution_mode="loop")
@@ -212,4 +218,90 @@ def test_loop_mode_still_auto_approves_manage_bots_deploy():
     result = asyncio.run(
         callback(_bot_call("deploy", bot_name="x", controllers_config=["cfg"]), _OPTIONS)
     )
+    assert result["outcome"]["outcome"] == "cancelled"
+
+
+def test_loop_mode_approves_bot_deploy_with_bounded_loss_cap():
+    engine = RiskEngine(RiskLimits(max_position_size_quote=500.0))
+    state = RiskState()
+    callback = auto_approve_with_risk_check(engine, state, execution_mode="loop")
+
+    result = asyncio.run(
+        callback(
+            _bot_call(
+                "deploy",
+                bot_name="x",
+                controllers_config=["cfg"],
+                max_global_drawdown_quote=400.0,
+            ),
+            _OPTIONS,
+        )
+    )
+    assert result["outcome"]["outcome"] == "selected"
+
+
+def test_loop_mode_blocks_bot_deploy_with_excessive_loss_cap():
+    engine = RiskEngine(RiskLimits(max_position_size_quote=500.0))
+    state = RiskState()
+    callback = auto_approve_with_risk_check(engine, state, execution_mode="loop")
+
+    result = asyncio.run(
+        callback(
+            _bot_call(
+                "deploy",
+                bot_name="x",
+                controllers_config=["cfg"],
+                max_global_drawdown_quote=5000.0,
+            ),
+            _OPTIONS,
+        )
+    )
+    assert result["outcome"]["outcome"] == "cancelled"
+
+
+def test_loop_mode_blocks_update_config_raising_amount_beyond_limit():
+    engine = RiskEngine(RiskLimits(max_position_size_quote=500.0))
+    state = RiskState()
+    callback = auto_approve_with_risk_check(engine, state, execution_mode="loop")
+
+    result = asyncio.run(
+        callback(
+            _bot_call(
+                "update_config",
+                bot_name="x",
+                config_name="cfg",
+                config_data={"total_amount_quote": 900.0},
+            ),
+            _OPTIONS,
+        )
+    )
+    assert result["outcome"]["outcome"] == "cancelled"
+
+
+def test_loop_mode_approves_update_config_within_limit():
+    engine = RiskEngine(RiskLimits(max_position_size_quote=500.0))
+    state = RiskState()
+    callback = auto_approve_with_risk_check(engine, state, execution_mode="loop")
+
+    result = asyncio.run(
+        callback(
+            _bot_call(
+                "update_config",
+                bot_name="x",
+                config_name="cfg",
+                config_data={"total_amount_quote": 300.0},
+            ),
+            _OPTIONS,
+        )
+    )
+    assert result["outcome"]["outcome"] == "selected"
+
+
+def test_loop_mode_still_approves_bot_stop():
+    """Stops are risk-reducing — never blocked by the loss-cap gate."""
+    engine = RiskEngine(RiskLimits())
+    state = RiskState()
+    callback = auto_approve_with_risk_check(engine, state, execution_mode="loop")
+
+    result = asyncio.run(callback(_bot_call("stop_bot", bot_name="x"), _OPTIONS))
     assert result["outcome"]["outcome"] == "selected"

--- a/tests/test_risk_gate.py
+++ b/tests/test_risk_gate.py
@@ -159,3 +159,57 @@ def test_callback_cumulative_exposure_cancelled_same_tick():
     first, second = asyncio.run(_drive())
     assert first["outcome"]["outcome"] == "selected"
     assert second["outcome"]["outcome"] == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# dry_run must block manage_bots deploy/mutate actions too, not just
+# manage_executors/place_order/gateway swaps — manage_bots(deploy) places real
+# capital via a controller-based bot, a separate path from manage_executors.
+# ---------------------------------------------------------------------------
+
+
+def _bot_call(action: str, **extra) -> dict:
+    return {"tool": "mcp__mcp-hummingbot__manage_bots", "input": {"action": action, **extra}}
+
+
+def test_dry_run_blocks_manage_bots_deploy():
+    engine = RiskEngine(RiskLimits())
+    state = RiskState()
+    callback = auto_approve_with_risk_check(engine, state, execution_mode="dry_run")
+
+    result = asyncio.run(
+        callback(_bot_call("deploy", bot_name="x", controllers_config=["cfg"]), _OPTIONS)
+    )
+    assert result["outcome"]["outcome"] == "cancelled"
+
+
+def test_dry_run_blocks_manage_bots_update_config():
+    engine = RiskEngine(RiskLimits())
+    state = RiskState()
+    callback = auto_approve_with_risk_check(engine, state, execution_mode="dry_run")
+
+    result = asyncio.run(callback(_bot_call("update_config", bot_name="x"), _OPTIONS))
+    assert result["outcome"]["outcome"] == "cancelled"
+
+
+def test_dry_run_allows_manage_bots_status():
+    """Read-only manage_bots actions must not be blocked in dry_run."""
+    engine = RiskEngine(RiskLimits())
+    state = RiskState()
+    callback = auto_approve_with_risk_check(engine, state, execution_mode="dry_run")
+
+    result = asyncio.run(callback(_bot_call("status"), _OPTIONS))
+    assert result["outcome"]["outcome"] == "selected"
+
+
+def test_loop_mode_still_auto_approves_manage_bots_deploy():
+    """Outside dry_run, manage_bots(deploy) is unaffected by this fix (pre-existing
+    behavior — no risk-engine coverage for bot deploys yet, tracked separately)."""
+    engine = RiskEngine(RiskLimits())
+    state = RiskState()
+    callback = auto_approve_with_risk_check(engine, state, execution_mode="loop")
+
+    result = asyncio.run(
+        callback(_bot_call("deploy", bot_name="x", controllers_config=["cfg"]), _OPTIONS)
+    )
+    assert result["outcome"]["outcome"] == "selected"


### PR DESCRIPTION
## Summary

Condor can now be driven end-to-end from external MCP harnesses — validated live with **Claude Code** and **OpenClaw** against a running backend. This PR ships the bug fixes that validation (and its self-review) surfaced, the validation write-up, and a per-harness QA guide so the same checks can be run for Codex.

📄 **Spike doc (validation methodology, results, QA guide, identity plan):** [`docs/architecture/mcp-harness-spike.md`](https://github.com/hummingbot/condor/blob/spike/mcp-harness-validation/docs/architecture/mcp-harness-spike.md)

## What was validated (live, both harnesses)

- **Strategy lifecycle**: `list_agents` / `start_agent` / `stop_agent`, including a cross-harness handoff — a strategy started from Claude Code, stopped from OpenClaw mid-tick. Session numbering interleaves across harnesses in one shared backend.
- **Agent creation**: `create_agent` → consult-alive → `create_strategy` → dry-run tick with snapshot, entirely from OpenClaw.
- **Consults**: domain agents (`market_making_expert`) return identical behavior regardless of the calling harness or its model — workers always run on their own configured model inside the main process.
- **Routine authoring**: `consult(agent="routine_builder", ...)` from OpenClaw wrote, self-tested, and executed a new routine.

Architectural confirmation underpinning all of it: `start_agent`/`consult` forward to the persistent main process via its web API, so tick/consult execution is harness-invariant **by construction** — the harness is only ever a front door.

## Bug fixes

1. **#150 — stale routine references**: `pmm_mister_operator/strategy.md` called two routines that no longer exist (`portfolio_scanner`, `bot_position_tracker`); every tick errored on Step 1. Swapped for `mm_dashboard` (their documented consolidation); verified in a live dry-run transcript.
2. **#151 — dry_run didn't block bot deployment**: an agent in "observation only" mode could deploy a live bot with real capital via `manage_bots(deploy)` — only `manage_executors`/`place_order`/gateway paths were gated. Added `DANGEROUS_BOT_ACTIONS`, extended the dry-run gate in `risk.py`, updated `BASE_PROMPT_DRY_RUN` (defense in depth), and taught the confirmation-prompt formatter to name the bot/config being touched instead of showing a bare tool name.
3. **#151's live-mode sibling (found in this PR's self-review)**: in `loop` mode, `manage_bots(deploy)` was auto-approved with **no** risk-engine check, while `manage_executors(create)` is exposure-gated. Since a bot's capital lives in saved controller configs on the API server — not in the tool call — the new `RiskEngine.check_bot_action` bounds the *loss* instead: a deploy must declare `max_global_drawdown_quote` ≤ the strategy's `max_position_size_quote`, and `update_config` can't raise `total_amount_quote` above that limit. The live prompt and strategy doc instruct the model to include the cap.
4. **#152 — serverless agents lost their memory/skill scope**: agents with `server_required: false` (e.g. `routine_builder`) got no `--agent-slug` in their MCP subprocess during consults and ticks, so `manage_skill`/`manage_memory` silently targeted the **chat's** stores. `build_mcp_servers_for_session()` gains `agent_slug`; both serverless call sites (`consult.py`, `engine.py`) now pass it. Verified live: the consult that errored "Skill 'routine_cookbook' not found" now succeeds.

#150/#151/#152 predate this work and affect Telegram users too — the harness validation just made them visible.

## Identity across harnesses (added after QA feedback)

QA hit an opaque `403 Access denied` driving consult/delegate from a stock `claude` session — the repo's identity-less `.mcp.json` left the MCP server minting a JWT for user 0. Fixed in layers, with the longer-term plan in the spike doc ("Identity across harnesses: the tiered plan"):

- **Tier A (this PR)**: with no identity configured, the MCP server auto-binds to the sole approved user in `config.yml` — single-user installs just work with zero setup. Ambiguous configs (0 or 2+ users) fail fast with an error naming the exact fix (`CONDOR_USER_ID`/`CONDOR_CHAT_ID` env or `--user-id`/`--chat-id` args). No trust change: the JWT secret lives on the same filesystem, so the id was never a credential locally. Hardened after self-review: the fail-fast also covers the **memory tools** (which resolve their store from `user_id` directly and would otherwise silently target user 0's store), and the identity probe never *creates* a `config.yml` in an arbitrary cwd.
- **Tier B (later, at real multi-user-on-one-box)**: `condor init` pairing with a stored credential the API actually verifies.
- **Tier C (only when Tier 2 leaves the machine — hosted/cloud)**: OAuth 2.1 per the MCP authorization spec, which harnesses already support natively for remote MCP servers.

## Docs

[`docs/architecture/mcp-harness-spike.md`](https://github.com/hummingbot/condor/blob/spike/mcp-harness-validation/docs/architecture/mcp-harness-spike.md) — trimmed to stand alone (no references to uncommitted strategy docs; speculative side-routes removed):

- The validation methodology, full execution results, and integration findings (e.g. OpenClaw's default MCP timeout kills consult-class tools; raise to ≥240s).
- **Per-harness QA instructions**: exact setup + a 9-step checklist with expected results for Claude Code and OpenClaw (tested), and the expected config shape for Codex (pending QA).
- A **proposed, not implemented** redesign section (dissolve `assistants/` into a root `CONDOR.md`, harness-native skills, single memory store) — recorded for discussion, deliberately deferred.

## Tests

**212 pass** (was 193 on main). New coverage: the dry-run `manage_bots` gate, the loop-mode loss-cap gate (block/approve on deploy and update_config, stops stay approved), the confirmation formatter, `--agent-slug` scoping (asserting chat sessions still get none), identity fail-fast + Tier A auto-bind, the no-config-file-creation guard, and the memory-tool identity guard.

## Notes for reviewers

- Operational: fixes reach the running backend only after a `main.py` restart (recorded in #151/#152 and in the QA prerequisites).
- Live-mode strategies that deploy bots must now declare `max_global_drawdown_quote` on deploy (blocked otherwise) — `pmm_mister_operator`'s instructions were updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Z4fTytfgSEufp5XTBrYPH
