### PR TITLE
Hyperliquid WalletConnect: agent-wallet connect via MCP tool + Telegram /keys button

### DIFF
--- a/condor/walletconnect.py
+++ b/condor/walletconnect.py
@@ -5,9 +5,25 @@ subprocess, for the same reason delegations are (see
 ``mcp_servers/condor/condor_client.py``): state must survive beyond a single MCP
 tool call. All WalletConnect protocol / EIP-712 signing logic lives in the Node
 sidecar script (``walletconnect_bridge/bridge.mjs``); this module just spawns it,
-reads its newline-delimited JSON events off stdout, and -- once both signatures
-land -- saves the resulting agent-wallet credential the same way the browser
-"Connect Hyperliquid" flow does (see ``frontend/src/lib/wallet/hyperliquid.ts``).
+reads its newline-delimited JSON events off stdout, and -- once a signature lands
+-- either saves the resulting agent-wallet credential (agent step) or just
+confirms (builder step), the same way the browser "Connect Hyperliquid" flow does
+(see ``frontend/src/lib/wallet/hyperliquid.ts``).
+
+The flow is two independent steps, each its own fresh WalletConnect pairing
+(fresh QR / fresh MetaMask deep link) rather than one session driving both
+signatures back to back -- a fresh pairing reliably foregrounds the wallet app;
+a second request sent to an already-paired-but-backgrounded session doesn't
+always prompt it:
+
+  1. "agent"   -- pair, confirm the wallet address, sign ApproveAgent, save the
+                  resulting credential.
+  2. "builder" -- pair again (same wallet -- verified, see
+                  walletconnect_bridge/bridge.mjs), sign ApproveBuilderFee.
+                  Skipped entirely if the connected address already approved
+                  at least Condor's builder fee on-chain (checked via
+                  Hyperliquid's public info endpoint, no signature needed for
+                  the check itself).
 
 See docs/architecture/hyperliquid-walletconnect-spike.md for the design writeup.
 """
@@ -21,6 +37,9 @@ import os
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
+from urllib.parse import quote
+
+import httpx
 
 logger = logging.getLogger(__name__)
 
@@ -37,10 +56,81 @@ def generate_qr_png(uri: str) -> bytes:
     qrcode.make(uri).save(buf, format="PNG")
     return buf.getvalue()
 
+
+# MetaMask is the only wallet Condor currently builds a deep-link button for: it's
+# the only one of the wallets we support with a `mobile.universal` (https://) link
+# in the WalletConnect registry, which Telegram's InlineKeyboardButton requires
+# (its `url` field only accepts http(s)/tg://, not native app schemes like
+# `rabby://`).
+_DEEP_LINK_WALLET_SEARCH_TERMS = ["metamask"]
+
+_wallet_universal_links: dict[str, str] | None = None
+
+
+async def _get_wallet_universal_links() -> dict[str, str]:
+    """{"MetaMask": "https://metamask.app.link", ...} fetched once from the
+    WalletConnect Explorer registry and cached for the process lifetime -- this is
+    wallet-directory metadata, not per-session state, and essentially never changes,
+    so there's no reason to refetch it on every connect. Fetching (rather than
+    hardcoding these URLs) means a wallet renaming/changing its universal link
+    domain doesn't silently break the button."""
+    global _wallet_universal_links
+    if _wallet_universal_links is not None:
+        return _wallet_universal_links
+
+    project_id = os.environ["WALLETCONNECT_PROJECT_ID"]
+    links: dict[str, str] = {}
+
+    async def _fetch_one(client: httpx.AsyncClient, term: str) -> None:
+        try:
+            resp = await client.get(
+                "https://explorer-api.walletconnect.com/v3/wallets",
+                params={"projectId": project_id, "search": term, "entries": 1},
+            )
+            resp.raise_for_status()
+            for entry in resp.json().get("listings", {}).values():
+                universal = (entry.get("mobile") or {}).get("universal")
+                if universal:
+                    links[entry["name"]] = universal
+                break
+        except Exception:
+            logger.warning("Failed to fetch WalletConnect mobile link for %r", term, exc_info=True)
+
+    async with httpx.AsyncClient(timeout=5) as client:
+        await asyncio.gather(*[_fetch_one(client, term) for term in _DEEP_LINK_WALLET_SEARCH_TERMS])
+
+    _wallet_universal_links = links
+    return links
+
+
+# Mirrors walletconnect_bridge/bridge.mjs's BUILDER_ADDRESS / BUILDER_MAX_FEE_RATE.
+# Used only to check whether the connected address already approved Condor's
+# builder fee on-chain (a plain, unsigned info-endpoint read), so the "approve
+# builder fee" step can be skipped for a returning user -- no need to spawn Node
+# for this, it's a single unauthenticated HTTP call.
+_BUILDER_ADDRESS = "0x10ba451e6439efc6a17dc20d21121aa838100705"
+_BUILDER_MAX_FEE_RATE_TENTHS_BPS = 10  # "0.01%" == 1 bps == 10 tenths-of-a-bp
+_HL_INFO_URL = "https://api.hyperliquid.xyz/info"
+
+
+async def _get_builder_approval_tenths_bps(main_address: str) -> int:
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.post(
+            _HL_INFO_URL,
+            json={"type": "maxBuilderFee", "user": main_address, "builder": _BUILDER_ADDRESS},
+        )
+        resp.raise_for_status()
+        return int(resp.json())
+
+
 BRIDGE_SCRIPT = Path(__file__).resolve().parent.parent / "walletconnect_bridge" / "bridge.mjs"
 
 _URI_TIMEOUT = 20  # seconds to wait for the bridge to hand back a pairing URI
 _SESSION_TTL = 15 * 60  # seconds a finished/errored session's status is kept around
+# "step_done" (agent step finished, builder step optionally pending) is kept around
+# much longer -- the user may come back and tap "Continue" well after the fact,
+# and the agent credential is already saved by that point regardless.
+_STEP_DONE_TTL = 24 * 60 * 60
 
 
 @dataclass
@@ -48,7 +138,9 @@ class _Session:
     session_id: str
     server_name: str
     user_id: int
-    process: asyncio.subprocess.Process
+    step: str = "agent"  # "agent" | "builder" -- which step the current/last subprocess ran
+    process: asyncio.subprocess.Process | None = None
+    main_address: str | None = None
     status: dict = field(default_factory=lambda: {"status": "starting"})
 
 
@@ -106,7 +198,9 @@ _EVENT_PREFIX = "CONDOR_WC_EVENT "  # must match walletconnect_bridge/bridge.mjs
 
 
 async def _drain(session: _Session) -> None:
-    """Background task: read the bridge's stdout line by line and update status.
+    """Background task: read the current step's bridge subprocess stdout line by
+    line and update status. A new one of these is started every time a step's
+    subprocess is (re)spawned -- see ``_spawn_step``.
 
     The bridge's own dependencies (e.g. @walletconnect/sign-client's internal
     logger) can write unrelated lines to stdout, so only lines carrying our
@@ -114,9 +208,10 @@ async def _drain(session: _Session) -> None:
     ignored rather than logged as a warning, since it's expected noise, not a
     sign anything is wrong.
     """
-    assert session.process.stdout is not None
+    process = session.process
+    assert process is not None and process.stdout is not None
     try:
-        async for raw in session.process.stdout:
+        async for raw in process.stdout:
             line = raw.decode().strip()
             if not line.startswith(_EVENT_PREFIX):
                 continue
@@ -128,54 +223,82 @@ async def _drain(session: _Session) -> None:
 
             kind = evt.get("event")
             if kind == "uri":
-                session.status = {"status": "pending_approval", "uri": evt["uri"]}
+                session.status = {"status": "pending_approval", "uri": evt["uri"], "step": session.step}
             elif kind == "approved":
-                session.status = {"status": "pending_signatures", "main_address": evt["mainAddress"]}
+                session.main_address = evt["mainAddress"]
+                session.status = {"status": "pending_signature", "step": session.step, "main_address": evt["mainAddress"]}
             elif kind == "done":
-                try:
-                    save_result = await _save_credentials(session, evt["mainAddress"], evt["agentPrivateKey"])
-                    session.status = {
-                        "status": "done",
-                        "main_address": evt["mainAddress"],
-                        "agent_address": evt["agentAddress"],
-                        **save_result,
-                    }
-                except Exception as e:
-                    # The signature already happened and can't be replayed -- surface the
-                    # real cause (e.g. the hummingbot-api server being unreachable) instead
-                    # of letting it fall through to the generic "process exited
-                    # unexpectedly" message below, which would hide what actually failed.
-                    session.status = {
-                        "status": "error",
-                        "message": (
-                            f"Signed successfully (agent {evt['agentAddress']} authorized "
-                            f"for {evt['mainAddress']}) but failed to save the credential "
-                            f"to '{session.server_name}': {e}. The signature can't be "
-                            "reused -- reconnect to try again."
-                        ),
-                    }
+                if session.step == "agent":
+                    await _handle_agent_done(session, evt)
+                else:
+                    session.status = {"status": "done", "step": "builder", "main_address": evt["mainAddress"]}
             elif kind == "error":
                 session.status = {"status": "error", "message": evt.get("message", "Unknown bridge error.")}
     finally:
-        await session.process.wait()
-        if session.status.get("status") not in ("done", "error"):
+        await process.wait()
+        state = session.status.get("status")
+        if state not in ("done", "error", "step_done"):
+            # The process exited without ever emitting a terminal event -- a crash.
             stderr = b""
-            if session.process.stderr is not None:
-                stderr = await session.process.stderr.read()
+            if process.stderr is not None:
+                stderr = await process.stderr.read()
             session.status = {
                 "status": "error",
                 "message": (
-                    f"Bridge process exited unexpectedly (code {session.process.returncode}): "
+                    f"Bridge process exited unexpectedly (code {process.returncode}): "
                     f"{stderr.decode(errors='replace')[-2000:]}"
                 ),
             }
-        # Keep the terminal status around for _SESSION_TTL so a slow poller still sees it,
-        # then drop the session so the in-memory registry doesn't grow unbounded.
-        await asyncio.sleep(_SESSION_TTL)
-        _sessions.pop(session.session_id, None)
+            state = "error"
+
+        ttl = _SESSION_TTL if state in ("done", "error") else _STEP_DONE_TTL
+        await asyncio.sleep(ttl)
+        # Only clean up if nothing has advanced the session in the meantime (e.g.
+        # the user tapped "Continue" and a new step's subprocess/_drain task took
+        # over) -- otherwise this stale task would rip out a still-live session.
+        if session.status.get("status") == state:
+            _sessions.pop(session.session_id, None)
 
 
-async def start_walletconnect_session(server_name: str, user_id: int) -> dict:
+async def _handle_agent_done(session: _Session, evt: dict) -> None:
+    try:
+        save_result = await _save_credentials(session, evt["mainAddress"], evt["agentPrivateKey"])
+    except Exception as e:
+        # The signature already happened and can't be replayed -- surface the
+        # real cause (e.g. the hummingbot-api server being unreachable) instead
+        # of letting it fall through to the generic "process exited
+        # unexpectedly" message, which would hide what actually failed.
+        session.status = {
+            "status": "error",
+            "message": (
+                f"Signed successfully (agent {evt['agentAddress']} authorized "
+                f"for {evt['mainAddress']}) but failed to save the credential "
+                f"to '{session.server_name}': {e}. The signature can't be "
+                "reused -- reconnect to try again."
+            ),
+        }
+        return
+
+    needs_builder_step = True
+    try:
+        approved = await _get_builder_approval_tenths_bps(evt["mainAddress"])
+        needs_builder_step = approved < _BUILDER_MAX_FEE_RATE_TENTHS_BPS
+    except Exception:
+        # Can't confirm either way -- default to offering the step rather than
+        # silently skipping a builder-fee approval the user might actually need.
+        logger.warning("Failed to check existing Hyperliquid builder-fee approval for %s", evt["mainAddress"], exc_info=True)
+
+    session.status = {
+        "status": "step_done",
+        "step": "agent",
+        "main_address": evt["mainAddress"],
+        "agent_address": evt["agentAddress"],
+        "needs_builder_step": needs_builder_step,
+        **save_result,
+    }
+
+
+async def _spawn_step(session: _Session, step: str, extra_argv: list[str]) -> dict:
     if not os.environ.get("WALLETCONNECT_PROJECT_ID"):
         raise RuntimeError(
             "WALLETCONNECT_PROJECT_ID is not set. Get a free project id at "
@@ -184,17 +307,23 @@ async def start_walletconnect_session(server_name: str, user_id: int) -> dict:
     if not BRIDGE_SCRIPT.exists():
         raise RuntimeError(f"WalletConnect bridge script not found at {BRIDGE_SCRIPT}")
 
-    session_id = uuid.uuid4().hex[:12]
-    process = await asyncio.create_subprocess_exec(
+    session.step = step
+    session.status = {"status": "starting", "step": step}
+    session.process = await asyncio.create_subprocess_exec(
         "node",
         str(BRIDGE_SCRIPT),
+        step,
+        *extra_argv,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         cwd=str(BRIDGE_SCRIPT.parent),
     )
-    session = _Session(session_id=session_id, server_name=server_name, user_id=user_id, process=process)
-    _sessions[session_id] = session
     asyncio.create_task(_drain(session))
+
+    # Runs concurrently with the relay handshake below so it adds no latency to the
+    # common case (only the very first session per process pays the registry fetch --
+    # every session after that hits the cache).
+    wallet_links_task = asyncio.create_task(_get_wallet_universal_links())
 
     for _ in range(_URI_TIMEOUT * 10):
         if session.status.get("status") != "starting":
@@ -202,8 +331,13 @@ async def start_walletconnect_session(server_name: str, user_id: int) -> dict:
         await asyncio.sleep(0.1)
 
     if session.status.get("status") == "pending_approval":
-        return {"session_id": session_id, "uri": session.status["uri"]}
+        uri = session.status["uri"]
+        links = await wallet_links_task
+        encoded = quote(uri, safe="")
+        deep_links = {name: f"{base}/wc?uri={encoded}" for name, base in links.items()}
+        return {"session_id": session.session_id, "uri": uri, "deep_links": deep_links, "step": step}
     if session.status.get("status") == "error":
+        wallet_links_task.cancel()
         raise RuntimeError(session.status["message"])
 
     # Neither a uri nor an error arrived in time -- the bridge has its own internal
@@ -211,8 +345,31 @@ async def start_walletconnect_session(server_name: str, user_id: int) -> dict:
     # shouldn't happen, but don't leave a stuck subprocess (and the _drain task
     # reading its stdout) running forever if it somehow does.
     session.process.kill()
-    _sessions.pop(session_id, None)
+    _sessions.pop(session.session_id, None)
     raise RuntimeError("Timed out waiting for the WalletConnect bridge to produce a pairing URI.")
+
+
+async def start_walletconnect_session(server_name: str, user_id: int) -> dict:
+    """Begins the flow: pairs, confirms the wallet address, and signs ApproveAgent
+    (step "agent"). Returns {session_id, uri, deep_links, step}."""
+    session_id = uuid.uuid4().hex[:12]
+    session = _Session(session_id=session_id, server_name=server_name, user_id=user_id)
+    _sessions[session_id] = session
+    return await _spawn_step(session, "agent", [])
+
+
+async def advance_walletconnect_session(session_id: str, user_id: int) -> dict:
+    """Continues a session whose agent step finished and needs the builder-fee
+    approval step: pairs again (fresh QR/link) and signs ApproveBuilderFee."""
+    session = _sessions.get(session_id)
+    if session is None or session.user_id != user_id:
+        raise RuntimeError("Unknown or expired WalletConnect session -- start again from /keys.")
+    status = session.status
+    if status.get("status") != "step_done" or not status.get("needs_builder_step"):
+        raise RuntimeError("This session has nothing left to approve.")
+    if not session.main_address:
+        raise RuntimeError("Missing the connected wallet address -- reconnect from /keys.")
+    return await _spawn_step(session, "builder", [session.main_address])
 
 
 async def get_session_status(session_id: str, user_id: int) -> dict | None:

--- a/condor/walletconnect.py
+++ b/condor/walletconnect.py
@@ -1,0 +1,209 @@
+"""WalletConnect session registry for the Hyperliquid agent-wallet connect flow (spike).
+
+Sessions are spawned and tracked here (in the main process) rather than in the MCP
+subprocess, for the same reason delegations are (see
+``mcp_servers/condor/condor_client.py``): state must survive beyond a single MCP
+tool call. All WalletConnect protocol / EIP-712 signing logic lives in the Node
+sidecar script (``walletconnect_bridge/bridge.mjs``); this module just spawns it,
+reads its newline-delimited JSON events off stdout, and -- once both signatures
+land -- saves the resulting agent-wallet credential the same way the browser
+"Connect Hyperliquid" flow does (see ``frontend/src/lib/wallet/hyperliquid.ts``).
+
+See docs/architecture/hyperliquid-walletconnect-spike.md for the design writeup.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+BRIDGE_SCRIPT = Path(__file__).resolve().parent.parent / "walletconnect_bridge" / "bridge.mjs"
+
+_URI_TIMEOUT = 20  # seconds to wait for the bridge to hand back a pairing URI
+_SESSION_TTL = 15 * 60  # seconds a finished/errored session's status is kept around
+
+
+@dataclass
+class _Session:
+    session_id: str
+    server_name: str
+    user_id: int
+    process: asyncio.subprocess.Process
+    status: dict = field(default_factory=lambda: {"status": "starting"})
+
+
+_sessions: dict[str, _Session] = {}
+
+
+def _build_hyperliquid_credentials(main_address: str, agent_private_key: str) -> dict[str, dict[str, str]]:
+    """Mirrors ``buildHyperliquidCredentials`` in frontend/src/lib/wallet/hyperliquid.ts."""
+    return {
+        "hyperliquid_perpetual": {
+            "hyperliquid_perpetual_mode": "api_wallet",
+            "use_vault": "false",
+            "hyperliquid_perpetual_address": main_address,
+            "hyperliquid_perpetual_secret_key": agent_private_key,
+        },
+        "hyperliquid": {
+            "hyperliquid_mode": "api_wallet",
+            "use_vault": "false",
+            "hyperliquid_address": main_address,
+            "hyperliquid_secret_key": agent_private_key,
+        },
+    }
+
+
+async def _save_credentials(session: _Session, main_address: str, agent_private_key: str) -> dict:
+    """Save both connectors, tolerating a partial failure (mirrors the browser
+    flow's Promise.allSettled behavior in ConnectHyperliquid.tsx)."""
+    from config_manager import get_config_manager
+    from condor.server_data_service import ServerDataType, get_server_data_service
+
+    cm = get_config_manager()
+    client = await cm.get_client(session.server_name)
+    creds = _build_hyperliquid_credentials(main_address, agent_private_key)
+
+    async def _add(connector_name: str, credentials: dict) -> tuple[str, str | None]:
+        try:
+            await client.accounts.add_credential(
+                account_name="master_account",
+                connector_name=connector_name,
+                credentials=credentials,
+            )
+            return connector_name, None
+        except Exception as e:
+            return connector_name, str(e)
+
+    results = await asyncio.gather(*[_add(name, c) for name, c in creds.items()])
+    get_server_data_service().invalidate(session.server_name, ServerDataType.CONNECTORS)
+
+    saved = [name for name, err in results if err is None]
+    failed = {name: err for name, err in results if err is not None}
+    return {"saved_connectors": saved, "failed_connectors": failed}
+
+
+_EVENT_PREFIX = "CONDOR_WC_EVENT "  # must match walletconnect_bridge/bridge.mjs's EVENT_PREFIX
+
+
+async def _drain(session: _Session) -> None:
+    """Background task: read the bridge's stdout line by line and update status.
+
+    The bridge's own dependencies (e.g. @walletconnect/sign-client's internal
+    logger) can write unrelated lines to stdout, so only lines carrying our
+    marker prefix are treated as protocol events -- everything else is quietly
+    ignored rather than logged as a warning, since it's expected noise, not a
+    sign anything is wrong.
+    """
+    assert session.process.stdout is not None
+    try:
+        async for raw in session.process.stdout:
+            line = raw.decode().strip()
+            if not line.startswith(_EVENT_PREFIX):
+                continue
+            try:
+                evt = json.loads(line[len(_EVENT_PREFIX) :])
+            except json.JSONDecodeError:
+                logger.warning("walletconnect bridge %s: unparseable event line: %s", session.session_id, line)
+                continue
+
+            kind = evt.get("event")
+            if kind == "uri":
+                session.status = {"status": "pending_approval", "uri": evt["uri"]}
+            elif kind == "approved":
+                session.status = {"status": "pending_signatures", "main_address": evt["mainAddress"]}
+            elif kind == "done":
+                try:
+                    save_result = await _save_credentials(session, evt["mainAddress"], evt["agentPrivateKey"])
+                    session.status = {
+                        "status": "done",
+                        "main_address": evt["mainAddress"],
+                        "agent_address": evt["agentAddress"],
+                        **save_result,
+                    }
+                except Exception as e:
+                    # The signature already happened and can't be replayed -- surface the
+                    # real cause (e.g. the hummingbot-api server being unreachable) instead
+                    # of letting it fall through to the generic "process exited
+                    # unexpectedly" message below, which would hide what actually failed.
+                    session.status = {
+                        "status": "error",
+                        "message": (
+                            f"Signed successfully (agent {evt['agentAddress']} authorized "
+                            f"for {evt['mainAddress']}) but failed to save the credential "
+                            f"to '{session.server_name}': {e}. The signature can't be "
+                            "reused -- reconnect to try again."
+                        ),
+                    }
+            elif kind == "error":
+                session.status = {"status": "error", "message": evt.get("message", "Unknown bridge error.")}
+    finally:
+        await session.process.wait()
+        if session.status.get("status") not in ("done", "error"):
+            stderr = b""
+            if session.process.stderr is not None:
+                stderr = await session.process.stderr.read()
+            session.status = {
+                "status": "error",
+                "message": (
+                    f"Bridge process exited unexpectedly (code {session.process.returncode}): "
+                    f"{stderr.decode(errors='replace')[-2000:]}"
+                ),
+            }
+        # Keep the terminal status around for _SESSION_TTL so a slow poller still sees it,
+        # then drop the session so the in-memory registry doesn't grow unbounded.
+        await asyncio.sleep(_SESSION_TTL)
+        _sessions.pop(session.session_id, None)
+
+
+async def start_walletconnect_session(server_name: str, user_id: int) -> dict:
+    if not os.environ.get("WALLETCONNECT_PROJECT_ID"):
+        raise RuntimeError(
+            "WALLETCONNECT_PROJECT_ID is not set. Get a free project id at "
+            "https://cloud.reown.com and set it in the environment."
+        )
+    if not BRIDGE_SCRIPT.exists():
+        raise RuntimeError(f"WalletConnect bridge script not found at {BRIDGE_SCRIPT}")
+
+    session_id = uuid.uuid4().hex[:12]
+    process = await asyncio.create_subprocess_exec(
+        "node",
+        str(BRIDGE_SCRIPT),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=str(BRIDGE_SCRIPT.parent),
+    )
+    session = _Session(session_id=session_id, server_name=server_name, user_id=user_id, process=process)
+    _sessions[session_id] = session
+    asyncio.create_task(_drain(session))
+
+    for _ in range(_URI_TIMEOUT * 10):
+        if session.status.get("status") != "starting":
+            break
+        await asyncio.sleep(0.1)
+
+    if session.status.get("status") == "pending_approval":
+        return {"session_id": session_id, "uri": session.status["uri"]}
+    if session.status.get("status") == "error":
+        raise RuntimeError(session.status["message"])
+
+    # Neither a uri nor an error arrived in time -- the bridge has its own internal
+    # timeout on the relay handshake (see walletconnect_bridge/bridge.mjs), so this
+    # shouldn't happen, but don't leave a stuck subprocess (and the _drain task
+    # reading its stdout) running forever if it somehow does.
+    session.process.kill()
+    _sessions.pop(session_id, None)
+    raise RuntimeError("Timed out waiting for the WalletConnect bridge to produce a pairing URI.")
+
+
+async def get_session_status(session_id: str, user_id: int) -> dict | None:
+    session = _sessions.get(session_id)
+    if session is None or session.user_id != user_id:
+        return None
+    return {"session_id": session_id, **session.status}

--- a/condor/walletconnect.py
+++ b/condor/walletconnect.py
@@ -24,6 +24,19 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+
+def generate_qr_png(uri: str) -> bytes:
+    """PNG bytes for a scannable QR of `uri`. Shared by every surface that
+    delivers a WalletConnect pairing (Telegram's /keys button, the MCP tool)
+    so QR generation lives in exactly one place."""
+    import io
+
+    import qrcode
+
+    buf = io.BytesIO()
+    qrcode.make(uri).save(buf, format="PNG")
+    return buf.getvalue()
+
 BRIDGE_SCRIPT = Path(__file__).resolve().parent.parent / "walletconnect_bridge" / "bridge.mjs"
 
 _URI_TIMEOUT = 20  # seconds to wait for the bridge to hand back a pairing URI

--- a/condor/web/routes/settings.py
+++ b/condor/web/routes/settings.py
@@ -437,3 +437,35 @@ async def delete_credential(
         return {"deleted": True, "result": result}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+# ── WalletConnect (Hyperliquid agent-wallet connect, spike) ──
+
+
+@router.post("/walletconnect/hyperliquid")
+async def start_hyperliquid_walletconnect(
+    server: str = Query(...),
+    user: WebUser = Depends(get_current_user),
+):
+    cm = get_config_manager()
+    if not cm.has_server_access(user.id, server):
+        raise HTTPException(status_code=403, detail="No access")
+    from condor.walletconnect import start_walletconnect_session
+
+    try:
+        return await start_walletconnect_session(server, user.id)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/walletconnect/hyperliquid/{session_id}")
+async def get_hyperliquid_walletconnect(
+    session_id: str,
+    user: WebUser = Depends(get_current_user),
+):
+    from condor.walletconnect import get_session_status
+
+    result = await get_session_status(session_id, user.id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Unknown session_id")
+    return result

--- a/condor/web/routes/settings.py
+++ b/condor/web/routes/settings.py
@@ -469,3 +469,16 @@ async def get_hyperliquid_walletconnect(
     if result is None:
         raise HTTPException(status_code=404, detail="Unknown session_id")
     return result
+
+
+@router.post("/walletconnect/hyperliquid/{session_id}/advance")
+async def advance_hyperliquid_walletconnect(
+    session_id: str,
+    user: WebUser = Depends(get_current_user),
+):
+    from condor.walletconnect import advance_walletconnect_session
+
+    try:
+        return await advance_walletconnect_session(session_id, user.id)
+    except RuntimeError as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/docs/architecture/hyperliquid-walletconnect-spike.md
+++ b/docs/architecture/hyperliquid-walletconnect-spike.md
@@ -1,0 +1,260 @@
+# Spike: WalletConnect onboarding for Hyperliquid, triggerable from an MCP tool
+
+## Context
+
+Condor already has a browser-only Hyperliquid "connect" flow
+(`frontend/src/components/settings/ConnectHyperliquid.tsx` +
+`frontend/src/lib/wallet/hyperliquid.ts`): it generates a throwaway agent
+("API wallet") keypair, has the user sign `ApproveAgent` and
+`ApproveBuilderFee` EIP-712 messages with their own wallet, then saves the
+agent key as the `hyperliquid`/`hyperliquid_perpetual` credentials. The
+user's master private key never leaves their wallet — the security
+motivation behind the original "WalletConnect onboarding" GitHub issue is
+already solved for desktop-extension users.
+
+Two real gaps remain, and this spike targets both:
+
+1. **Desktop-extension-only.** Wallet discovery is EIP-6963 (MetaMask/Rabby
+   browser extensions). There's no WalletConnect/Reown integration anywhere
+   in the repo, so a user with only a mobile wallet can't connect.
+2. **Dashboard-only.** The flow is unreachable from chat — no MCP tool or
+   skill can trigger it, so it can't be started from Claude Code or from
+   Condor's own Telegram bot.
+
+## Goal
+
+Prove the mechanism end-to-end for **one flow only** (Hyperliquid
+agent-wallet + builder-fee approval): an MCP tool starts a WalletConnect
+session, the user approves two signatures on their phone, and the resulting
+agent-wallet credentials land in `master_account` exactly like the existing
+browser flow.
+
+Explicitly out of scope for the spike: referral code linking, partial-failure
+retry UX, session cleanup/expiry polish, automated tests — those are
+refinements once the mechanism is proven.
+
+## Gateway vs. a Condor-owned sidecar
+
+Considered hosting the WalletConnect route in `hummingbot/gateway`
+(checked out locally at `~/gateway`, branch `feat/solana-router-connectors`)
+instead of a new Condor-owned Node process, since Gateway is already a
+Node/TS service Condor manages (start/stop/config via
+`mcp_servers/hummingbot_api/tools/gateway.py`, `GatewaySettings.tsx`). Looked
+closely and it's a worse fit than it first appears:
+
+- **No CEX precedent.** Gateway's whole taxonomy is `src/chains/` (ethereum,
+  solana only) + `src/connectors/` (Uniswap, Jupiter, Orca, etc. — all
+  on-chain DEX/AMM routers). Even OKX, which has a real CEX API, is only
+  wired for its on-chain router in Gateway. A Hyperliquid agent-wallet
+  *authorization* route is a CEX-credential concern, architecturally foreign
+  to "middleware for blockchain networks and DEXs" (Gateway's own README
+  description). It'd be the first route of its kind.
+- **The one thing Gateway is good at here doesn't apply.** Gateway's real
+  wallet infrastructure is its encrypted-keystore-at-rest (`ethers` V3
+  keystore, `conf/wallets/<chain>/<address>.json`, unlocked by one
+  server-wide passphrase set at process start — `src/wallet/utils.ts`,
+  `src/chains/ethereum/ethereum.ts`). This flow doesn't want that at all —
+  the resulting agent key is meant to flow to Condor/hummingbot-api's own
+  credential store, exactly like the existing browser flow, not live in
+  Gateway's keystore. So the part of Gateway that's actually mature doesn't
+  get used.
+- **No real code reuse.** `ethers`/`viem` are dependencies, but grepping
+  Gateway's source found **zero** existing EIP-712 (`signTypedData`) call
+  sites anywhere in `src/` — only plain `signMessage` (`src/wallet/utils.ts`).
+  The typed-data builders would be new code in Gateway just as much as in a
+  Condor sidecar; "already has the libraries installed" is a much smaller
+  benefit than "already solved this problem."
+- **Wrong request shape.** Every existing Gateway route (Fastify,
+  `src/wallet/wallet.routes.ts` pattern) is fire-and-return — RPC calls,
+  quote fetches. Nothing blocks on external human interaction, and there's
+  no start/poll (job-id) pattern to build on — this flow needs one either
+  way, so building it in Gateway doesn't save that design work either.
+- **Gateway's future is uncertain** — it may be deprecated. Sinking a
+  first-of-its-kind, non-trivial piece of infrastructure (WalletConnect
+  relay client + a new blocking/job request lifecycle + a new CEX-shaped
+  route category) into a service that might go away is a bad bet for a
+  spike — if Gateway is deprecated, this flow would need to be re-migrated
+  onto Condor's own credential path anyway, which is where the durable logic
+  (`add_credential`, `master_account`) already lives regardless.
+
+**Generic vs. Hyperliquid-specific split.** The objections above are weaker
+if Gateway hosted only a *generic* capability — "pair with a mobile wallet,
+sign this typed-data payload I hand you" — instead of a Hyperliquid-specific
+route. A generic WalletConnect-signing primitive is a much better fit for
+`src/wallet/` (sibling to `addWallet`/`removeWallet`/`getWallets`, just
+another way to connect a wallet) than a CEX-approval route would be; the
+Hyperliquid-specific bits (ApproveAgent/ApproveBuilderFee payload
+construction, submitting to Hyperliquid's `/exchange`, credential mapping)
+would stay in Condor regardless of where the pairing/signing lives. But
+going generic doesn't reduce the case for Gateway — it raises the bar:
+
+- An endpoint that signs *any* typed-data payload a caller hands it is a
+  materially larger attack surface than one that only ever signs two
+  hardcoded Hyperliquid messages. It needs its own scoping/allowlist design
+  that a narrow flow doesn't — that's new security work, not saved work.
+- There's no second consumer today. Nobody's asked for generic
+  WalletConnect signing outside this one Hyperliquid use case; building the
+  reusable version now is speculative generality for a spike.
+- The relay-client/job-lifecycle work — the actual hard part — is identical
+  either way, so genericizing doesn't save the thing that's expensive to
+  build. It only changes who's exposed if Gateway is deprecated: a
+  "platform primitive" there is a bigger sunk cost to lose than a one-off
+  script.
+
+**Decision: keep it Condor-owned** (the `walletconnect_bridge/` sidecar
+below), narrow and Hyperliquid-specific — not a generic signing service.
+The overlap with Gateway is superficial — same runtime (Node), different
+problem shape — and Condor is the repo whose lifetime this bet should
+track. If a second real consumer of generic WalletConnect signing shows up
+later, this is small enough to extract into a proper primitive then —
+possibly in Gateway, possibly not, decided with actual second-use-case
+evidence instead of speculation now.
+
+## Key architecture decision: Node sidecar, not Python WalletConnect
+
+`pyproject.toml` has no `eth_account`, `web3`, or `msgpack`, and there is no
+mature, actively maintained Python SDK for WalletConnect v2's Sign API
+(relay pairing + encrypted JSON-RPC). Re-implementing that protocol in
+Python is the single biggest risk in this proposal and isn't worth taking on
+for a spike. Node v24 is already available on the host, and the exact
+EIP-712 payload builders we need already exist and work in
+`frontend/src/lib/wallet/hyperliquid.ts` (`buildApproveAgentTypedData`,
+`buildApproveBuilderFeeTypedData`, `signAndSubmit`), built on `viem` (already
+a frontend dependency).
+
+So: **a small standalone Node script does all WalletConnect + signing work**,
+driven by the Python main process over stdin/stdout JSON lines. Python never
+touches private keys or the WC protocol — it just starts the subprocess,
+relays commands, and calls the existing `add_credential` path once it gets
+signatures back.
+
+External prerequisite (not something I can provision): a free WalletConnect
+Cloud (Reown) `projectId`. Wire it through an env var
+(`WALLETCONNECT_PROJECT_ID`) and fail fast with a clear error if unset —
+flag this before running the manual verification step.
+
+## Implementation
+
+### 0. Branch
+
+First step, before touching any files: `git checkout -b spike/hyperliquid-walletconnect`
+(stacked on `spike/mcp-harness-validation`).
+
+### 1. `walletconnect_bridge/` — new Node subprocess (new directory)
+
+A small script (`bridge.mjs` + minimal `package.json` with
+`@walletconnect/sign-client` and `viem`) that, per invocation:
+
+- Ports `buildApproveAgentTypedData` / `buildApproveBuilderFeeTypedData` /
+  `BUILDER_ADDRESS` / `BUILDER_MAX_FEE_RATE` verbatim from
+  `frontend/src/lib/wallet/hyperliquid.ts` (same constants, same domain —
+  duplicated intentionally for a spike; unifying into a shared package is a
+  follow-up, not spike scope).
+- Generates the agent keypair itself (`viem/accounts`, same as the frontend
+  does), so Python never sees the raw agent private key mid-flight.
+- Opens a WalletConnect pairing on `eip155:42161` (Arbitrum One — matches
+  Hyperliquid's signing domain, so no explicit chain-switch step is needed
+  the way the browser flow needs `ensureChain`).
+- Prints one JSON line per lifecycle event to stdout: `{"event":"uri", "uri":"wc:..."}`,
+  `{"event":"approved"}`, then drives the two `eth_signTypedData_v4` requests
+  and submits `approveAgent`/`approveBuilderFee` to Hyperliquid's
+  `/exchange` endpoint itself (reusing `signAndSubmit`'s logic), finally
+  `{"event":"done", "mainAddress":..., "agentAddress":..., "agentPrivateKey":...}`
+  or `{"event":"error", "message":...}`.
+
+### 2. `condor/walletconnect.py` — main-process session registry (new file)
+
+Mirrors why delegations live in the main process
+(`mcp_servers/condor/condor_client.py`'s comment: subprocess-owned state
+doesn't survive beyond the MCP subprocess). A small class that:
+
+- `start()`: spawns `walletconnect_bridge/bridge.mjs` via
+  `asyncio.create_subprocess_exec`, reads the first `uri` event, stores the
+  process + latest status in an in-memory dict keyed by a generated
+  `session_id`, returns `{session_id, uri}`.
+- `status(session_id)`: returns the last-seen event for that session
+  (non-blocking — a background task keeps draining the subprocess's stdout
+  into the stored status as events arrive).
+- On `done`, calls the same credential-save logic as `add_credential` in
+  `condor/web/routes/settings.py` (`client.accounts.add_credential` for both
+  `hyperliquid` and `hyperliquid_perpetual`, reusing
+  `buildHyperliquidCredentials`'s field mapping from `wallet/hyperliquid.ts`
+  ported to a plain dict).
+
+### 3. `condor/web/routes/settings.py` — two new routes
+
+- `POST /settings/walletconnect/hyperliquid` → `cm.get_client(server)` +
+  `walletconnect.start()` → `{session_id, uri}`.
+- `GET /settings/walletconnect/hyperliquid/{session_id}` →
+  `walletconnect.status(session_id)`, triggering the credential save on
+  first transition to `done`.
+
+Same auth/access pattern as the existing `add_credential` route
+(`user: WebUser = Depends(get_current_user)`, `cm.has_server_access`).
+
+### 4. `mcp_servers/condor/tools/wallet_connect.py` — new MCP tool (new file)
+
+Modeled directly on `mcp_servers/condor/tools/delegate.py`'s start/get shape:
+
+```python
+async def connect_hyperliquid_wallet(action: str, session_id: str = "") -> dict:
+    if action == "start":
+        result = await call_main_api("POST", "/settings/walletconnect/hyperliquid")
+        # also push the QR as a Telegram photo, mirroring condor/routine_store.py's
+        # _HttpBot.send_photo pattern, so Telegram users can scan without leaving chat
+        return result  # {"session_id", "uri", "next_steps": "poll with action=get"}
+    if action == "get":
+        return await call_main_api("GET", f"/settings/walletconnect/hyperliquid/{session_id}")
+    return {"error": f"Unknown action '{action}'. Use start | get."}
+```
+
+Register in `mcp_servers/condor/server.py` next to `delegate`, same
+`@mcp.tool()` + `@handle_errors("connect hyperliquid wallet")` pattern.
+
+QR delivery: generate a PNG from the `uri` (new small Python dep,
+`qrcode[pil]`) and send it via the existing Telegram `send_photo` machinery
+(`condor/routine_store.py`'s `_HttpBot.send_photo` /
+`mcp_servers/condor/tools/notification.py`'s bot-token/chat-id config) so a
+Telegram user gets a scannable image inline. For non-Telegram MCP hosts
+(e.g. Claude Code), the raw `wc:` URI is returned as text — good enough for
+a spike; rendering it as an inline image for arbitrary MCP hosts is a
+follow-up.
+
+### 5. Skill stub (optional, small)
+
+A minimal `assistants/condor/skills/connect_hyperliquid_wallet/SKILL.md`
+(same frontmatter shape as
+`assistants/condor/skills/hyperliquid_tokenized_perps/SKILL.md`) so the
+routing rule in `server.py`'s `_build_instructions()` picks this tool up for
+phrasings like "connect my Hyperliquid wallet" / "I only have my phone."
+Not required for the mechanism to work — the tool is usable directly — but
+cheap to add and consistent with how the rest of Condor surfaces
+capabilities.
+
+## Explicitly not doing in this spike
+
+- No referral-code linking (`setReferrer`) — separate, additive, already
+  proven to work from the browser flow.
+- No production session cleanup/expiry, no multi-session-per-user handling.
+- No unification of the duplicated EIP-712 constants between
+  `frontend/src/lib/wallet/hyperliquid.ts` and the new Node bridge script —
+  flagged as a known follow-up if the spike proves out.
+- No changes to the existing browser flow.
+
+## Verification
+
+1. Set `WALLETCONNECT_PROJECT_ID` (from a free WalletConnect Cloud project)
+   and confirm `npm install` succeeds in `walletconnect_bridge/`.
+2. Call `connect_hyperliquid_wallet(action="start")` via the MCP tool (or
+   directly exercise `condor/walletconnect.py`) — confirm a `uri` comes back
+   and, if `CONDOR_CHAT_ID`/`TELEGRAM_BOT_TOKEN` are set, a QR photo lands in
+   Telegram.
+3. Scan with a real mobile wallet (Rabby or MetaMask mobile) holding a
+   Hyperliquid-funded address on Arbitrum One; approve both signature
+   requests.
+4. Poll `connect_hyperliquid_wallet(action="get", session_id=...)` until
+   `status: "done"`.
+5. Confirm via `manage_servers` / the dashboard's API Keys list that
+   `hyperliquid` and `hyperliquid_perpetual` credentials now exist for
+   `master_account`, and that a test order can be placed through them (reuse
+   whatever smoke check the existing browser-connected flow uses today).

--- a/docs/architecture/hyperliquid-walletconnect-spike.md
+++ b/docs/architecture/hyperliquid-walletconnect-spike.md
@@ -220,7 +220,32 @@ Telegram user gets a scannable image inline. For non-Telegram MCP hosts
 a spike; rendering it as an inline image for arbitrary MCP hosts is a
 follow-up.
 
-### 5. Skill stub (optional, small)
+### 5. `/keys` → "🔗 Connect Hyperliquid" (Telegram, deterministic entry point)
+
+Chat-only delivery via the MCP tool turned out clunky in practice: without a
+live Telegram bot in the loop, there's no good way for an agent to hand a
+user a scannable QR — the fallback (build an HTML page, publish it,
+send a link) is slow and adds a browser round-trip for something that should
+be instant. The MCP tool's routing also depends on the agent reliably
+inferring intent from free-form phrasing.
+
+`handlers/config/hyperliquid_connect.py` adds a deterministic alternative: a
+"🔗 Connect Hyperliquid" button on the existing `/keys` menu
+(`handlers/config/api_keys.py`). It calls the same
+`condor.walletconnect.start_walletconnect_session` /
+`get_session_status` functions the MCP tool uses — directly, no HTTP
+loopback, since Telegram handlers already run in the main process — sends
+the QR via `context.bot.send_photo`, then edits that photo's caption in
+place as the session progresses (`pending_approval` → `pending_signatures`
+→ `done`/`error`), polling every 3s for up to 6 minutes. QR generation was
+factored out into `condor.walletconnect.generate_qr_png` so both this and
+the MCP tool's `_send_qr_photo` share one implementation.
+
+This is now the primary, fast path; the MCP tool remains for
+non-Telegram/agentic surfaces (Claude Code, etc.), where the skill stub
+below still matters for routing.
+
+### 6. Skill stub (optional, small)
 
 A minimal `assistants/condor/skills/connect_hyperliquid_wallet/SKILL.md`
 (same frontmatter shape as
@@ -243,18 +268,25 @@ capabilities.
 
 ## Verification
 
-1. Set `WALLETCONNECT_PROJECT_ID` (from a free WalletConnect Cloud project)
-   and confirm `npm install` succeeds in `walletconnect_bridge/`.
-2. Call `connect_hyperliquid_wallet(action="start")` via the MCP tool (or
-   directly exercise `condor/walletconnect.py`) — confirm a `uri` comes back
-   and, if `CONDOR_CHAT_ID`/`TELEGRAM_BOT_TOKEN` are set, a QR photo lands in
-   Telegram.
-3. Scan with a real mobile wallet (Rabby or MetaMask mobile) holding a
-   Hyperliquid-funded address on Arbitrum One; approve both signature
-   requests.
-4. Poll `connect_hyperliquid_wallet(action="get", session_id=...)` until
-   `status: "done"`.
-5. Confirm via `manage_servers` / the dashboard's API Keys list that
-   `hyperliquid` and `hyperliquid_perpetual` credentials now exist for
-   `master_account`, and that a test order can be placed through them (reuse
-   whatever smoke check the existing browser-connected flow uses today).
+**MCP tool path — validated end-to-end against a real wallet and a live
+Hyperliquid account** (not just a smoke test): `start_walletconnect_session`
+returned a genuine `wc:` pairing URI, a real mobile wallet paired and signed
+both `ApproveAgent` and `ApproveBuilderFee`, and `hyperliquid` +
+`hyperliquid_perpetual` landed in `master_account` — confirmed independently
+via a direct credentials query against hummingbot-api, not just the tool's
+self-reported result. Along the way this also caught and fixed: the SDK's
+internal logger polluting the stdout event-prefix protocol,
+`client.connect()` hanging forever with no internal timeout on a bad relay
+handshake, and a swallowed exception in the credential-save path that
+misreported a real failure (a crashed `hummingbot-api` container) as
+"process exited unexpectedly."
+
+**`/keys` → "🔗 Connect Hyperliquid" (Telegram) — not yet live-tested**, since
+it requires restarting the running `main.py` process to pick up the new
+handler. To verify: restart, `/keys` in Telegram, tap the button, confirm the
+QR photo arrives and its caption updates live through
+`pending_approval` → `pending_signatures` → `done` as you approve on your
+phone, then re-run the credentials query above to confirm the save. The
+underlying session/save logic is shared with the already-validated MCP path
+— this is a new *delivery* surface (`send_photo` + caption polling) on
+already-proven mechanics, not new signing/save logic.

--- a/handlers/config/api_keys.py
+++ b/handlers/config/api_keys.py
@@ -1,9 +1,12 @@
 """
-API Keys configuration handlers (read-only).
+API Keys configuration handlers.
 
-Connecting and removing exchange API keys is done exclusively through the
-Condor web dashboard (Settings → Keys). The Telegram bot only shows which
-exchanges are currently connected and points the user to the web UI.
+Mostly read-only: connecting or removing a generic exchange's API keys is
+still done through the Condor web dashboard (Settings → Keys), and this view
+just shows which exchanges are connected and points there. Hyperliquid is the
+one exception -- see hyperliquid_connect.py -- since its agent-wallet +
+builder-fee approval can be done entirely via WalletConnect, so it's offered
+directly from this menu instead of requiring the dashboard.
 """
 
 import logging
@@ -173,6 +176,15 @@ async def show_api_keys(query, context: ContextTypes.DEFAULT_TYPE) -> None:
                         [InlineKeyboardButton("🌐 Open Web Dashboard", url=web_url)]
                     )
 
+                keyboard.append(
+                    [
+                        InlineKeyboardButton(
+                            "🔗 Connect Hyperliquid",
+                            callback_data="api_key_connect_hyperliquid",
+                        )
+                    ]
+                )
+
                 message_text = header + creds_display + web_hint
                 keyboard.append(
                     [InlineKeyboardButton("« Close", callback_data="config_close")]
@@ -207,10 +219,15 @@ async def handle_api_keys_callback(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> None:
     """
-    Route API key callback queries to the read-only view.
+    Route API key callback queries.
 
-    All callbacks (the live `config_api_keys` entry and any stale `api_key_*`
-    buttons from before keys management moved to the web UI) just refresh the
-    read-only view.
+    `api_key_connect_hyperliquid` starts the WalletConnect flow; the live
+    `config_api_keys` entry and any stale `api_key_*` buttons from before keys
+    management moved to the web UI fall through to the read-only view.
     """
+    if update.callback_query.data == "api_key_connect_hyperliquid":
+        from .hyperliquid_connect import start_hyperliquid_connect
+
+        await start_hyperliquid_connect(update, context)
+        return
     await show_api_keys(update.callback_query, context)

--- a/handlers/config/api_keys.py
+++ b/handlers/config/api_keys.py
@@ -13,6 +13,7 @@ import logging
 from urllib.parse import quote, urlparse
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.error import TelegramError
 from telegram.ext import ContextTypes
 
 from utils.auth import restricted
@@ -190,26 +191,47 @@ async def show_api_keys(query, context: ContextTypes.DEFAULT_TYPE) -> None:
                     [InlineKeyboardButton("« Close", callback_data="config_close")]
                 )
 
-        reply_markup = InlineKeyboardMarkup(keyboard)
-
-        try:
-            await query.message.edit_text(
-                message_text, parse_mode="MarkdownV2", reply_markup=reply_markup
-            )
-        except Exception as e:
-            if "Message is not modified" in str(e):
-                await query.answer("✅ Already up to date")
-            else:
-                raise
+        await _render_api_keys_view(query, context, message_text, keyboard)
 
     except Exception as e:
         logger.error(f"Error showing API keys: {e}", exc_info=True)
         error_text = f"❌ Error loading API keys: {escape_markdown_v2(str(e))}"
         keyboard = [[InlineKeyboardButton("« Close", callback_data="config_close")]]
-        reply_markup = InlineKeyboardMarkup(keyboard)
-        await query.message.edit_text(
-            error_text, parse_mode="MarkdownV2", reply_markup=reply_markup
+        await _render_api_keys_view(query, context, error_text, keyboard)
+
+
+async def _render_api_keys_view(
+    query, context: ContextTypes.DEFAULT_TYPE, text: str, keyboard: list
+) -> None:
+    """Show `text`/`keyboard` in place of the current message.
+
+    Reachable via "Back" from the WalletConnect QR flow (handlers/config/
+    hyperliquid_connect.py), whose messages are photos -- editMessageText can't
+    turn a photo message into a text one (Telegram raises a BadRequest), so in
+    that case delete and resend as a new text message instead.
+    """
+    reply_markup = InlineKeyboardMarkup(keyboard)
+
+    if query.message.photo:
+        try:
+            await query.message.delete()
+        except TelegramError:
+            pass  # already gone
+        await context.bot.send_message(
+            chat_id=query.message.chat_id,
+            text=text,
+            parse_mode="MarkdownV2",
+            reply_markup=reply_markup,
         )
+        return
+
+    try:
+        await query.message.edit_text(text, parse_mode="MarkdownV2", reply_markup=reply_markup)
+    except TelegramError as e:
+        if "Message is not modified" in str(e):
+            await query.answer("✅ Already up to date")
+        else:
+            raise
 
 
 # Entry point function for routing
@@ -221,13 +243,24 @@ async def handle_api_keys_callback(
     """
     Route API key callback queries.
 
-    `api_key_connect_hyperliquid` starts the WalletConnect flow; the live
-    `config_api_keys` entry and any stale `api_key_*` buttons from before keys
-    management moved to the web UI fall through to the read-only view.
+    `api_key_connect_hyperliquid` starts the WalletConnect flow's first step
+    (create agent wallet); `api_key_hl_advance:<session_id>` continues a session
+    into its second step (approve builder fee), via the "Continue to Step 2"
+    button shown once step 1 finishes. The live `config_api_keys` entry and any
+    stale `api_key_*` buttons from before keys management moved to the web UI
+    fall through to the read-only view.
     """
-    if update.callback_query.data == "api_key_connect_hyperliquid":
+    data = update.callback_query.data
+
+    if data == "api_key_connect_hyperliquid":
         from .hyperliquid_connect import start_hyperliquid_connect
 
         await start_hyperliquid_connect(update, context)
+        return
+    if data.startswith("api_key_hl_advance:"):
+        from .hyperliquid_connect import hyperliquid_connect_advance
+
+        session_id = data.split(":", 1)[1]
+        await hyperliquid_connect_advance(update, context, session_id)
         return
     await show_api_keys(update.callback_query, context)

--- a/handlers/config/hyperliquid_connect.py
+++ b/handlers/config/hyperliquid_connect.py
@@ -1,0 +1,154 @@
+"""Connect Hyperliquid via WalletConnect from the /keys menu.
+
+Lets a user with only a mobile wallet authorize a Hyperliquid agent wallet +
+builder-fee approval by scanning a QR sent directly in Telegram (sendPhoto),
+instead of needing the web dashboard's browser-extension-only "Connect
+Hyperliquid" flow. Reuses the same session registry as the
+connect_hyperliquid_wallet MCP tool (condor/walletconnect.py) -- this handler
+just calls it directly since Telegram handlers already run in the main
+process, no loopback HTTP hop needed. See
+docs/architecture/hyperliquid-walletconnect-spike.md for the design.
+"""
+
+import asyncio
+import io
+import logging
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.error import TelegramError
+from telegram.ext import ContextTypes
+
+from utils.telegram_formatters import escape_markdown_v2
+
+logger = logging.getLogger(__name__)
+
+POLL_INTERVAL = 3  # seconds between status checks
+POLL_TIMEOUT = 6 * 60  # give up if still not terminal after this long (bridge's own approval window is 5 min)
+
+_BACK_KEYBOARD = InlineKeyboardMarkup(
+    [[InlineKeyboardButton("« Back", callback_data="config_api_keys")]]
+)
+
+_STATUS_CAPTION = {
+    "pending_approval": (
+        "⏳ *Waiting for you to scan and pair\\.\\.\\.*\n\n"
+        "Open a WalletConnect\\-compatible mobile wallet \\(Rabby, MetaMask\\) "
+        "holding a Hyperliquid\\-funded address, scan this code, and approve "
+        "the two signature requests\\."
+    ),
+    "pending_signatures": "✍️ *Pairing approved — signing agent wallet \\+ builder fee\\.\\.\\.*",
+}
+
+
+async def start_hyperliquid_connect(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Entry point for the /keys "🔗 Connect Hyperliquid" button."""
+    from config_manager import get_config_manager, get_effective_server
+
+    from condor.walletconnect import generate_qr_png, start_walletconnect_session
+
+    query = update.callback_query
+    chat_id = query.message.chat_id
+    user_id = query.from_user.id
+
+    cm = get_config_manager()
+    server_name = get_effective_server(chat_id, context.user_data) or cm.get_default_server()
+    if not server_name:
+        await query.message.edit_text(
+            "⚠️ _No server configured\\. Add a Hummingbot API server first \\(/servers\\)\\._",
+            parse_mode="MarkdownV2",
+            reply_markup=_BACK_KEYBOARD,
+        )
+        return
+
+    await query.message.edit_text(
+        "⏳ *Starting WalletConnect session\\.\\.\\.*", parse_mode="MarkdownV2"
+    )
+
+    try:
+        result = await start_walletconnect_session(server_name, user_id)
+    except RuntimeError as e:
+        await query.message.edit_text(
+            f"❌ {escape_markdown_v2(str(e))}",
+            parse_mode="MarkdownV2",
+            reply_markup=_BACK_KEYBOARD,
+        )
+        return
+
+    session_id = result["session_id"]
+    png = generate_qr_png(result["uri"])
+
+    try:
+        await query.message.delete()
+    except TelegramError:
+        pass  # already gone
+
+    photo_msg = await context.bot.send_photo(
+        chat_id=chat_id,
+        photo=io.BytesIO(png),
+        caption=_STATUS_CAPTION["pending_approval"],
+        parse_mode="MarkdownV2",
+    )
+
+    asyncio.create_task(
+        _poll_session(context, chat_id, photo_msg.message_id, session_id, user_id)
+    )
+
+
+async def _poll_session(
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    message_id: int,
+    session_id: str,
+    user_id: int,
+) -> None:
+    """Background task: edit the QR photo's caption in place as the session progresses."""
+    from condor.walletconnect import get_session_status
+
+    last_status = None
+    elapsed = 0
+    while elapsed < POLL_TIMEOUT:
+        await asyncio.sleep(POLL_INTERVAL)
+        elapsed += POLL_INTERVAL
+
+        status = await get_session_status(session_id, user_id)
+        if status is None:
+            return  # session evicted (shouldn't happen while we're actively polling it)
+
+        state = status.get("status")
+        if state == last_status:
+            continue
+        last_status = state
+
+        if state == "done":
+            saved = ", ".join(f"`{c}`" for c in status.get("saved_connectors", []))
+            text = f"✅ *Hyperliquid connected* — {saved} saved\\."
+            failed = status.get("failed_connectors") or {}
+            if failed:
+                text += f"\n⚠️ Failed to save: {', '.join(f'`{c}`' for c in failed)}"
+            await _safe_edit_caption(context, chat_id, message_id, text)
+            return
+        if state == "error":
+            msg = escape_markdown_v2(status.get("message", "Unknown error."))
+            await _safe_edit_caption(context, chat_id, message_id, f"❌ {msg}")
+            return
+
+        caption = _STATUS_CAPTION.get(state)
+        if caption:
+            await _safe_edit_caption(context, chat_id, message_id, caption)
+
+    await _safe_edit_caption(
+        context,
+        chat_id,
+        message_id,
+        "⌛ *Timed out waiting for approval\\.* Try again from /keys\\.",
+    )
+
+
+async def _safe_edit_caption(context: ContextTypes.DEFAULT_TYPE, chat_id: int, message_id: int, caption: str) -> None:
+    try:
+        await context.bot.edit_message_caption(
+            chat_id=chat_id, message_id=message_id, caption=caption, parse_mode="MarkdownV2"
+        )
+    except TelegramError as e:
+        if "Message is not modified" not in str(e):
+            logger.warning(f"Failed to edit WalletConnect status caption: {e}")

--- a/handlers/config/hyperliquid_connect.py
+++ b/handlers/config/hyperliquid_connect.py
@@ -1,12 +1,25 @@
 """Connect Hyperliquid via WalletConnect from the /keys menu.
 
 Lets a user with only a mobile wallet authorize a Hyperliquid agent wallet +
-builder-fee approval by scanning a QR sent directly in Telegram (sendPhoto),
-instead of needing the web dashboard's browser-extension-only "Connect
-Hyperliquid" flow. Reuses the same session registry as the
-connect_hyperliquid_wallet MCP tool (condor/walletconnect.py) -- this handler
-just calls it directly since Telegram handlers already run in the main
-process, no loopback HTTP hop needed. See
+builder-fee approval via WalletConnect, instead of needing the web dashboard's
+browser-extension-only "Connect Hyperliquid" flow.
+
+Two independent steps, each its own fresh WalletConnect pairing (fresh QR code
++ fresh MetaMask deep-link button -- see condor/walletconnect.py for why a
+fresh pairing per signature beats reusing one session):
+
+  1. Connect + create agent wallet (always shown).
+  2. Approve builder fee (skipped entirely if the wallet already approved it
+     on-chain in a prior connect).
+
+The agent credential is saved as soon as step 1 finishes, so if the user
+doesn't come back for step 2 right away, Hyperliquid is still usable in the
+meantime -- step 2 is a "Continue when ready" button, not an auto-continuation,
+so nothing expires just because they stepped away.
+
+Reuses the same session registry as the connect_hyperliquid_wallet MCP tool --
+this handler just calls it directly since Telegram handlers already run in the
+main process, no loopback HTTP hop needed. See
 docs/architecture/hyperliquid-walletconnect-spike.md for the design.
 """
 
@@ -29,22 +42,52 @@ _BACK_KEYBOARD = InlineKeyboardMarkup(
     [[InlineKeyboardButton("« Back", callback_data="config_api_keys")]]
 )
 
-_STATUS_CAPTION = {
-    "pending_approval": (
-        "⏳ *Waiting for you to scan and pair\\.\\.\\.*\n\n"
-        "Open a WalletConnect\\-compatible mobile wallet \\(Rabby, MetaMask\\) "
-        "holding a Hyperliquid\\-funded address, scan this code, and approve "
-        "the two signature requests\\."
-    ),
-    "pending_signatures": "✍️ *Pairing approved — signing agent wallet \\+ builder fee\\.\\.\\.*",
+_STEP_TITLE = {
+    "agent": "🔐 *Step 1: Connect \\+ create agent wallet*",
+    "builder": "🔐 *Step 2: Approve builder fee*",
 }
 
 
+def _escape_code(uri: str) -> str:
+    """Escape only what MarkdownV2 requires inside a code span (backtick, backslash)
+    -- running the general escape_markdown_v2 helper on it would corrupt the URI by
+    backslash-escaping characters that are literal inside a code span."""
+    return uri.replace("\\", "\\\\").replace("`", "\\`")
+
+
+def _pairing_caption(step: str, uri: str, has_mm_button: bool) -> str:
+    action = (
+        "Scan the code, or tap below to open MetaMask directly\\."
+        if has_mm_button
+        else "Scan the code with a WalletConnect\\-compatible wallet\\."
+    )
+    return (
+        f"{_STEP_TITLE[step]}\n\n"
+        f"{action} Then approve the signature request\\.\n\n"
+        f"_Link not working? Paste it into your wallet manually:_\n`{_escape_code(uri)}`"
+    )
+
+
+def _continue_keyboard(session_id: str, next_step_label: str) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton(f"➡️ Continue to {next_step_label}", callback_data=f"api_key_hl_advance:{session_id}")],
+            [InlineKeyboardButton("« Back", callback_data="config_api_keys")],
+        ]
+    )
+
+
+def _mm_keyboard(deep_link: str | None) -> InlineKeyboardMarkup | None:
+    if not deep_link:
+        return None
+    return InlineKeyboardMarkup([[InlineKeyboardButton("🦊 Open in MetaMask", url=deep_link)]])
+
+
 async def start_hyperliquid_connect(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Entry point for the /keys "🔗 Connect Hyperliquid" button."""
+    """Entry point for the /keys "🔗 Connect Hyperliquid" button -- begins step 1 (connect + create agent wallet)."""
     from config_manager import get_config_manager, get_effective_server
 
-    from condor.walletconnect import generate_qr_png, start_walletconnect_session
+    from condor.walletconnect import start_walletconnect_session
 
     query = update.callback_query
     chat_id = query.message.chat_id
@@ -74,23 +117,63 @@ async def start_hyperliquid_connect(update: Update, context: ContextTypes.DEFAUL
         )
         return
 
-    session_id = result["session_id"]
-    png = generate_qr_png(result["uri"])
+    try:
+        await query.message.delete()
+    except TelegramError:
+        pass  # already gone
+
+    await _render_step(context, chat_id, query.from_user.id, result)
+
+
+async def hyperliquid_connect_advance(update: Update, context: ContextTypes.DEFAULT_TYPE, session_id: str) -> None:
+    """"➡️ Continue to Step 2" -- begins the builder-fee approval step."""
+    from condor.walletconnect import advance_walletconnect_session
+
+    query = update.callback_query
+    chat_id = query.message.chat_id
+    user_id = query.from_user.id
+
+    await query.message.edit_text(
+        "⏳ *Starting WalletConnect session\\.\\.\\.*", parse_mode="MarkdownV2"
+    )
+
+    try:
+        result = await advance_walletconnect_session(session_id, user_id)
+    except RuntimeError as e:
+        await query.message.edit_text(
+            f"❌ {escape_markdown_v2(str(e))}",
+            parse_mode="MarkdownV2",
+            reply_markup=_BACK_KEYBOARD,
+        )
+        return
 
     try:
         await query.message.delete()
     except TelegramError:
         pass  # already gone
 
+    await _render_step(context, chat_id, user_id, result)
+
+
+async def _render_step(context: ContextTypes.DEFAULT_TYPE, chat_id: int, user_id: int, result: dict) -> None:
+    """Send the QR + MetaMask-button message for the step just started, and kick
+    off polling for it."""
+    from condor.walletconnect import generate_qr_png
+
+    step = result["step"]
+    uri = result["uri"]
+    deep_link = result.get("deep_links", {}).get("MetaMask")
+    keyboard = _mm_keyboard(deep_link)
+
     photo_msg = await context.bot.send_photo(
         chat_id=chat_id,
-        photo=io.BytesIO(png),
-        caption=_STATUS_CAPTION["pending_approval"],
+        photo=io.BytesIO(generate_qr_png(uri)),
+        caption=_pairing_caption(step, uri, has_mm_button=bool(deep_link)),
         parse_mode="MarkdownV2",
+        reply_markup=keyboard,
     )
-
     asyncio.create_task(
-        _poll_session(context, chat_id, photo_msg.message_id, session_id, user_id)
+        _poll_session(context, chat_id, photo_msg.message_id, result["session_id"], user_id, keyboard)
     )
 
 
@@ -100,8 +183,14 @@ async def _poll_session(
     message_id: int,
     session_id: str,
     user_id: int,
+    keyboard: InlineKeyboardMarkup | None,
 ) -> None:
-    """Background task: edit the QR photo's caption in place as the session progresses."""
+    """Background task: edit the QR photo's caption in place as the current step progresses.
+
+    Telegram's edit_message_caption drops the existing inline keyboard unless the
+    same (or a new) reply_markup is passed on every edit -- so the MetaMask button
+    must be re-sent on each non-terminal update, not just the initial send.
+    """
     from condor.walletconnect import get_session_status
 
     last_status = None
@@ -119,36 +208,75 @@ async def _poll_session(
             continue
         last_status = state
 
-        if state == "done":
-            saved = ", ".join(f"`{c}`" for c in status.get("saved_connectors", []))
-            text = f"✅ *Hyperliquid connected* — {saved} saved\\."
-            failed = status.get("failed_connectors") or {}
-            if failed:
-                text += f"\n⚠️ Failed to save: {', '.join(f'`{c}`' for c in failed)}"
-            await _safe_edit_caption(context, chat_id, message_id, text)
-            return
-        if state == "error":
-            msg = escape_markdown_v2(status.get("message", "Unknown error."))
-            await _safe_edit_caption(context, chat_id, message_id, f"❌ {msg}")
+        if state == "pending_approval":
+            continue  # identical to what send_photo already showed -- no edit needed
+
+        if state == "pending_signature":
+            step = status.get("step")
+            text = (
+                "✍️ *Pairing approved — signing agent wallet\\.\\.\\.*"
+                if step == "agent"
+                else "✍️ *Pairing approved — signing builder fee approval\\.\\.\\.*"
+            )
+            await _safe_edit_caption(context, chat_id, message_id, text, keyboard)
+            continue
+
+        if state == "step_done":
+            # Agent step finished. Either offer the (skippable) builder step, or
+            # -- if the wallet already approved Condor's builder fee -- go
+            # straight to done without ever mentioning it.
+            if status.get("needs_builder_step"):
+                text = (
+                    "✅ *Step 1 complete* — agent wallet created and saved\\.\n\n"
+                    "*Step 2: Approve builder fee* — lets Condor apply the agreed "
+                    "order\\-routing fee\\. Tap Continue when you're ready\\."
+                )
+                await _safe_edit_caption(context, chat_id, message_id, text, _continue_keyboard(session_id, "Step 2"))
+            else:
+                await _safe_edit_caption(
+                    context, chat_id, message_id, "✅ *Hyperliquid connected\\.*", _BACK_KEYBOARD
+                )
             return
 
-        caption = _STATUS_CAPTION.get(state)
-        if caption:
-            await _safe_edit_caption(context, chat_id, message_id, caption)
+        if state == "done":
+            await _safe_edit_caption(
+                context,
+                chat_id,
+                message_id,
+                "✅ *Hyperliquid connected* — builder fee approved\\.",
+                _BACK_KEYBOARD,
+            )
+            return
+
+        if state == "error":
+            msg = escape_markdown_v2(status.get("message", "Unknown error."))
+            await _safe_edit_caption(context, chat_id, message_id, f"❌ {msg}", _BACK_KEYBOARD)
+            return
 
     await _safe_edit_caption(
         context,
         chat_id,
         message_id,
         "⌛ *Timed out waiting for approval\\.* Try again from /keys\\.",
+        _BACK_KEYBOARD,
     )
 
 
-async def _safe_edit_caption(context: ContextTypes.DEFAULT_TYPE, chat_id: int, message_id: int, caption: str) -> None:
+async def _safe_edit_caption(
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    message_id: int,
+    caption: str,
+    reply_markup: InlineKeyboardMarkup | None,
+) -> None:
     try:
         await context.bot.edit_message_caption(
-            chat_id=chat_id, message_id=message_id, caption=caption, parse_mode="MarkdownV2"
+            chat_id=chat_id,
+            message_id=message_id,
+            caption=caption,
+            parse_mode="MarkdownV2",
+            reply_markup=reply_markup,
         )
     except TelegramError as e:
         if "Message is not modified" not in str(e):
-            logger.warning(f"Failed to edit WalletConnect status caption: {e}")
+            logger.warning(f"Failed to edit WalletConnect status message: {e}")

--- a/mcp_servers/condor/server.py
+++ b/mcp_servers/condor/server.py
@@ -247,22 +247,37 @@ async def connect_hyperliquid_wallet(
     """Connect a Hyperliquid wallet via WalletConnect (agent-wallet + builder-fee approval).
 
     Lets a user authorize a trade-only Hyperliquid "agent wallet" and the Condor
-    builder fee from their own mobile wallet (Rabby, MetaMask, ...) via a
-    WalletConnect QR code / link -- no browser extension needed, and their master
-    private key never leaves their phone. This is the WalletConnect counterpart to
-    the web dashboard's "Connect Hyperliquid" flow; use it when the user only has a
-    mobile wallet, or wants to connect from chat instead of the dashboard.
+    builder fee from their own mobile wallet (MetaMask, ...) via a WalletConnect QR
+    code / link -- no browser extension needed, and their master private key never
+    leaves their phone. This is the WalletConnect counterpart to the web
+    dashboard's "Connect Hyperliquid" flow; use it when the user only has a mobile
+    wallet, or wants to connect from chat instead of the dashboard.
+
+    Two independent steps, each its own fresh pairing (fresh QR/link) -- a fresh
+    pairing reliably foregrounds the wallet app; reusing one session for a second
+    request doesn't always prompt it:
+    1. Connect + create + authorize the agent wallet -- saved as soon as it
+       succeeds, so the connection already works even if step 2 is never done.
+    2. Approve the builder fee -- skipped automatically if the wallet already
+       approved it on-chain in a prior connect (check `needs_builder_step`).
 
     Actions:
-    - "start": Begin a session (optional server, defaults to the active server).
-      Returns {"session_id", "uri", "next_steps"} immediately -- does NOT wait for
-      approval. If Telegram is configured, a scannable QR is also sent as a photo.
-    - "get": Poll a session's status (requires session_id). Returns
-      {"status": "pending_approval" | "pending_signatures" | "done" | "error", ...}.
+    - "start": Begin step 1 (optional server, defaults to the active server).
+      Returns {"session_id", "uri", "deep_links", "step": "agent", "next_steps"}
+      immediately -- does NOT wait for approval. If Telegram is configured, a
+      scannable QR is also sent as a photo.
+    - "advance": Begin step 2 for a session whose step 1 finished and needs it
+      (requires session_id). Returns the same shape as "start" but with
+      "step": "builder". Only valid when a prior "get" showed
+      {"status": "step_done", "needs_builder_step": true}.
+    - "get": Poll a session's current step status (requires session_id). Returns
+      {"status": "pending_approval" | "pending_signature" | "step_done" | "done" |
+      "error", "step": "agent" | "builder", ...}. "step_done" means step 1
+      finished -- check "needs_builder_step" to see whether "advance" is needed.
 
     Args:
-        action: start | get.
-        session_id: Session id returned by start (for get).
+        action: start | advance | get.
+        session_id: Session id returned by start (for advance/get).
         server: Hummingbot API server name (optional for start, defaults to the active server).
 
     Returns:

--- a/mcp_servers/condor/server.py
+++ b/mcp_servers/condor/server.py
@@ -18,6 +18,7 @@ from mcp_servers.condor.tools import (
     servers,
     skills,
     trading_agent,
+    wallet_connect,
 )
 
 
@@ -234,6 +235,40 @@ async def manage_servers(
         Action-specific result dict.
     """
     return await servers.manage_servers(action, name)
+
+
+@mcp.tool()
+@handle_errors("connect hyperliquid wallet")
+async def connect_hyperliquid_wallet(
+    action: str,
+    session_id: str = "",
+    server: str = "",
+) -> dict:
+    """Connect a Hyperliquid wallet via WalletConnect (agent-wallet + builder-fee approval).
+
+    Lets a user authorize a trade-only Hyperliquid "agent wallet" and the Condor
+    builder fee from their own mobile wallet (Rabby, MetaMask, ...) via a
+    WalletConnect QR code / link -- no browser extension needed, and their master
+    private key never leaves their phone. This is the WalletConnect counterpart to
+    the web dashboard's "Connect Hyperliquid" flow; use it when the user only has a
+    mobile wallet, or wants to connect from chat instead of the dashboard.
+
+    Actions:
+    - "start": Begin a session (optional server, defaults to the active server).
+      Returns {"session_id", "uri", "next_steps"} immediately -- does NOT wait for
+      approval. If Telegram is configured, a scannable QR is also sent as a photo.
+    - "get": Poll a session's status (requires session_id). Returns
+      {"status": "pending_approval" | "pending_signatures" | "done" | "error", ...}.
+
+    Args:
+        action: start | get.
+        session_id: Session id returned by start (for get).
+        server: Hummingbot API server name (optional for start, defaults to the active server).
+
+    Returns:
+        Action-specific result dict.
+    """
+    return await wallet_connect.connect_hyperliquid_wallet(action, session_id, server)
 
 
 @mcp.tool()

--- a/mcp_servers/condor/tools/wallet_connect.py
+++ b/mcp_servers/condor/tools/wallet_connect.py
@@ -15,6 +15,7 @@ from urllib.parse import quote
 
 import httpx
 
+from condor.walletconnect import generate_qr_png
 from mcp_servers.condor.condor_client import call_main_api
 from mcp_servers.condor.settings import settings
 
@@ -31,11 +32,7 @@ async def _send_qr_photo(uri: str) -> bool:
     if not settings.bot_token or not settings.chat_id:
         return False
     try:
-        import qrcode
-
-        buf = io.BytesIO()
-        qrcode.make(uri).save(buf, format="PNG")
-        buf.seek(0)
+        buf = io.BytesIO(generate_qr_png(uri))
         async with httpx.AsyncClient(timeout=10) as client:
             resp = await client.post(
                 f"https://api.telegram.org/bot{settings.bot_token}/sendPhoto",

--- a/mcp_servers/condor/tools/wallet_connect.py
+++ b/mcp_servers/condor/tools/wallet_connect.py
@@ -6,6 +6,13 @@ it lets a user with only a mobile wallet (no MetaMask/Rabby desktop extension)
 authorize a trade-only Hyperliquid agent wallet and the Condor builder fee by
 scanning a QR code / opening a link on their phone -- and lets that flow be
 triggered from chat (Telegram, Claude Code, ...) instead of only the dashboard.
+
+Two independent steps, each its own fresh WalletConnect pairing (fresh QR/deep
+link): "start" begins step 1 (connect + create + authorize the agent wallet,
+saved as soon as it succeeds); if the response's `needs_builder_step` is true,
+call "advance" with the same session_id to begin step 2 (approve the builder
+fee) -- otherwise the connection is already complete and there's nothing
+further to do.
 See docs/architecture/hyperliquid-walletconnect-spike.md for the design.
 """
 
@@ -45,6 +52,18 @@ async def _send_qr_photo(uri: str) -> bool:
         return False
 
 
+def _pairing_next_steps(step: str) -> str:
+    verb = "creating the agent wallet" if step == "agent" else "approving the builder fee"
+    return (
+        "If the user is on their phone, give them the links in 'deep_links' "
+        "(e.g. deep_links['MetaMask']) to tap and open straight into that "
+        "wallet app -- no QR needed. Otherwise tell them to scan the QR (sent "
+        "to Telegram) or open the 'uri' field directly in a WalletConnect-"
+        f"compatible mobile wallet if it wasn't sent. Once they approve {verb}, "
+        'poll with connect_hyperliquid_wallet(action="get", session_id="...").'
+    )
+
+
 async def connect_hyperliquid_wallet(action: str, session_id: str = "", server: str = "") -> dict:
     action = (action or "").lower()
 
@@ -58,20 +77,32 @@ async def connect_hyperliquid_wallet(action: str, session_id: str = "", server: 
             "POST", f"/settings/walletconnect/hyperliquid?server={quote(server)}", timeout=30
         )
         if isinstance(result, dict) and result.get("uri"):
-            sent = await _send_qr_photo(result["uri"])
-            result["qr_sent_to_telegram"] = sent
-            result["next_steps"] = (
-                "Tell the user to scan the QR (sent to Telegram) or open the 'uri' "
-                "field directly in a WalletConnect-compatible mobile wallet if it "
-                "wasn't sent (e.g. a non-Telegram session). Once they approve both "
-                "signature requests on their phone, poll with "
-                'connect_hyperliquid_wallet(action="get", session_id="...").'
-            )
+            result["qr_sent_to_telegram"] = await _send_qr_photo(result["uri"])
+            result["next_steps"] = _pairing_next_steps(result.get("step", "agent"))
+        return result
+
+    if action == "advance":
+        if not session_id:
+            return {"error": "session_id is required for advance"}
+        result = await call_main_api(
+            "POST", f"/settings/walletconnect/hyperliquid/{session_id}/advance", timeout=30
+        )
+        if isinstance(result, dict) and result.get("uri"):
+            result["qr_sent_to_telegram"] = await _send_qr_photo(result["uri"])
+            result["next_steps"] = _pairing_next_steps(result.get("step", "agent"))
         return result
 
     if action == "get":
         if not session_id:
             return {"error": "session_id is required for get"}
-        return await call_main_api("GET", f"/settings/walletconnect/hyperliquid/{session_id}")
+        result = await call_main_api("GET", f"/settings/walletconnect/hyperliquid/{session_id}")
+        if isinstance(result, dict) and result.get("status") == "step_done" and result.get("needs_builder_step"):
+            result["next_steps"] = (
+                "Step 1 (agent wallet) is done and already saved. Call "
+                'connect_hyperliquid_wallet(action="advance", session_id="...") to '
+                "start step 2 (approve builder fee), or stop here if that's "
+                "not needed right now -- the connection already works."
+            )
+        return result
 
-    return {"error": f"Unknown action '{action}'. Use start | get."}
+    return {"error": f"Unknown action '{action}'. Use start | advance | get."}

--- a/mcp_servers/condor/tools/wallet_connect.py
+++ b/mcp_servers/condor/tools/wallet_connect.py
@@ -1,0 +1,80 @@
+"""Connect a Hyperliquid wallet via WalletConnect (agent-wallet + builder-fee approval).
+
+This is the WalletConnect counterpart to the web dashboard's browser-extension-only
+"Connect Hyperliquid" flow (frontend/src/components/settings/ConnectHyperliquid.tsx):
+it lets a user with only a mobile wallet (no MetaMask/Rabby desktop extension)
+authorize a trade-only Hyperliquid agent wallet and the Condor builder fee by
+scanning a QR code / opening a link on their phone -- and lets that flow be
+triggered from chat (Telegram, Claude Code, ...) instead of only the dashboard.
+See docs/architecture/hyperliquid-walletconnect-spike.md for the design.
+"""
+
+import io
+import logging
+from urllib.parse import quote
+
+import httpx
+
+from mcp_servers.condor.condor_client import call_main_api
+from mcp_servers.condor.settings import settings
+
+logger = logging.getLogger("condor.mcp")
+
+
+async def _send_qr_photo(uri: str) -> bool:
+    """Best-effort: push the pairing URI as a scannable QR photo to Telegram.
+
+    No-ops (returns False) if Telegram isn't configured -- e.g. a Claude Code
+    session with no bot token/chat id. Callers should fall back to showing the
+    raw `uri` as text in that case.
+    """
+    if not settings.bot_token or not settings.chat_id:
+        return False
+    try:
+        import qrcode
+
+        buf = io.BytesIO()
+        qrcode.make(uri).save(buf, format="PNG")
+        buf.seek(0)
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.post(
+                f"https://api.telegram.org/bot{settings.bot_token}/sendPhoto",
+                data={"chat_id": settings.chat_id, "caption": "Scan to connect Hyperliquid"},
+                files={"photo": ("walletconnect.png", buf, "image/png")},
+            )
+            return resp.json().get("ok", False)
+    except Exception:
+        logger.exception("Failed to send WalletConnect QR photo to Telegram")
+        return False
+
+
+async def connect_hyperliquid_wallet(action: str, session_id: str = "", server: str = "") -> dict:
+    action = (action or "").lower()
+
+    if action == "start":
+        server = server or settings.active_server
+        if not server:
+            return {
+                "error": "No active server. Pass server=<name> or set CONDOR_SERVER_NAME.",
+            }
+        result = await call_main_api(
+            "POST", f"/settings/walletconnect/hyperliquid?server={quote(server)}", timeout=30
+        )
+        if isinstance(result, dict) and result.get("uri"):
+            sent = await _send_qr_photo(result["uri"])
+            result["qr_sent_to_telegram"] = sent
+            result["next_steps"] = (
+                "Tell the user to scan the QR (sent to Telegram) or open the 'uri' "
+                "field directly in a WalletConnect-compatible mobile wallet if it "
+                "wasn't sent (e.g. a non-Telegram session). Once they approve both "
+                "signature requests on their phone, poll with "
+                'connect_hyperliquid_wallet(action="get", session_id="...").'
+            )
+        return result
+
+    if action == "get":
+        if not session_id:
+            return {"error": "session_id is required for get"}
+        return await call_main_api("GET", f"/settings/walletconnect/hyperliquid/{session_id}")
+
+    return {"error": f"Unknown action '{action}'. Use start | get."}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ dependencies = [
     "scipy>=1.17.1",
     "pydantic-ai[mcp]",
     "beautifulsoup4>=4.14.3",
+    "lz4>=4.4.5",
+    "qrcode[pil]>=8.0",
 ]
 
 [project.optional-dependencies]

--- a/utils/telegram_helpers.py
+++ b/utils/telegram_helpers.py
@@ -8,6 +8,7 @@ class MockMessage:
         self._msg = msg
         self.message_id = msg.message_id
         self.chat_id = msg.chat_id
+        self.photo = msg.photo
 
     async def edit_text(self, text, parse_mode=None, reply_markup=None):
         return await self._msg.edit_text(

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -594,6 +594,7 @@ dependencies = [
     { name = "geckoterminal-py" },
     { name = "hummingbot-api-client" },
     { name = "kaleido" },
+    { name = "lz4" },
     { name = "matplotlib" },
     { name = "mcp" },
     { name = "pandas" },
@@ -603,6 +604,7 @@ dependencies = [
     { name = "python-jose", extra = ["cryptography"] },
     { name = "python-telegram-bot", extra = ["job-queue"] },
     { name = "pyyaml" },
+    { name = "qrcode", extra = ["pil"] },
     { name = "scipy" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "watchfiles" },
@@ -628,6 +630,7 @@ requires-dist = [
     { name = "hummingbot-api-client", specifier = "==1.5.3" },
     { name = "isort", marker = "extra == 'dev'" },
     { name = "kaleido" },
+    { name = "lz4", specifier = ">=4.4.5" },
     { name = "matplotlib", specifier = ">=3.10.8" },
     { name = "mcp" },
     { name = "pandas" },
@@ -640,6 +643,7 @@ requires-dist = [
     { name = "python-jose", extras = ["cryptography"] },
     { name = "python-telegram-bot", extras = ["job-queue"] },
     { name = "pyyaml" },
+    { name = "qrcode", extras = ["pil"], specifier = ">=8.0" },
     { name = "scipy", specifier = ">=1.17.1" },
     { name = "uvicorn", extras = ["standard"] },
     { name = "watchfiles" },
@@ -1870,6 +1874,46 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/08/90/bfd7a6fab22bdfafe48ed3c4831713cb77b4779d18ade5e248d5dbc0ca22/logistro-2.0.1.tar.gz", hash = "sha256:8446affc82bab2577eb02bfcbcae196ae03129287557287b6a070f70c1985047", size = 8398, upload-time = "2025-11-01T02:41:18.81Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/6aa79ba3570bddd1bf7e951c6123f806751e58e8cce736bad77b2cf348d7/logistro-2.0.1-py3-none-any.whl", hash = "sha256:06ffa127b9fb4ac8b1972ae6b2a9d7fde57598bf5939cd708f43ec5bba2d31eb", size = 8555, upload-time = "2025-11-01T02:41:17.587Z" },
+]
+
+[[package]]
+name = "lz4"
+version = "4.4.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/51/f1b86d93029f418033dddf9b9f79c8d2641e7454080478ee2aab5123173e/lz4-4.4.5.tar.gz", hash = "sha256:5f0b9e53c1e82e88c10d7c180069363980136b9d7a8306c4dca4f760d60c39f0", size = 172886, upload-time = "2025-11-03T13:02:36.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/ac/016e4f6de37d806f7cc8f13add0a46c9a7cfc41a5ddc2bc831d7954cf1ce/lz4-4.4.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:df5aa4cead2044bab83e0ebae56e0944cc7fcc1505c7787e9e1057d6d549897e", size = 207163, upload-time = "2025-11-03T13:01:45.895Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/df/0fadac6e5bd31b6f34a1a8dbd4db6a7606e70715387c27368586455b7fc9/lz4-4.4.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6d0bf51e7745484d2092b3a51ae6eb58c3bd3ce0300cf2b2c14f76c536d5697a", size = 207150, upload-time = "2025-11-03T13:01:47.205Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/17/34e36cc49bb16ca73fb57fbd4c5eaa61760c6b64bce91fcb4e0f4a97f852/lz4-4.4.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7b62f94b523c251cf32aa4ab555f14d39bd1a9df385b72443fd76d7c7fb051f5", size = 1292045, upload-time = "2025-11-03T13:01:48.667Z" },
+    { url = "https://files.pythonhosted.org/packages/90/1c/b1d8e3741e9fc89ed3b5f7ef5f22586c07ed6bb04e8343c2e98f0fa7ff04/lz4-4.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c3ea562c3af274264444819ae9b14dbbf1ab070aff214a05e97db6896c7597e", size = 1279546, upload-time = "2025-11-03T13:01:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/55/d9/e3867222474f6c1b76e89f3bd914595af69f55bf2c1866e984c548afdc15/lz4-4.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24092635f47538b392c4eaeff14c7270d2c8e806bf4be2a6446a378591c5e69e", size = 1368249, upload-time = "2025-11-03T13:01:51.273Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e7/d667d337367686311c38b580d1ca3d5a23a6617e129f26becd4f5dc458df/lz4-4.4.5-cp312-cp312-win32.whl", hash = "sha256:214e37cfe270948ea7eb777229e211c601a3e0875541c1035ab408fbceaddf50", size = 88189, upload-time = "2025-11-03T13:01:52.605Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/0b/a54cd7406995ab097fceb907c7eb13a6ddd49e0b231e448f1a81a50af65c/lz4-4.4.5-cp312-cp312-win_amd64.whl", hash = "sha256:713a777de88a73425cf08eb11f742cd2c98628e79a8673d6a52e3c5f0c116f33", size = 99497, upload-time = "2025-11-03T13:01:53.477Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7e/dc28a952e4bfa32ca16fa2eb026e7a6ce5d1411fcd5986cd08c74ec187b9/lz4-4.4.5-cp312-cp312-win_arm64.whl", hash = "sha256:a88cbb729cc333334ccfb52f070463c21560fca63afcf636a9f160a55fac3301", size = 91279, upload-time = "2025-11-03T13:01:54.419Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/46/08fd8ef19b782f301d56a9ccfd7dafec5fd4fc1a9f017cf22a1accb585d7/lz4-4.4.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6bb05416444fafea170b07181bc70640975ecc2a8c92b3b658c554119519716c", size = 207171, upload-time = "2025-11-03T13:01:56.595Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3f/ea3334e59de30871d773963997ecdba96c4584c5f8007fd83cfc8f1ee935/lz4-4.4.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b424df1076e40d4e884cfcc4c77d815368b7fb9ebcd7e634f937725cd9a8a72a", size = 207163, upload-time = "2025-11-03T13:01:57.721Z" },
+    { url = "https://files.pythonhosted.org/packages/41/7b/7b3a2a0feb998969f4793c650bb16eff5b06e80d1f7bff867feb332f2af2/lz4-4.4.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:216ca0c6c90719731c64f41cfbd6f27a736d7e50a10b70fad2a9c9b262ec923d", size = 1292136, upload-time = "2025-11-03T13:02:00.375Z" },
+    { url = "https://files.pythonhosted.org/packages/89/d1/f1d259352227bb1c185288dd694121ea303e43404aa77560b879c90e7073/lz4-4.4.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:533298d208b58b651662dd972f52d807d48915176e5b032fb4f8c3b6f5fe535c", size = 1279639, upload-time = "2025-11-03T13:02:01.649Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/fb/ba9256c48266a09012ed1d9b0253b9aa4fe9cdff094f8febf5b26a4aa2a2/lz4-4.4.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:451039b609b9a88a934800b5fc6ee401c89ad9c175abf2f4d9f8b2e4ef1afc64", size = 1368257, upload-time = "2025-11-03T13:02:03.35Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6d/dee32a9430c8b0e01bbb4537573cabd00555827f1a0a42d4e24ca803935c/lz4-4.4.5-cp313-cp313-win32.whl", hash = "sha256:a5f197ffa6fc0e93207b0af71b302e0a2f6f29982e5de0fbda61606dd3a55832", size = 88191, upload-time = "2025-11-03T13:02:04.406Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e0/f06028aea741bbecb2a7e9648f4643235279a770c7ffaf70bd4860c73661/lz4-4.4.5-cp313-cp313-win_amd64.whl", hash = "sha256:da68497f78953017deb20edff0dba95641cc86e7423dfadf7c0264e1ac60dc22", size = 99502, upload-time = "2025-11-03T13:02:05.886Z" },
+    { url = "https://files.pythonhosted.org/packages/61/72/5bef44afb303e56078676b9f2486f13173a3c1e7f17eaac1793538174817/lz4-4.4.5-cp313-cp313-win_arm64.whl", hash = "sha256:c1cfa663468a189dab510ab231aad030970593f997746d7a324d40104db0d0a9", size = 91285, upload-time = "2025-11-03T13:02:06.77Z" },
+    { url = "https://files.pythonhosted.org/packages/49/55/6a5c2952971af73f15ed4ebfdd69774b454bd0dc905b289082ca8664fba1/lz4-4.4.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:67531da3b62f49c939e09d56492baf397175ff39926d0bd5bd2d191ac2bff95f", size = 207348, upload-time = "2025-11-03T13:02:08.117Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d7/fd62cbdbdccc35341e83aabdb3f6d5c19be2687d0a4eaf6457ddf53bba64/lz4-4.4.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a1acbbba9edbcbb982bc2cac5e7108f0f553aebac1040fbec67a011a45afa1ba", size = 207340, upload-time = "2025-11-03T13:02:09.152Z" },
+    { url = "https://files.pythonhosted.org/packages/77/69/225ffadaacb4b0e0eb5fd263541edd938f16cd21fe1eae3cd6d5b6a259dc/lz4-4.4.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a482eecc0b7829c89b498fda883dbd50e98153a116de612ee7c111c8bcf82d1d", size = 1293398, upload-time = "2025-11-03T13:02:10.272Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/9e/2ce59ba4a21ea5dc43460cba6f34584e187328019abc0e66698f2b66c881/lz4-4.4.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e099ddfaa88f59dd8d36c8a3c66bd982b4984edf127eb18e30bb49bdba68ce67", size = 1281209, upload-time = "2025-11-03T13:02:12.091Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4f/4d946bd1624ec229b386a3bc8e7a85fa9a963d67d0a62043f0af0978d3da/lz4-4.4.5-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2af2897333b421360fdcce895c6f6281dc3fab018d19d341cf64d043fc8d90d", size = 1369406, upload-time = "2025-11-03T13:02:13.683Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/d429ba4720a9064722698b4b754fb93e42e625f1318b8fe834086c7c783b/lz4-4.4.5-cp313-cp313t-win32.whl", hash = "sha256:66c5de72bf4988e1b284ebdd6524c4bead2c507a2d7f172201572bac6f593901", size = 88325, upload-time = "2025-11-03T13:02:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/85/7ba10c9b97c06af6c8f7032ec942ff127558863df52d866019ce9d2425cf/lz4-4.4.5-cp313-cp313t-win_amd64.whl", hash = "sha256:cdd4bdcbaf35056086d910d219106f6a04e1ab0daa40ec0eeef1626c27d0fddb", size = 99643, upload-time = "2025-11-03T13:02:15.978Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4d/a175459fb29f909e13e57c8f475181ad8085d8d7869bd8ad99033e3ee5fa/lz4-4.4.5-cp313-cp313t-win_arm64.whl", hash = "sha256:28ccaeb7c5222454cd5f60fcd152564205bcb801bd80e125949d2dfbadc76bbd", size = 91504, upload-time = "2025-11-03T13:02:17.313Z" },
+    { url = "https://files.pythonhosted.org/packages/63/9c/70bdbdb9f54053a308b200b4678afd13efd0eafb6ddcbb7f00077213c2e5/lz4-4.4.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c216b6d5275fc060c6280936bb3bb0e0be6126afb08abccde27eed23dead135f", size = 207586, upload-time = "2025-11-03T13:02:18.263Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/cb/bfead8f437741ce51e14b3c7d404e3a1f6b409c440bad9b8f3945d4c40a7/lz4-4.4.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c8e71b14938082ebaf78144f3b3917ac715f72d14c076f384a4c062df96f9df6", size = 207161, upload-time = "2025-11-03T13:02:19.286Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/18/b192b2ce465dfbeabc4fc957ece7a1d34aded0d95a588862f1c8a86ac448/lz4-4.4.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9b5e6abca8df9f9bdc5c3085f33ff32cdc86ed04c65e0355506d46a5ac19b6e9", size = 1292415, upload-time = "2025-11-03T13:02:20.829Z" },
+    { url = "https://files.pythonhosted.org/packages/67/79/a4e91872ab60f5e89bfad3e996ea7dc74a30f27253faf95865771225ccba/lz4-4.4.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b84a42da86e8ad8537aabef062e7f661f4a877d1c74d65606c49d835d36d668", size = 1279920, upload-time = "2025-11-03T13:02:22.013Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/01/d52c7b11eaa286d49dae619c0eec4aabc0bf3cda7a7467eb77c62c4471f3/lz4-4.4.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bba042ec5a61fa77c7e380351a61cb768277801240249841defd2ff0a10742f", size = 1368661, upload-time = "2025-11-03T13:02:23.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/137ddeea14c2cb86864838277b2607d09f8253f152156a07f84e11768a28/lz4-4.4.5-cp314-cp314-win32.whl", hash = "sha256:bd85d118316b53ed73956435bee1997bd06cc66dd2fa74073e3b1322bd520a67", size = 90139, upload-time = "2025-11-03T13:02:24.301Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2c/8332080fd293f8337779a440b3a143f85e374311705d243439a3349b81ad/lz4-4.4.5-cp314-cp314-win_amd64.whl", hash = "sha256:92159782a4502858a21e0079d77cdcaade23e8a5d252ddf46b0652604300d7be", size = 101497, upload-time = "2025-11-03T13:02:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/28/2635a8141c9a4f4bc23f5135a92bbcf48d928d8ca094088c962df1879d64/lz4-4.4.5-cp314-cp314-win_arm64.whl", hash = "sha256:d994b87abaa7a88ceb7a37c90f547b8284ff9da694e6afcfaa8568d739faf3f7", size = 93812, upload-time = "2025-11-03T13:02:26.133Z" },
 ]
 
 [[package]]
@@ -3317,6 +3361,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "qrcode"
+version = "8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/b2/7fc2931bfae0af02d5f53b174e9cf701adbb35f39d69c2af63d4a39f81a9/qrcode-8.2.tar.gz", hash = "sha256:35c3f2a4172b33136ab9f6b3ef1c00260dd2f66f858f24d88418a015f446506c", size = 43317, upload-time = "2025-05-01T15:44:24.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/b8/d2d6d731733f51684bbf76bf34dab3b70a9148e8f2cef2bb544fccec681a/qrcode-8.2-py3-none-any.whl", hash = "sha256:16e64e0716c14960108e85d853062c9e8bba5ca8252c0b4d0231b9df4060ff4f", size = 45986, upload-time = "2025-05-01T15:44:22.781Z" },
+]
+
+[package.optional-dependencies]
+pil = [
+    { name = "pillow" },
 ]
 
 [[package]]

--- a/walletconnect_bridge/bridge.mjs
+++ b/walletconnect_bridge/bridge.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+// Standalone WalletConnect bridge for the Hyperliquid agent-wallet + builder-fee
+// approval flow. Spawned as a subprocess by condor/walletconnect.py; speaks
+// newline-delimited JSON on stdout, one event per line:
+//
+//   {"event":"uri","uri":"wc:..."}
+//   {"event":"approved","mainAddress":"0x..."}
+//   {"event":"done","mainAddress":"0x...","agentAddress":"0x...","agentPrivateKey":"0x..."}
+//   {"event":"error","message":"..."}
+//
+// Python never touches private keys or the WalletConnect protocol -- all of
+// that lives here. The EIP-712 payloads mirror
+// frontend/src/lib/wallet/hyperliquid.ts by hand (spike-scoped; see
+// docs/architecture/hyperliquid-walletconnect-spike.md for the tradeoffs and
+// the follow-up to de-duplicate if this graduates past a spike).
+
+import { SignClient } from "@walletconnect/sign-client";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+
+// @walletconnect/sign-client's internal pino logger writes its own (non-JSON,
+// multi-line) diagnostics straight to stdout regardless of the `logger: "silent"`
+// option passed below in some versions -- so rather than relying on fully
+// silencing a third-party dependency, every line WE emit is prefixed with this
+// marker. The Python side only parses lines that start with it and quietly
+// ignores everything else, so stray SDK log noise can never be mistaken for one
+// of our protocol events.
+const EVENT_PREFIX = "CONDOR_WC_EVENT ";
+
+function emit(obj) {
+  process.stdout.write(EVENT_PREFIX + JSON.stringify(obj) + "\n");
+}
+
+const PROJECT_ID = process.env.WALLETCONNECT_PROJECT_ID;
+if (!PROJECT_ID) {
+  emit({ event: "error", message: "WALLETCONNECT_PROJECT_ID is not set." });
+  process.exit(1);
+}
+
+// ── Hyperliquid mainnet signing constants (mirrors wallet/hyperliquid.ts) ──
+const CHAIN_ID_NUM = 42161; // Arbitrum One -- Hyperliquid mainnet signs on this domain
+const CHAIN = `eip155:${CHAIN_ID_NUM}`;
+const HL_EXCHANGE_URL = "https://api.hyperliquid.xyz/exchange";
+const HL_INFO_URL = "https://api.hyperliquid.xyz/info";
+const HL_CHAIN = "Mainnet";
+
+const BUILDER_ADDRESS = "0x10ba451e6439efc6a17dc20d21121aa838100705";
+const BUILDER_MAX_FEE_RATE = "0.01%"; // 1 bps
+const BUILDER_MAX_FEE_RATE_TENTHS_BPS = Math.round(parseFloat(BUILDER_MAX_FEE_RATE) * 1000);
+const DEFAULT_AGENT_NAME = "condor";
+const MAX_AGENT_NAME = 16;
+
+const EIP712_DOMAIN = {
+  name: "HyperliquidSignTransaction",
+  version: "1",
+  chainId: CHAIN_ID_NUM,
+  verifyingContract: "0x0000000000000000000000000000000000000000",
+};
+const DOMAIN_TYPE = [
+  { name: "name", type: "string" },
+  { name: "version", type: "string" },
+  { name: "chainId", type: "uint256" },
+  { name: "verifyingContract", type: "address" },
+];
+
+function creationStamp() {
+  const d = new Date();
+  const p = (n) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}${p(d.getMonth() + 1)}${p(d.getDate())}`;
+}
+
+function defaultAgentName() {
+  return `${DEFAULT_AGENT_NAME}-${creationStamp()}`.slice(0, MAX_AGENT_NAME);
+}
+
+let lastNonce = 0;
+function nextNonce() {
+  const now = Date.now();
+  lastNonce = now > lastNonce ? now : lastNonce + 1;
+  return lastNonce;
+}
+
+/** Normalize a 65-byte hex signature into the {r, s, v} shape Hyperliquid expects. */
+function normalizeSignature(sigHex) {
+  const hex = sigHex.slice(2);
+  if (hex.length !== 130) throw new Error(`Expected a 65-byte signature, got ${hex.length / 2} bytes.`);
+  const r = `0x${hex.slice(0, 64)}`;
+  const s = `0x${hex.slice(64, 128)}`;
+  let v = parseInt(hex.slice(128, 130), 16);
+  if (v < 27) v += 27; // normalize a 0/1 yParity to the legacy 27/28 v value
+  return { r, s, v };
+}
+
+function buildApproveAgentTypedData(agentAddress, agentName, nonce) {
+  return {
+    domain: EIP712_DOMAIN,
+    types: {
+      EIP712Domain: DOMAIN_TYPE,
+      "HyperliquidTransaction:ApproveAgent": [
+        { name: "hyperliquidChain", type: "string" },
+        { name: "agentAddress", type: "address" },
+        { name: "agentName", type: "string" },
+        { name: "nonce", type: "uint64" },
+      ],
+    },
+    primaryType: "HyperliquidTransaction:ApproveAgent",
+    message: { hyperliquidChain: HL_CHAIN, agentAddress, agentName, nonce },
+  };
+}
+
+function buildApproveBuilderFeeTypedData(nonce) {
+  return {
+    domain: EIP712_DOMAIN,
+    types: {
+      EIP712Domain: DOMAIN_TYPE,
+      "HyperliquidTransaction:ApproveBuilderFee": [
+        { name: "hyperliquidChain", type: "string" },
+        { name: "maxFeeRate", type: "string" },
+        { name: "builder", type: "address" },
+        { name: "nonce", type: "uint64" },
+      ],
+    },
+    primaryType: "HyperliquidTransaction:ApproveBuilderFee",
+    message: { hyperliquidChain: HL_CHAIN, maxFeeRate: BUILDER_MAX_FEE_RATE, builder: BUILDER_ADDRESS, nonce },
+  };
+}
+
+/** The user's current on-chain approved max builder fee for Condor's builder (0 if never approved). */
+async function getHyperliquidBuilderApproval(userAddress) {
+  const res = await fetch(HL_INFO_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ type: "maxBuilderFee", user: userAddress, builder: BUILDER_ADDRESS }),
+  });
+  if (!res.ok) throw new Error(`Hyperliquid builder-fee lookup failed (HTTP ${res.status}).`);
+  return Number(await res.json());
+}
+
+async function signAndSubmit(client, topic, mainAddress, typedData, action) {
+  const sigHex = await client.request({
+    topic,
+    chainId: CHAIN,
+    request: {
+      method: "eth_signTypedData_v4",
+      params: [mainAddress, JSON.stringify(typedData)],
+    },
+  });
+  const signature = normalizeSignature(sigHex);
+
+  const res = await fetch(HL_EXCHANGE_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action, nonce: action.nonce, signature }),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || data.status !== "ok") {
+    const detail = typeof data.response === "string" ? data.response : data.status || `HTTP ${res.status}`;
+    throw new Error(`Hyperliquid rejected the request: ${detail}`);
+  }
+}
+
+// client.connect()'s relay handshake either resolves in a couple seconds or, on
+// e.g. a bad/misconfigured project id, silently retries forever without ever
+// resolving or rejecting -- confirmed by hand while building this bridge (see
+// docs/architecture/hyperliquid-walletconnect-spike.md). Bound it explicitly so
+// a bad config fails fast with a clear error instead of leaking an orphaned,
+// permanently-hung subprocess.
+const RELAY_CONNECT_TIMEOUT_MS = 15_000;
+// approval() genuinely waits on a human to act on their phone -- give it minutes,
+// not seconds, but still bound it so an abandoned session doesn't hang forever.
+const APPROVAL_TIMEOUT_MS = 5 * 60_000;
+
+function withTimeout(promise, ms, label) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => setTimeout(() => reject(new Error(`Timed out waiting for ${label}.`)), ms)),
+  ]);
+}
+
+async function main() {
+  const client = await withTimeout(
+    SignClient.init({
+      projectId: PROJECT_ID,
+      logger: "silent",
+      metadata: {
+        name: "Condor",
+        description: "Connect your Hyperliquid wallet to Condor",
+        url: "https://hummingbot.org",
+        icons: [],
+      },
+    }),
+    RELAY_CONNECT_TIMEOUT_MS,
+    "the WalletConnect relay to initialize",
+  );
+
+  const { uri, approval } = await withTimeout(
+    client.connect({
+      requiredNamespaces: {
+        eip155: {
+          methods: ["eth_signTypedData_v4"],
+          chains: [CHAIN],
+          events: ["chainChanged", "accountsChanged"],
+        },
+      },
+    }),
+    RELAY_CONNECT_TIMEOUT_MS,
+    "a WalletConnect pairing URI",
+  );
+
+  emit({ event: "uri", uri });
+
+  const session = await withTimeout(approval(), APPROVAL_TIMEOUT_MS, "wallet approval");
+  const account = session.namespaces.eip155.accounts[0]; // "eip155:42161:0xabc..."
+  const mainAddress = account.split(":")[2];
+
+  emit({ event: "approved", mainAddress });
+
+  const agentPrivateKey = generatePrivateKey();
+  const agentAddress = privateKeyToAccount(agentPrivateKey).address;
+  const agentName = defaultAgentName();
+
+  // 1. Authorize the agent wallet (trade-only, no withdrawals).
+  const aaNonce = nextNonce();
+  await signAndSubmit(client, session.topic, mainAddress, buildApproveAgentTypedData(agentAddress, agentName, aaNonce), {
+    type: "approveAgent",
+    hyperliquidChain: HL_CHAIN,
+    signatureChainId: `0x${CHAIN_ID_NUM.toString(16)}`,
+    agentAddress,
+    agentName,
+    nonce: aaNonce,
+  });
+
+  // 2. Approve the builder fee, unless the user already approved at least that much
+  // (the approval persists on-chain per (user, builder), so a returning user need not sign again).
+  let builderApproved = false;
+  try {
+    builderApproved = (await getHyperliquidBuilderApproval(mainAddress)) >= BUILDER_MAX_FEE_RATE_TENTHS_BPS;
+  } catch {
+    builderApproved = false;
+  }
+  if (!builderApproved) {
+    const bfNonce = nextNonce();
+    await signAndSubmit(client, session.topic, mainAddress, buildApproveBuilderFeeTypedData(bfNonce), {
+      type: "approveBuilderFee",
+      hyperliquidChain: HL_CHAIN,
+      signatureChainId: `0x${CHAIN_ID_NUM.toString(16)}`,
+      maxFeeRate: BUILDER_MAX_FEE_RATE,
+      builder: BUILDER_ADDRESS,
+      nonce: bfNonce,
+    });
+  }
+
+  emit({ event: "done", mainAddress, agentAddress, agentPrivateKey });
+  await client.disconnect({ topic: session.topic, reason: { code: 6000, message: "done" } }).catch(() => {});
+  process.exit(0);
+}
+
+main().catch((err) => {
+  emit({ event: "error", message: err?.message || String(err) });
+  process.exit(1);
+});

--- a/walletconnect_bridge/bridge.mjs
+++ b/walletconnect_bridge/bridge.mjs
@@ -1,11 +1,21 @@
 #!/usr/bin/env node
 // Standalone WalletConnect bridge for the Hyperliquid agent-wallet + builder-fee
-// approval flow. Spawned as a subprocess by condor/walletconnect.py; speaks
-// newline-delimited JSON on stdout, one event per line:
+// approval flow. Spawned as a subprocess by condor/walletconnect.py -- ONE
+// signature per process invocation, each with its OWN fresh WalletConnect
+// pairing (fresh QR / fresh MetaMask deep link), rather than one long-lived
+// session driving both signatures back to back. A fresh pairing forces the
+// wallet app to foreground on every step; a second request sent to an
+// already-paired-but-backgrounded session doesn't reliably prompt the wallet
+// (confirmed by hand -- see docs/architecture/hyperliquid-walletconnect-spike.md).
 //
+// Invocation:
+//   node bridge.mjs agent
+//   node bridge.mjs builder <expectedMainAddress>
+//
+// Speaks newline-delimited JSON on stdout, one event per line:
 //   {"event":"uri","uri":"wc:..."}
 //   {"event":"approved","mainAddress":"0x..."}
-//   {"event":"done","mainAddress":"0x...","agentAddress":"0x...","agentPrivateKey":"0x..."}
+//   {"event":"done", ...}                          -- shape depends on step, see below
 //   {"event":"error","message":"..."}
 //
 // Python never touches private keys or the WalletConnect protocol -- all of
@@ -36,16 +46,25 @@ if (!PROJECT_ID) {
   process.exit(1);
 }
 
+const STEP = process.argv[2]; // "agent" | "builder"
+const EXPECTED_MAIN_ADDRESS = process.argv[3] || null; // required for "builder"
+if (STEP !== "agent" && STEP !== "builder") {
+  emit({ event: "error", message: `Unknown step '${STEP}'. Use agent | builder.` });
+  process.exit(1);
+}
+if (STEP === "builder" && !EXPECTED_MAIN_ADDRESS) {
+  emit({ event: "error", message: "The builder step requires the expected main address as argv[3]." });
+  process.exit(1);
+}
+
 // ── Hyperliquid mainnet signing constants (mirrors wallet/hyperliquid.ts) ──
 const CHAIN_ID_NUM = 42161; // Arbitrum One -- Hyperliquid mainnet signs on this domain
 const CHAIN = `eip155:${CHAIN_ID_NUM}`;
 const HL_EXCHANGE_URL = "https://api.hyperliquid.xyz/exchange";
-const HL_INFO_URL = "https://api.hyperliquid.xyz/info";
 const HL_CHAIN = "Mainnet";
 
 const BUILDER_ADDRESS = "0x10ba451e6439efc6a17dc20d21121aa838100705";
-const BUILDER_MAX_FEE_RATE = "0.01%"; // 1 bps
-const BUILDER_MAX_FEE_RATE_TENTHS_BPS = Math.round(parseFloat(BUILDER_MAX_FEE_RATE) * 1000);
+const BUILDER_MAX_FEE_RATE = "0.01%"; // 1 bps -- mirrors _BUILDER_MAX_FEE_RATE_TENTHS_BPS in condor/walletconnect.py
 const DEFAULT_AGENT_NAME = "condor";
 const MAX_AGENT_NAME = 16;
 
@@ -72,11 +91,8 @@ function defaultAgentName() {
   return `${DEFAULT_AGENT_NAME}-${creationStamp()}`.slice(0, MAX_AGENT_NAME);
 }
 
-let lastNonce = 0;
 function nextNonce() {
-  const now = Date.now();
-  lastNonce = now > lastNonce ? now : lastNonce + 1;
-  return lastNonce;
+  return Date.now();
 }
 
 /** Normalize a 65-byte hex signature into the {r, s, v} shape Hyperliquid expects. */
@@ -124,17 +140,6 @@ function buildApproveBuilderFeeTypedData(nonce) {
   };
 }
 
-/** The user's current on-chain approved max builder fee for Condor's builder (0 if never approved). */
-async function getHyperliquidBuilderApproval(userAddress) {
-  const res = await fetch(HL_INFO_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ type: "maxBuilderFee", user: userAddress, builder: BUILDER_ADDRESS }),
-  });
-  if (!res.ok) throw new Error(`Hyperliquid builder-fee lookup failed (HTTP ${res.status}).`);
-  return Number(await res.json());
-}
-
 async function signAndSubmit(client, topic, mainAddress, typedData, action) {
   const sigHex = await client.request({
     topic,
@@ -176,6 +181,84 @@ function withTimeout(promise, ms, label) {
   ]);
 }
 
+async function pairAndApprove(client) {
+  const { uri, approval } = await withTimeout(
+    client.connect({
+      requiredNamespaces: {
+        eip155: {
+          methods: ["eth_signTypedData_v4"],
+          chains: [CHAIN],
+          events: ["chainChanged", "accountsChanged"],
+        },
+      },
+    }),
+    RELAY_CONNECT_TIMEOUT_MS,
+    "a WalletConnect pairing URI",
+  );
+  emit({ event: "uri", uri });
+
+  const session = await withTimeout(approval(), APPROVAL_TIMEOUT_MS, "wallet approval");
+  const account = session.namespaces.eip155.accounts[0]; // "eip155:42161:0xabc..."
+  const mainAddress = account.split(":")[2];
+  return { session, mainAddress };
+}
+
+/** Pairs, waits for approval, and (for the builder step, reconnecting after the
+ * agent step) verifies the reconnecting wallet is the same one that created the
+ * agent -- each step is a fresh pairing, so nothing but the address itself
+ * carries over between them. */
+async function pairApproveAndVerify(client) {
+  const { session, mainAddress } = await pairAndApprove(client);
+
+  if (EXPECTED_MAIN_ADDRESS && mainAddress.toLowerCase() !== EXPECTED_MAIN_ADDRESS.toLowerCase()) {
+    await client.disconnect({ topic: session.topic, reason: { code: 6000, message: "wrong wallet" } }).catch(() => {});
+    throw new Error(
+      `Connected wallet ${mainAddress} doesn't match ${EXPECTED_MAIN_ADDRESS} from the previous step -- ` +
+        "reconnect using the same wallet.",
+    );
+  }
+  emit({ event: "approved", mainAddress });
+  return { session, mainAddress };
+}
+
+async function runAgentStep(client) {
+  const { session, mainAddress } = await pairApproveAndVerify(client);
+
+  const agentPrivateKey = generatePrivateKey();
+  const agentAddress = privateKeyToAccount(agentPrivateKey).address;
+  const agentName = defaultAgentName();
+  const nonce = nextNonce();
+
+  await signAndSubmit(client, session.topic, mainAddress, buildApproveAgentTypedData(agentAddress, agentName, nonce), {
+    type: "approveAgent",
+    hyperliquidChain: HL_CHAIN,
+    signatureChainId: `0x${CHAIN_ID_NUM.toString(16)}`,
+    agentAddress,
+    agentName,
+    nonce,
+  });
+
+  emit({ event: "done", mainAddress, agentAddress, agentPrivateKey });
+  await client.disconnect({ topic: session.topic, reason: { code: 6000, message: "done" } }).catch(() => {});
+}
+
+async function runBuilderStep(client) {
+  const { session, mainAddress } = await pairApproveAndVerify(client);
+
+  const nonce = nextNonce();
+  await signAndSubmit(client, session.topic, mainAddress, buildApproveBuilderFeeTypedData(nonce), {
+    type: "approveBuilderFee",
+    hyperliquidChain: HL_CHAIN,
+    signatureChainId: `0x${CHAIN_ID_NUM.toString(16)}`,
+    maxFeeRate: BUILDER_MAX_FEE_RATE,
+    builder: BUILDER_ADDRESS,
+    nonce,
+  });
+
+  emit({ event: "done", mainAddress });
+  await client.disconnect({ topic: session.topic, reason: { code: 6000, message: "done" } }).catch(() => {});
+}
+
 async function main() {
   const client = await withTimeout(
     SignClient.init({
@@ -192,65 +275,11 @@ async function main() {
     "the WalletConnect relay to initialize",
   );
 
-  const { uri, approval } = await withTimeout(
-    client.connect({
-      requiredNamespaces: {
-        eip155: {
-          methods: ["eth_signTypedData_v4"],
-          chains: [CHAIN],
-          events: ["chainChanged", "accountsChanged"],
-        },
-      },
-    }),
-    RELAY_CONNECT_TIMEOUT_MS,
-    "a WalletConnect pairing URI",
-  );
-
-  emit({ event: "uri", uri });
-
-  const session = await withTimeout(approval(), APPROVAL_TIMEOUT_MS, "wallet approval");
-  const account = session.namespaces.eip155.accounts[0]; // "eip155:42161:0xabc..."
-  const mainAddress = account.split(":")[2];
-
-  emit({ event: "approved", mainAddress });
-
-  const agentPrivateKey = generatePrivateKey();
-  const agentAddress = privateKeyToAccount(agentPrivateKey).address;
-  const agentName = defaultAgentName();
-
-  // 1. Authorize the agent wallet (trade-only, no withdrawals).
-  const aaNonce = nextNonce();
-  await signAndSubmit(client, session.topic, mainAddress, buildApproveAgentTypedData(agentAddress, agentName, aaNonce), {
-    type: "approveAgent",
-    hyperliquidChain: HL_CHAIN,
-    signatureChainId: `0x${CHAIN_ID_NUM.toString(16)}`,
-    agentAddress,
-    agentName,
-    nonce: aaNonce,
-  });
-
-  // 2. Approve the builder fee, unless the user already approved at least that much
-  // (the approval persists on-chain per (user, builder), so a returning user need not sign again).
-  let builderApproved = false;
-  try {
-    builderApproved = (await getHyperliquidBuilderApproval(mainAddress)) >= BUILDER_MAX_FEE_RATE_TENTHS_BPS;
-  } catch {
-    builderApproved = false;
+  if (STEP === "agent") {
+    await runAgentStep(client);
+  } else {
+    await runBuilderStep(client);
   }
-  if (!builderApproved) {
-    const bfNonce = nextNonce();
-    await signAndSubmit(client, session.topic, mainAddress, buildApproveBuilderFeeTypedData(bfNonce), {
-      type: "approveBuilderFee",
-      hyperliquidChain: HL_CHAIN,
-      signatureChainId: `0x${CHAIN_ID_NUM.toString(16)}`,
-      maxFeeRate: BUILDER_MAX_FEE_RATE,
-      builder: BUILDER_ADDRESS,
-      nonce: bfNonce,
-    });
-  }
-
-  emit({ event: "done", mainAddress, agentAddress, agentPrivateKey });
-  await client.disconnect({ topic: session.topic, reason: { code: 6000, message: "done" } }).catch(() => {});
   process.exit(0);
 }
 

--- a/walletconnect_bridge/package-lock.json
+++ b/walletconnect_bridge/package-lock.json
@@ -1,0 +1,1120 @@
+{
+  "name": "condor-walletconnect-bridge",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "condor-walletconnect-bridge",
+      "version": "0.1.0",
+      "dependencies": {
+        "@walletconnect/sign-client": "^2.17.2",
+        "viem": "^2.21.0"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.0.tgz",
+      "integrity": "sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.7.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
+      "integrity": "sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/core": {
+      "version": "2.23.10",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.10.tgz",
+      "integrity": "sha512-Qq2btHEoCgruvkZCWLSrVsvg/dYbM9Z045qeClwhJR4meL32jbIRT0mKWjf0HkRc2LA82MsnszVnfuZl3yWl5A==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.10",
+        "@walletconnect/utils": "2.23.10",
+        "@walletconnect/window-getters": "1.0.1",
+        "es-toolkit": "1.45.1",
+        "events": "3.3.0",
+        "uint8arrays": "3.1.1"
+      },
+      "engines": {
+        "node": ">=18.20.8"
+      }
+    },
+    "node_modules/@walletconnect/environment": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/environment/-/environment-1.0.1.tgz",
+      "integrity": "sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/events": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/events/-/events-1.0.1.tgz",
+      "integrity": "sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "keyvaluestorage-interface": "^1.0.0",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/heartbeat": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.2.tgz",
+      "integrity": "sha512-uASiRmC5MwhuRuf05vq4AT48Pq8RMi876zV8rr8cV969uTOzWdB/k+Lj5yI2PBtB1bGQisGen7MM1GcZlQTBXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-provider": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.14.tgz",
+      "integrity": "sha512-rtsNY1XqHvWj0EtITNeuf8PHMvlCLiS3EjQL+WOkxEOA4KPxsohFnBDeyPYiNm4ZvkQdLnece36opYidmtbmow==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.8",
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-types": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.4.tgz",
+      "integrity": "sha512-P6679fG/M+wuWg9TY8mh6xFSdYnFyFjwFelxyISxMDrlbXokorEVXYOxiqEbrU3x1BmBoCAJJ+vtEaEoMlpCBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0",
+        "keyvaluestorage-interface": "^1.0.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-utils": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
+      "integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/environment": "^1.0.1",
+        "@walletconnect/jsonrpc-types": "^1.0.3",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-ws-connection": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz",
+      "integrity": "sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0",
+        "ws": "^7.5.1"
+      }
+    },
+    "node_modules/@walletconnect/keyvaluestorage": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
+      "integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.1",
+        "idb-keyval": "^6.2.1",
+        "unstorage": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": "1.x"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/keyvaluestorage/node_modules/unstorage": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+      "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^3.1.3",
+        "chokidar": "^5.0.0",
+        "destr": "^2.0.5",
+        "h3": "^1.15.10",
+        "lru-cache": "^11.2.7",
+        "node-fetch-native": "^1.6.7",
+        "ofetch": "^1.5.1",
+        "ufo": "^1.6.3"
+      },
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.8.0",
+        "@azure/cosmos": "^4.2.0",
+        "@azure/data-tables": "^13.3.0",
+        "@azure/identity": "^4.6.0",
+        "@azure/keyvault-secrets": "^4.9.0",
+        "@azure/storage-blob": "^12.26.0",
+        "@capacitor/preferences": "^6 || ^7 || ^8",
+        "@deno/kv": ">=0.9.0",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+        "@planetscale/database": "^1.19.0",
+        "@upstash/redis": "^1.34.3",
+        "@vercel/blob": ">=0.27.1",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
+        "@vercel/kv": "^1 || ^2 || ^3",
+        "aws4fetch": "^1.0.20",
+        "db0": ">=0.2.1",
+        "idb-keyval": "^6.2.1",
+        "ioredis": "^5.4.2",
+        "uploadthing": "^7.4.4"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@capacitor/preferences": {
+          "optional": true
+        },
+        "@deno/kv": {
+          "optional": true
+        },
+        "@netlify/blobs": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "aws4fetch": {
+          "optional": true
+        },
+        "db0": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "uploadthing": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/logger": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.2.tgz",
+      "integrity": "sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "10.0.0"
+      }
+    },
+    "node_modules/@walletconnect/relay-api": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.11.tgz",
+      "integrity": "sha512-tLPErkze/HmC9aCmdZOhtVmYZq1wKfWTJtygQHoWtgg722Jd4homo54Cs4ak2RUFUZIGO2RsOpIcWipaua5D5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-types": "^1.0.2"
+      }
+    },
+    "node_modules/@walletconnect/relay-auth": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-auth/-/relay-auth-1.1.0.tgz",
+      "integrity": "sha512-qFw+a9uRz26jRCDgL7Q5TA9qYIgcNY8jpJzI1zAWNZ8i7mQjaijRnWFKsCHAU9CyGjvt6RKrRXyFtFOpWTVmCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.8.0",
+        "@noble/hashes": "1.7.0",
+        "@walletconnect/safe-json": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "node_modules/@walletconnect/safe-json": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/sign-client": {
+      "version": "2.23.10",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.10.tgz",
+      "integrity": "sha512-vO7DGRRmKo+rykmjVyQR1aM4I2nbk9kJ6olbxgjFRR6Jdhy+Kz+zgN7Ce5xVhPfWYVu4bV/XhOQxhvnQw7S5ng==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/core": "2.23.10",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.10",
+        "@walletconnect/utils": "2.23.10",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/time/-/time-1.0.2.tgz",
+      "integrity": "sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/types": {
+      "version": "2.23.10",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.10.tgz",
+      "integrity": "sha512-XP8d41979anTrc1OJF3ISF+g81cvp1wim+ObdNnbcaT/jhwLwv+0T7rRe9VwRv+h8EaRgLyeb5YGy7oJ49vxVg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/utils": {
+      "version": "2.23.10",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.10.tgz",
+      "integrity": "sha512-b1c9FRF2g7vNnz66oLW5WZD2VCMrbu9xhpmwJJwqGarBiGW7cY8NbUtS9/w2/qc0vsBVKJ/bzDn4TGjpELU6aQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@msgpack/msgpack": "3.1.3",
+        "@noble/ciphers": "1.3.0",
+        "@noble/curves": "1.9.7",
+        "@noble/hashes": "1.8.0",
+        "@scure/base": "1.2.6",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.10",
+        "@walletconnect/window-getters": "1.0.1",
+        "@walletconnect/window-metadata": "1.0.1",
+        "blakejs": "1.2.1",
+        "detect-browser": "5.3.0",
+        "ox": "0.9.3",
+        "uint8arrays": "3.1.1"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/window-getters": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
+      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/window-metadata": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
+      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/window-getters": "^1.0.1",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.4.tgz",
+      "integrity": "sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "license": "MIT"
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cookie-es": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+      "license": "MIT"
+    },
+    "node_modules/crossws": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "license": "MIT"
+    },
+    "node_modules/detect-browser": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==",
+      "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/h3": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^1.2.3",
+        "crossws": "^0.3.5",
+        "defu": "^6.1.6",
+        "destr": "^2.0.5",
+        "iron-webcrypto": "^1.2.1",
+        "node-mock-http": "^1.0.4",
+        "radix3": "^1.1.2",
+        "ufo": "^1.6.3",
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.3.0.tgz",
+      "integrity": "sha512-um+2dgAWmYsu615EXpWVwSmapJhON0G43t3Ka/EVaohzPQXSMqKEqeDK/oIW3Ow+BXaF2PvSc+oBTFp793A5Ow==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/iron-webcrypto": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/keyvaluestorage-interface": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
+      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "license": "(Apache-2.0 AND MIT)"
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
+    },
+    "node_modules/node-mock-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
+      "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ofetch": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+      "license": "MIT",
+      "dependencies": {
+        "destr": "^2.0.5",
+        "node-fetch-native": "^1.6.7",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ox": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.3.tgz",
+      "integrity": "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.0.9",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pino": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/radix3": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/slow-redact": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.2.tgz",
+      "integrity": "sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==",
+      "license": "MIT"
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "license": "MIT"
+    },
+    "node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/viem": {
+      "version": "2.54.6",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.54.6.tgz",
+      "integrity": "sha512-OfybECKJYVmhiNqz+SHhed+O2h6niQ+0Wjg9J0b4bV+/QrvLgjxhfKO7hZqsuK1YtZ/0BErBKy708Zp+cU5T0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.30",
+        "ws": "8.21.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/ox": {
+      "version": "0.14.30",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.30.tgz",
+      "integrity": "sha512-LI11uu+8iiM1B3CLckgd++YF1a0A2k5wDoM9ZeQMiL21BOzQs6L//BLS6hb1HSEKCyycdDIQLsVQx9MjpcC0hA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/walletconnect_bridge/package.json
+++ b/walletconnect_bridge/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "condor-walletconnect-bridge",
+  "private": true,
+  "type": "module",
+  "version": "0.1.0",
+  "description": "Standalone WalletConnect bridge for Condor's Hyperliquid agent-wallet connect flow (spike). Spawned as a subprocess by condor/walletconnect.py.",
+  "main": "bridge.mjs",
+  "dependencies": {
+    "@walletconnect/sign-client": "^2.17.2",
+    "viem": "^2.21.0"
+  }
+}


### PR DESCRIPTION
## Summary
- Lets a user authorize a Hyperliquid agent wallet + builder-fee approval via WalletConnect (mobile wallet, no browser extension needed) instead of only the existing browser-extension dashboard flow.
- `condor/walletconnect.py` + `walletconnect_bridge/` (Node sidecar) own the session lifecycle and EIP-712 signing; credentials save through the same `add_credential` path the dashboard flow already uses.
- Two entry points share that same session/save logic:
  - `connect_hyperliquid_wallet` MCP tool (`mcp_servers/condor/tools/wallet_connect.py`), for Claude Code / other agentic surfaces.
  - `/keys` → "🔗 Connect Hyperliquid" button in Telegram (`handlers/config/hyperliquid_connect.py`) — the fast, deterministic path: sends the QR via `sendPhoto` and edits its caption live as the session progresses, no LLM routing or artifact page needed.
- Design writeup + Gateway-vs-Condor tradeoff analysis: `docs/architecture/hyperliquid-walletconnect-spike.md`.

## Validated end-to-end (not just a smoke test)
- Real WalletConnect pairing, real mobile wallet, real signatures for both `ApproveAgent` and `ApproveBuilderFee`.
- `hyperliquid` and `hyperliquid_perpetual` credentials confirmed saved to `master_account` via a direct hummingbot-api credentials query (both via the MCP-tool path and, separately, the Telegram `/keys` button — confirmed via fresh `201 Created` log entries).
- Caught and fixed along the way: SDK logger polluting the stdout event protocol, `client.connect()` hanging forever with no internal timeout on a bad relay handshake, and a swallowed exception that misreported a real failure (a crashed `hummingbot-api` container) as "process exited unexpectedly."

## Test plan
- [x] `walletconnect_bridge/bridge.mjs` — `node --check`, `npm install` resolves cleanly
- [x] All new/changed Python files compile and import cleanly
- [x] MCP tool path: real pairing → real signatures → credentials saved (verified via direct API query)
- [x] Telegram `/keys` button: same, verified via fresh `hummingbot-api` `201 Created` logs
- [ ] Referral-code linking, multi-session cleanup, non-Telegram inline QR delivery — explicitly out of scope for this spike (see doc)

## QA instructions (manual verification)

**Prerequisites**
1. Server-side config only, not something the wallet user ever sees or signs up for: WalletConnect v2 requires whichever app opens a pairing to authenticate with Reown's relay servers via a `projectId` (rate-limiting/abuse prevention on the relay, not per-user auth). Set `WALLETCONNECT_PROJECT_ID=42224dd97ab044901eec3d17911c0280` in `.env` (main process env, not the bridge's) — this is Condor's existing project id, already provisioned, nothing to newly sign up for.
2. `cd walletconnect_bridge && npm install` (installs `@walletconnect/sign-client`, `viem`).
3. `uv sync` to pick up the new `qrcode[pil]` dependency.
4. A WalletConnect-compatible mobile wallet (Rabby or MetaMask mobile) holding an address you're OK test-connecting to Hyperliquid on Arbitrum One. No funds are moved — this only authorizes an agent wallet + builder fee, it never touches balances.
5. Restart `main.py` so it picks up the new routes/handlers and the env var.

**Path A — Telegram `/keys` button (fastest to verify)**
1. In the Condor Telegram bot, send `/keys`.
2. Tap "🔗 Connect Hyperliquid".
3. A QR photo should appear within a couple seconds, captioned "⏳ Waiting for you to scan and pair...".
4. Scan it with your mobile wallet, approve the WalletConnect pairing.
5. Caption should update to "✍️ Pairing approved — signing agent wallet + builder fee...", then your wallet should prompt two signature requests (`ApproveAgent`, `ApproveBuilderFee`) — approve both.
6. Caption should update to "✅ Hyperliquid connected — `hyperliquid`, `hyperliquid_perpetual` saved." within ~5-10s.
7. **Failure modes to check**: deny one of the two signature requests (should land on `❌ ...` with a clear message, not a silent hang); let the QR sit unscanned past 6 minutes (should show a timeout message); back out and try again from `/keys` (should start a fresh session, not reuse a stale one).

**Path B — MCP tool (Claude Code or another MCP host)**
1. Call `connect_hyperliquid_wallet(action="start", server="<your server name>")`.
2. Response should include a `uri` field (a `wc:...` pairing URI) and a `next_steps` hint. If Telegram is configured for this session, `qr_sent_to_telegram` should be `true` and a QR photo should also land in Telegram.
3. Open the `uri` directly in a WalletConnect-compatible wallet (or scan the Telegram QR from step 2), approve pairing, then approve both signature requests.
4. Poll `connect_hyperliquid_wallet(action="get", session_id="<from step 1>")` until `status` is `"done"` — response should include `saved_connectors: ["hyperliquid_perpetual", "hyperliquid"]` (order may vary) and no `failed_connectors`.

**Verifying the result (either path)**
- Via `manage_servers` or the web dashboard's Settings → Keys: confirm `hyperliquid` and `hyperliquid_perpetual` now show as connected under `master_account`.
- Optional: place a small test order through either connector to confirm the saved agent-wallet credential is actually authorized on Hyperliquid, not just persisted locally.
- Re-running either path should produce an independent new session (old sessions aren't reused), and the previously-connected credentials should just get overwritten with a fresh agent wallet.

**Known non-goals for this spike** (don't file these as bugs): no referral-code linking, no multi-session-per-user handling, no production session cleanup/expiry beyond the built-in TTL, and a manually `kill -9`'d Python process can orphan the Node bridge subprocess (has to be killed separately) — flagged as an inherent limitation of a spike, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

