### PR TITLE
fix / Fix Codex ACP package integration

### DIFF
--- a/condor/acp/client.py
+++ b/condor/acp/client.py
@@ -170,7 +170,7 @@ ACP_COMMANDS: dict[str, str] = {
     "claude-acp": "claude-agent-acp",  # model-configurable form: claude-acp:<model>
     "gemini": "npx @google/gemini-cli --acp",
     "copilot": "npx @github/copilot --acp --stdio",
-    "codex": "npx @zed-industries/codex-acp",
+    "codex": "npx @agentclientprotocol/codex-acp",
 }
 
 # ACP bases whose model can be picked via a suffix (e.g. "claude-acp:opus").

--- a/handlers/agents/__init__.py
+++ b/handlers/agents/__init__.py
@@ -110,7 +110,7 @@ async def agent_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
                 "Install one of:\n"
                 "• claude-agent-acp (Claude Agent)\n"
                 "• gemini (Gemini CLI)\n"
-                "• npx @zed-industries/codex-acp (ChatGPT Codex ACP bridge)\n\n"
+                "• npx @agentclientprotocol/codex-acp (ChatGPT Codex ACP bridge)\n\n"
                 "Then restart the bot."
             )
             return


### PR DESCRIPTION
## Summary
- replace the legacy `@zed-industries/codex-acp` package
- use the maintained `@agentclientprotocol/codex-acp` bridge
- update Telegram installation guidance

## Testing
- `uv run pytest tests/test_agents.py -q`
- verified a successful Codex ACP handshake
- confirmed no model metadata warning was emitted