### PR TITLE
OpenRouter model access: web picker + agent model-selection advisor

### DIFF
--- a/assistants/condor/skills/agent_builder/SKILL.md
+++ b/assistants/condor/skills/agent_builder/SKILL.md
@@ -59,15 +59,17 @@ short conversation:
 - **What it's used for** — the kind of question Condor should be able to ask it. This
   becomes `when_to_consult`.
 
-That's enough to create it. Pick a sensible default model (easiest thing to change
-later) and create:
+That's enough to create it. **Pick the model from what the operator actually has** —
+call `get_available_models` once and choose a sensible default for THIS agent's job (see
+**Model selection** below for the heuristic); it's the easiest thing to change later.
+Then create:
 
 ```
 manage_trading_agent(
     action="create_agent",
     name="Executor Manager",
     description="Expert in deploying and tuning Hummingbot executors",
-    agent_key="ollama:qwen3:32b",          # default model; change anytime
+    agent_key="openrouter:anthropic/claude-sonnet-4-5",   # chosen from get_available_models; change anytime
     when_to_consult="When the user wants to deploy, tune, or stop an executor",
     tools=[],                              # leave open unless the user named tools
     instructions="<AGENT.md body — the agent's system prompt>"
@@ -205,12 +207,36 @@ against this string, so vague ones cause misses. Rules:
   controller backtesting"). Same shape applies to a skill's `when_to_use`.
 
 **Model selection:** Set per session, not baked in. The agent/strategy `agent_key` is the
-default; override at launch via `config={"agent_key": "…"}`.
-- ACP (subprocess CLI): `claude-code`, `gemini`, `copilot`
-- Pydantic-AI local: `ollama:llama3.1`, `ollama:qwen3:32b`, `lmstudio:<model>`
-- Pydantic-AI cloud: `openai:gpt-4o`, `groq:llama-3.3-70b-versatile`
-- Custom endpoint: `openai:<model>` + `model_base_url` in config.
-Default URLs: Ollama=localhost:11434, LM Studio=localhost:1234.
+default; override at launch via `config={"agent_key": "…"}`. **Recommend from what the
+operator actually has — call `get_available_models` and pick for the agent's job. Do NOT
+default to a hardcoded model.** The tool reports:
+- `acp_clis` — subscription/CLI bridges (`claude-code`, `gemini`, `copilot`, `codex`) and
+  whether each launcher is installed. No API key or per-token cost (rides the operator's
+  Claude/ChatGPT subscription); runs unrestricted (does NOT enforce the `tools` allowlist).
+- `local` — `ollama` / `lmstudio`, each with the models currently **loaded** (empty =
+  server not running). Free, private, offline; addressed as `ollama:<model>` /
+  `lmstudio:<model>`. Only offer a local model that is actually loaded.
+- `cloud_keys` — which of openrouter / openai / anthropic / groq / google keys are set.
+- `openrouter` — tool-capable catalog, cheapest first, each with a ready `agent_key`
+  (`openrouter:<slug>`) and in/out $/Mtok. **The catalog is public — recommendations work
+  with no key.** If `openrouter.key_present` is false, those models need `OPENROUTER_API_KEY`
+  (web Settings) before they can run — say so and prefer a runnable option (a loaded local
+  model, or an installed ACP CLI) unless the user wants to add a key.
+
+Choose by the agent's job, not by habit:
+- **Correctness-critical / high-capital** (decides real trades) → a strong model: an ACP
+  subscription bridge, or a capable OpenRouter model (e.g. a Claude/GPT/DeepSeek-V3-class,
+  not a tiny "flash" model — lightweight models drop instructions, e.g. answering in the
+  wrong language). Validate a cheaper pick with a `dry_run` before going live.
+- **Simple report / watch loop, or privacy / offline / zero-cost** → a loaded local model
+  (`ollama:…`/`lmstudio:…`) or a cheap OpenRouter model.
+- **Must be sandboxed to specific `tools`** → a pydantic-ai key
+  (`openrouter:`/`ollama:`/`lmstudio:`/`openai:`/`groq:`); only these enforce the allowlist.
+- Custom OpenAI-compatible endpoint (remote Ollama, vLLM): `openai:<model>` +
+  `model_base_url` in config. Default local URLs: Ollama=localhost:11434, LM Studio=localhost:1234.
+
+Propose one sensible pick with a one-line why; offer the alternatives you saw. Don't turn
+it into a questionnaire — it's the easiest thing to change later.
 
 **Generic vs Specific strategies:**
 - GENERIC (default): pair/connector are NOT in the instructions — passed at launch via

--- a/assistants/condor/skills/agent_builder/SKILL.md
+++ b/assistants/condor/skills/agent_builder/SKILL.md
@@ -211,8 +211,11 @@ default; override at launch via `config={"agent_key": "…"}`. **Recommend from 
 operator actually has — call `get_available_models` and pick for the agent's job. Do NOT
 default to a hardcoded model.** The tool reports:
 - `acp_clis` — subscription/CLI bridges (`claude-code`, `gemini`, `copilot`, `codex`) and
-  whether each launcher is installed. No API key or per-token cost (rides the operator's
+  whether each CLI is installed. No API key or per-token cost (rides the operator's
   Claude/ChatGPT subscription); runs unrestricted (does NOT enforce the `tools` allowlist).
+  **`available` means installed, not signed in** — each bridge needs its own interactive
+  login that Condor cannot probe. Never recommend one as if it were ready; name it as an
+  option and ask the user to confirm they use it.
 - `local` — `ollama` / `lmstudio`, each with the models currently **loaded** (empty =
   server not running). Free, private, offline; addressed as `ollama:<model>` /
   `lmstudio:<model>`. Only offer a local model that is actually loaded.
@@ -224,8 +227,10 @@ default to a hardcoded model.** The tool reports:
   model, or an installed ACP CLI) unless the user wants to add a key.
 
 Choose by the agent's job, not by habit:
-- **Correctness-critical / high-capital** (decides real trades) → a strong model: an ACP
-  subscription bridge, or a capable OpenRouter model (e.g. a Claude/GPT/DeepSeek-V3-class,
+- **Correctness-critical / high-capital** (decides real trades) → a strong model. Lead with
+  a credential you can verify: if `openrouter.key_present` (or another `cloud_keys` provider)
+  is true, recommend from there; offer an ACP bridge as the alternative to confirm, not the
+  default. Pick a capable OpenRouter model (e.g. a Claude/GPT/DeepSeek-V3-class,
   not a tiny "flash" model — lightweight models drop instructions, e.g. answering in the
   wrong language). Validate a cheaper pick with a `dry_run` before going live.
 - **Simple report / watch loop, or privacy / offline / zero-cost** → a loaded local model

--- a/condor/acp/pydantic_ai_client.py
+++ b/condor/acp/pydantic_ai_client.py
@@ -486,7 +486,12 @@ class PydanticAIClient:
             command = srv_config["command"]
             args = srv_config.get("args", [])
 
-            env = dict(self.extra_env or {})
+            # Inherit the parent process env (same as ACPClient) so cloud keys
+            # loaded via dotenv — e.g. OPENROUTER_API_KEY — reach MCP tools like
+            # get_available_models. extra_env / per-server env overlay on top.
+            env = dict(os.environ)
+            if self.extra_env:
+                env.update(self.extra_env)
             for env_entry in srv_config.get("env", []):
                 if isinstance(env_entry, dict):
                     env[env_entry["name"]] = env_entry["value"]
@@ -494,7 +499,7 @@ class PydanticAIClient:
             mcp_server = MCPServerStdio(
                 command,
                 args=args,
-                env=env if env else None,
+                env=env,
                 timeout=30,
             )
 

--- a/condor/web/app.py
+++ b/condor/web/app.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 from urllib.parse import urlparse
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -94,7 +94,17 @@ def create_app() -> FastAPI:
 
         @app.get("/{full_path:path}")
         async def serve_spa(request: Request, full_path: str):
-            """SPA fallback: serve index.html for all non-API routes."""
+            """SPA fallback: serve index.html for all non-API routes.
+
+            An unknown ``/api/`` path is a real 404, never index.html: a frontend
+            running ahead of the backend would otherwise get 200 HTML where it
+            expects JSON, and surface the version skew as an opaque parse error
+            instead of a missing route.
+            """
+            if full_path.startswith("api/"):
+                raise HTTPException(
+                    status_code=404, detail=f"No such API route: /{full_path}"
+                )
             if full_path:
                 try:
                     candidate = (dist / full_path).resolve()

--- a/condor/web/routes/chat_ws.py
+++ b/condor/web/routes/chat_ws.py
@@ -33,6 +33,7 @@ from handlers.agents._shared import (
     load_assistant,
 )
 from handlers.agents.confirmation import _format_tool_summary
+from handlers.agents.openrouter_models import fetch_models
 from handlers.agents.session import destroy_session, get_or_create_session, get_session
 
 log = logging.getLogger(__name__)
@@ -486,4 +487,27 @@ async def get_chat_options(user: WebUser = Depends(get_current_user)):
         ],
         "default_agent": DEFAULT_AGENT,
         "default_mode": DEFAULT_MODE,
+    }
+
+
+@router.get("/chat/openrouter/models")
+async def get_openrouter_models(user: WebUser = Depends(get_current_user)):
+    """OpenRouter models that support tool-calling, for the web model picker.
+
+    Mirrors the Telegram OpenRouter picker: the catalog is public/unauthenticated,
+    so this works without OPENROUTER_API_KEY set. Starting a session with one of
+    these models still requires the key, and raises a clear error if it is unset.
+    """
+    models = await fetch_models()
+    return {
+        "models": [
+            {
+                "slug": m.slug,
+                "name": m.name,
+                "context_length": m.context_length,
+                "prompt_price": m.prompt_price,
+                "completion_price": m.completion_price,
+            }
+            for m in models
+        ],
     }

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -390,7 +390,13 @@ function AgentDropdown({
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
 
-  const directAgents = agents.filter((a) => !a.key.endsWith(":"));
+  // Direct picks: the CLI/ACP agents plus the local "Default Model" sentinels
+  // (ollama:/lmstudio:), which select a loaded local model directly — same set
+  // the Telegram /agent picker shows. Only "openrouter:" is a real picker (it
+  // needs a specific model chosen), handled by the submenu below.
+  const directAgents = agents.filter(
+    (a) => !a.key.endsWith(":") || a.key === "ollama:" || a.key === "lmstudio:",
+  );
   const hasOpenRouter = agents.some((a) => a.key === "openrouter:");
   const label = agentDisplayLabel(selectedAgent, agents, models);
 

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -3,10 +3,13 @@ import {
   AlertTriangle,
   Brain,
   ChevronDown,
+  ChevronLeft,
+  ChevronRight,
   Loader2,
   MessageSquare,
   Minus,
   Plus,
+  Search,
   Server,
   X,
   Zap,
@@ -14,7 +17,12 @@ import {
 import { useChatSocket, type ChatSlot } from "@/hooks/useChatSocket";
 import { ChatMessageView } from "./ChatMessage";
 import { ChatInput } from "./ChatInput";
-import { api, type ChatAgentOption, type ChatModeOption } from "@/lib/api";
+import {
+  api,
+  type ChatAgentOption,
+  type ChatModeOption,
+  type OpenRouterModelOption,
+} from "@/lib/api";
 import { useServer } from "@/hooks/useServer";
 import { useResizeDrag } from "@/hooks/useResizeDrag";
 
@@ -126,9 +134,6 @@ export function ChatPanel({ isOpen, onToggle }: ChatPanelProps) {
   const effectiveAgent = selectedAgent || defaultAgent;
   const effectiveMode = selectedMode || defaultMode;
 
-  // Filter out sentinel keys (ending with :) that are pickers, not direct agents
-  const directAgents = agents.filter((a) => !a.key.endsWith(":"));
-
   return (
     <>
       {/* Panel -- slides from right, below navbar */}
@@ -182,7 +187,7 @@ export function ChatPanel({ isOpen, onToggle }: ChatPanelProps) {
               </button>
               {showNewMenu && (
                 <NewSessionMenu
-                  agents={directAgents}
+                  agents={agents}
                   modes={modes}
                   selectedAgent={effectiveAgent}
                   selectedMode={effectiveMode}
@@ -272,7 +277,7 @@ export function ChatPanel({ isOpen, onToggle }: ChatPanelProps) {
             </div>
           ) : !activeSlot ? (
             <EmptyState
-              agents={directAgents}
+              agents={agents}
               modes={modes}
               defaultAgent={defaultAgent}
               defaultMode={defaultMode}
@@ -342,6 +347,190 @@ function shortAgentLabel(agentKey: string, agents: ChatAgentOption[]): string {
   return shortMap[full] || (full.length > 12 ? full.slice(0, 12) + "..." : full);
 }
 
+// ── Agent Dropdown (shared) ──
+
+/** Resolve the button label for the current selection, incl. openrouter:<slug>. */
+function agentDisplayLabel(
+  agentKey: string,
+  agents: ChatAgentOption[],
+  orModels: OpenRouterModelOption[] | null,
+): string {
+  const match = agents.find((a) => a.key === agentKey);
+  if (match) return match.label;
+  if (agentKey.startsWith("openrouter:")) {
+    const slug = agentKey.slice("openrouter:".length);
+    const model = orModels?.find((m) => m.slug === slug);
+    return `OpenRouter: ${model?.name || slug}`;
+  }
+  return agentKey;
+}
+
+/**
+ * Model selector used by both the new-session menu and the empty state.
+ *
+ * Direct agents (CLI/ACP) select immediately. The "openrouter:" sentinel from
+ * the backend opens a searchable model list (fetched lazily on first open);
+ * picking a model sets the agent to "openrouter:<slug>".
+ */
+function AgentDropdown({
+  agents,
+  selectedAgent,
+  onSelectAgent,
+  variant,
+}: {
+  agents: ChatAgentOption[];
+  selectedAgent: string;
+  onSelectAgent: (key: string) => void;
+  variant: "block" | "inline";
+}) {
+  const [open, setOpen] = useState(false);
+  const [showModels, setShowModels] = useState(false);
+  const [models, setModels] = useState<OpenRouterModelOption[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+
+  const directAgents = agents.filter((a) => !a.key.endsWith(":"));
+  const hasOpenRouter = agents.some((a) => a.key === "openrouter:");
+  const label = agentDisplayLabel(selectedAgent, agents, models);
+
+  const loadModels = () => {
+    if (models || loading) return;
+    setLoading(true);
+    setError(null);
+    api
+      .getOpenRouterModels()
+      .then((res) => setModels(res.models))
+      .catch(() => setError("Failed to load OpenRouter models"))
+      .finally(() => setLoading(false));
+  };
+
+  const closeAll = () => {
+    setOpen(false);
+    setShowModels(false);
+    setQuery("");
+  };
+
+  const q = query.trim().toLowerCase();
+  const filtered = (models || []).filter(
+    (m) => !q || m.slug.toLowerCase().includes(q) || m.name.toLowerCase().includes(q),
+  );
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className={
+          variant === "block"
+            ? "flex w-full items-center justify-between rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2.5 py-1.5 text-left text-xs text-[var(--color-text)] hover:border-[var(--color-primary)]/40"
+            : "flex items-center gap-1.5 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-xs text-[var(--color-text)] hover:border-[var(--color-primary)]/40"
+        }
+      >
+        <span className="truncate">{label}</span>
+        <ChevronDown className="ml-1 h-3 w-3 shrink-0 text-[var(--color-text-muted)]" />
+      </button>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={closeAll} />
+          <div
+            className={`absolute top-full z-50 mt-1 flex max-h-64 flex-col overflow-y-auto rounded border border-[var(--color-border)] bg-[var(--color-surface)] py-0.5 shadow-lg ${
+              variant === "block" ? "left-0 w-full" : "left-1/2 w-56 -translate-x-1/2"
+            }`}
+          >
+            {!showModels ? (
+              <>
+                {directAgents.map((a) => (
+                  <button
+                    key={a.key}
+                    onClick={() => {
+                      onSelectAgent(a.key);
+                      closeAll();
+                    }}
+                    className={`flex w-full items-center px-2.5 py-1.5 text-left text-xs hover:bg-[var(--color-surface-hover)] ${
+                      a.key === selectedAgent
+                        ? "font-medium text-[var(--color-primary)]"
+                        : "text-[var(--color-text)]"
+                    }`}
+                  >
+                    {a.label}
+                  </button>
+                ))}
+                {hasOpenRouter && (
+                  <button
+                    onClick={() => {
+                      setShowModels(true);
+                      loadModels();
+                    }}
+                    className={`flex w-full items-center justify-between px-2.5 py-1.5 text-left text-xs hover:bg-[var(--color-surface-hover)] ${
+                      selectedAgent.startsWith("openrouter:")
+                        ? "font-medium text-[var(--color-primary)]"
+                        : "text-[var(--color-text)]"
+                    }`}
+                  >
+                    <span>OpenRouter — Pick Model</span>
+                    <ChevronRight className="h-3 w-3 shrink-0 text-[var(--color-text-muted)]" />
+                  </button>
+                )}
+              </>
+            ) : (
+              <>
+                <button
+                  onClick={() => setShowModels(false)}
+                  className="flex items-center gap-1 border-b border-[var(--color-border)] px-2.5 py-1.5 text-left text-[11px] text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+                >
+                  <ChevronLeft className="h-3 w-3" /> Back
+                </button>
+                <div className="sticky top-0 flex items-center gap-1 border-b border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1.5">
+                  <Search className="h-3 w-3 shrink-0 text-[var(--color-text-muted)]" />
+                  <input
+                    autoFocus
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder="Search models..."
+                    className="w-full bg-transparent text-xs text-[var(--color-text)] placeholder:text-[var(--color-text-muted)] focus:outline-none"
+                  />
+                </div>
+                {loading && (
+                  <div className="flex items-center gap-2 px-2.5 py-2 text-xs text-[var(--color-text-muted)]">
+                    <Loader2 className="h-3 w-3 animate-spin" /> Loading models…
+                  </div>
+                )}
+                {error && <div className="px-2.5 py-2 text-xs text-red-400">{error}</div>}
+                {!loading && !error && filtered.length === 0 && (
+                  <div className="px-2.5 py-2 text-xs text-[var(--color-text-muted)]">
+                    No models found
+                  </div>
+                )}
+                {filtered.map((m) => (
+                  <button
+                    key={m.slug}
+                    title={m.slug}
+                    onClick={() => {
+                      onSelectAgent(`openrouter:${m.slug}`);
+                      closeAll();
+                    }}
+                    className={`flex w-full flex-col items-start px-2.5 py-1.5 text-left text-xs hover:bg-[var(--color-surface-hover)] ${
+                      selectedAgent === `openrouter:${m.slug}`
+                        ? "font-medium text-[var(--color-primary)]"
+                        : "text-[var(--color-text)]"
+                    }`}
+                  >
+                    <span className="w-full truncate">{m.name}</span>
+                    <span className="w-full truncate text-[10px] text-[var(--color-text-muted)]">
+                      {m.slug}
+                      {m.prompt_price > 0 ? ` · $${m.prompt_price.toFixed(2)}/M in` : " · free"}
+                    </span>
+                  </button>
+                ))}
+              </>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
 // ── New Session Menu ──
 
 function NewSessionMenu({
@@ -363,9 +552,6 @@ function NewSessionMenu({
   onStart: (agent: string, mode: string) => void;
   onClose: () => void;
 }) {
-  const [showAgentPicker, setShowAgentPicker] = useState(false);
-
-  const agentLabel = agents.find((a) => a.key === selectedAgent)?.label || selectedAgent;
   const ModeIcon = MODE_ICONS[selectedMode] || Zap;
 
   return (
@@ -377,34 +563,13 @@ function NewSessionMenu({
           <label className="text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
             Model
           </label>
-          <div className="relative mt-1">
-            <button
-              onClick={() => setShowAgentPicker((v) => !v)}
-              className="flex w-full items-center justify-between rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2.5 py-1.5 text-left text-xs text-[var(--color-text)] hover:border-[var(--color-primary)]/40"
-            >
-              <span className="truncate">{agentLabel}</span>
-              <ChevronDown className="ml-1 h-3 w-3 shrink-0 text-[var(--color-text-muted)]" />
-            </button>
-            {showAgentPicker && (
-              <div className="absolute left-0 top-full z-10 mt-1 max-h-48 w-full overflow-y-auto rounded border border-[var(--color-border)] bg-[var(--color-surface)] py-0.5 shadow-lg">
-                {agents.map((a) => (
-                  <button
-                    key={a.key}
-                    onClick={() => {
-                      onSelectAgent(a.key);
-                      setShowAgentPicker(false);
-                    }}
-                    className={`flex w-full items-center px-2.5 py-1.5 text-left text-xs hover:bg-[var(--color-surface-hover)] ${
-                      a.key === selectedAgent
-                        ? "text-[var(--color-primary)] font-medium"
-                        : "text-[var(--color-text)]"
-                    }`}
-                  >
-                    {a.label}
-                  </button>
-                ))}
-              </div>
-            )}
+          <div className="mt-1">
+            <AgentDropdown
+              agents={agents}
+              selectedAgent={selectedAgent}
+              onSelectAgent={onSelectAgent}
+              variant="block"
+            />
           </div>
         </div>
 
@@ -462,9 +627,6 @@ function EmptyState({
   onStart: (agent: string, mode: string) => void;
 }) {
   const [selectedAgent, setSelectedAgent] = useState(defaultAgent);
-  const [showAgentPicker, setShowAgentPicker] = useState(false);
-
-  const agentLabel = agents.find((a) => a.key === selectedAgent)?.label || selectedAgent;
 
   return (
     <div className="flex h-full flex-col items-center justify-center text-center">
@@ -475,37 +637,13 @@ function EmptyState({
 
       {/* Agent picker */}
       {agents.length > 1 && (
-        <div className="relative mt-4 mb-2">
-          <button
-            onClick={() => setShowAgentPicker((v) => !v)}
-            className="flex items-center gap-1.5 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-xs text-[var(--color-text)] hover:border-[var(--color-primary)]/40"
-          >
-            <span>{agentLabel}</span>
-            <ChevronDown className="h-3 w-3 text-[var(--color-text-muted)]" />
-          </button>
-          {showAgentPicker && (
-            <>
-              <div className="fixed inset-0 z-40" onClick={() => setShowAgentPicker(false)} />
-              <div className="absolute left-1/2 top-full z-50 mt-1 max-h-48 w-48 -translate-x-1/2 overflow-y-auto rounded border border-[var(--color-border)] bg-[var(--color-surface)] py-0.5 shadow-lg">
-                {agents.map((a) => (
-                  <button
-                    key={a.key}
-                    onClick={() => {
-                      setSelectedAgent(a.key);
-                      setShowAgentPicker(false);
-                    }}
-                    className={`flex w-full items-center px-3 py-1.5 text-left text-xs hover:bg-[var(--color-surface-hover)] ${
-                      a.key === selectedAgent
-                        ? "text-[var(--color-primary)] font-medium"
-                        : "text-[var(--color-text)]"
-                    }`}
-                  >
-                    {a.label}
-                  </button>
-                ))}
-              </div>
-            </>
-          )}
+        <div className="mt-4 mb-2">
+          <AgentDropdown
+            agents={agents}
+            selectedAgent={selectedAgent}
+            onSelectAgent={setSelectedAgent}
+            variant="inline"
+          />
         </div>
       )}
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -664,6 +664,14 @@ export interface ChatOptionsResponse {
   default_mode: string;
 }
 
+export interface OpenRouterModelOption {
+  slug: string;
+  name: string;
+  context_length: number;
+  prompt_price: number;
+  completion_price: number;
+}
+
 // ── Backtesting ──
 
 export interface BacktestTask {
@@ -1371,4 +1379,7 @@ export const api = {
 
   getChatOptions: () =>
     apiFetch<ChatOptionsResponse>("/api/v1/chat/options"),
+
+  getOpenRouterModels: () =>
+    apiFetch<{ models: OpenRouterModelOption[] }>("/api/v1/chat/openrouter/models"),
 };

--- a/handlers/agents/__init__.py
+++ b/handlers/agents/__init__.py
@@ -304,21 +304,14 @@ async def _handle_openrouter_picker(
     Fetches the model list (cached for 1h), filters to tool-calling models, and
     stores the resolved list in user_data so or_pick:N can resolve the index.
     """
-    import os
-
     from .menu import _openrouter_picker_keyboard
     from .openrouter_models import fetch_models
 
     query = update.callback_query
 
-    # Surface a hint instead of silently presenting an unusable picker
-    if not os.environ.get("OPENROUTER_API_KEY"):
-        await query.message.edit_text(
-            "OPENROUTER_API_KEY is not set. Add it to your .env to use OpenRouter models, "
-            "then restart the bot.\n\nGet a key at https://openrouter.ai/keys"
-        )
-        return
-
+    # The catalog is public, so browse it without a key — same as the web picker
+    # (condor/web/routes/chat_ws.py). The key is only needed to RUN a model; that
+    # is enforced with a clear error at session start (pydantic_ai_client.py).
     if page == 0:
         await query.message.edit_text("Loading OpenRouter models...")
 

--- a/mcp_servers/condor/server.py
+++ b/mcp_servers/condor/server.py
@@ -7,6 +7,7 @@ All business logic lives in mcp_servers.condor.tools.*
 from mcp.server.fastmcp import FastMCP
 
 from mcp_servers.condor.middleware import handle_errors
+from mcp_servers.condor.tools import available_models as available_models_tool
 from mcp_servers.condor.tools import consult as consult_tool
 from mcp_servers.condor.tools import context
 from mcp_servers.condor.tools import delegate as delegate_tool
@@ -248,6 +249,47 @@ async def get_user_context() -> dict:
         - is_admin: Whether the user is an admin
     """
     return await context.get_user_context()
+
+
+@mcp.tool()
+@handle_errors("get available models")
+async def get_available_models(
+    openrouter_query: str = "", openrouter_limit: int = 20
+) -> dict:
+    """List every model/provider currently usable for a trading agent's ``agent_key``.
+
+    Use this when helping the user pick a model for an agent they are building
+    (agent_builder skill) — recommend from what is ACTUALLY configured, not a
+    hardcoded default. Read-only; never returns key values.
+
+    Args:
+        openrouter_query: Optional substring to filter the OpenRouter catalog by
+            slug or name (e.g. "claude", "deepseek", "free"). Empty = no filter.
+        openrouter_limit: Max OpenRouter models to return (default 20, cheapest
+            input price first). ``total_matching`` reports how many matched.
+
+    Returns a dict with:
+      - acp_clis: subscription/CLI bridges (claude-code, gemini, copilot, …),
+        each with ``agent_key`` and ``available`` (launcher binary on PATH).
+      - cloud_keys: {provider: bool} — whether OPENROUTER/OPENAI/ANTHROPIC/GROQ/
+        GOOGLE keys are set in the environment.
+      - local: {ollama, lmstudio} each with ``base_url``, ``reachable``, and the
+        ``models`` currently loaded on that server (empty if not running).
+      - openrouter: tool-capable catalog (``models`` with ``agent_key`` set to
+        ``openrouter:<slug>``, plus in/out $/Mtok and context). The catalog is
+        public so this is ALWAYS present — no key needed to recommend. Check
+        ``key_present``: false means these are options that need OPENROUTER_API_KEY
+        added (Settings) before they can run; recommend a runnable option first.
+
+    Guidance for choosing: correctness-critical or high-capital agents → a strong
+    model (a subscription ACP bridge, or a capable OpenRouter model); simple
+    report/watch loops or privacy/offline needs → a loaded local model or a cheap
+    OpenRouter one. Only pydantic-ai keys (openrouter:/ollama:/lmstudio:/openai:/
+    groq:) enforce an agent's ``tools`` allowlist; ACP bridges run unrestricted.
+    """
+    return await available_models_tool.get_available_models(
+        openrouter_query, openrouter_limit
+    )
 
 
 @mcp.tool()

--- a/mcp_servers/condor/server.py
+++ b/mcp_servers/condor/server.py
@@ -270,7 +270,12 @@ async def get_available_models(
 
     Returns a dict with:
       - acp_clis: subscription/CLI bridges (claude-code, gemini, copilot, …),
-        each with ``agent_key`` and ``available`` (launcher binary on PATH).
+        each with ``agent_key`` and ``available`` — the CLI is installed and
+        launchable. ``available`` does NOT mean signed in: every bridge needs its
+        own interactive login (Claude/Google/GitHub/OpenAI) that cannot be probed
+        from here. Treat a bridge as a candidate to CONFIRM with the user, and
+        prefer a credential you can verify (a set ``cloud_keys`` provider, or a
+        loaded local model) when recommending unprompted.
       - cloud_keys: {provider: bool} — whether OPENROUTER/OPENAI/ANTHROPIC/GROQ/
         GOOGLE keys are set in the environment.
       - local: {ollama, lmstudio} each with ``base_url``, ``reachable``, and the
@@ -282,7 +287,8 @@ async def get_available_models(
         added (Settings) before they can run; recommend a runnable option first.
 
     Guidance for choosing: correctness-critical or high-capital agents → a strong
-    model (a subscription ACP bridge, or a capable OpenRouter model); simple
+    model (a capable OpenRouter model when its key is set, or a subscription ACP
+    bridge the user confirms is signed in); simple
     report/watch loops or privacy/offline needs → a loaded local model or a cheap
     OpenRouter one. Only pydantic-ai keys (openrouter:/ollama:/lmstudio:/openai:/
     groq:) enforce an agent's ``tools`` allowlist; ACP bridges run unrestricted.

--- a/mcp_servers/condor/tools/available_models.py
+++ b/mcp_servers/condor/tools/available_models.py
@@ -1,0 +1,126 @@
+"""Detect which models/providers are actually usable right now.
+
+Backs the agent_builder skill's model recommendation: instead of guessing or
+hardcoding a default, the assistant asks what the operator has actually
+configured — installed ACP CLI bridges, cloud API keys present in the
+environment, reachable local model servers (Ollama / LM Studio) with the models
+they have loaded, and (only when an OpenRouter key is set) the tool-capable
+OpenRouter catalog, cheapest first.
+
+Read-only and side-effect-free. NEVER returns a key value — only whether each
+key's env var is set. An unreachable local server is a normal state (the user
+simply isn't running it), reported as ``reachable: false``, never raised.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+
+import httpx
+
+from condor.acp import ACP_COMMANDS
+from condor.acp.pydantic_ai_client import DEFAULT_BASE_URLS
+from handlers.agents.openrouter_models import fetch_models
+
+# Cloud providers Condor can address as "<prefix>:<model>", mapped to the env
+# var holding each key. Presence of the key = the provider is usable. Sourced
+# here (not hardcoded elsewhere) so the set stays in one place.
+_CLOUD_KEY_ENVS = {
+    "openrouter": "OPENROUTER_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "groq": "GROQ_API_KEY",
+    "google": "GOOGLE_API_KEY",
+}
+
+# Local, keyless OpenAI-compatible servers. Base URLs come from the resolver's
+# own defaults (DEFAULT_BASE_URLS) so they can never drift from what actually
+# runs the model at request time.
+_LOCAL_PREFIXES = ("ollama", "lmstudio")
+
+
+def _acp_clis() -> list[dict]:
+    """ACP CLI bridges and whether each launcher binary is on PATH."""
+    binary_available: dict[str, bool] = {}
+    out: list[dict] = []
+    for base, cmd in ACP_COMMANDS.items():
+        binary = cmd.split()[0] if cmd else ""
+        if binary not in binary_available:
+            binary_available[binary] = shutil.which(binary) is not None
+        out.append(
+            {"agent_key": base, "command": cmd, "available": binary_available[binary]}
+        )
+    return out
+
+
+async def _local_servers() -> dict:
+    """Probe local OpenAI-compatible servers and list their loaded models.
+
+    Unreachable servers are reported (``reachable: false``), not raised — the
+    user just isn't running that server.
+    """
+    result: dict = {}
+    timeout = httpx.Timeout(connect=1.5, read=3.0, write=1.5, pool=1.5)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        for prefix in _LOCAL_PREFIXES:
+            base = DEFAULT_BASE_URLS.get(prefix)
+            entry = {"base_url": base, "reachable": False, "models": []}
+            if base:
+                try:
+                    resp = await client.get(f"{base.rstrip('/')}/models")
+                    if resp.status_code == 200:
+                        data = resp.json().get("data", [])
+                        entry["reachable"] = True
+                        entry["models"] = sorted(
+                            m["id"] for m in data if isinstance(m, dict) and m.get("id")
+                        )
+                except Exception:
+                    pass  # not running = normal, leave reachable=False
+            result[prefix] = entry
+    return result
+
+
+async def _openrouter(query: str, limit: int) -> dict:
+    """Tool-capable OpenRouter catalog, cheapest first.
+
+    The catalog is public, so recommendations work WITHOUT a key. ``key_present``
+    reports whether OPENROUTER_API_KEY is set — i.e. whether these models can be
+    RUN now, or are shown as options the operator would need to enable a key for.
+    """
+    key_present = bool(os.environ.get("OPENROUTER_API_KEY"))
+    models = await fetch_models()  # already filtered to tool-calling support
+    q = query.strip().lower()
+    matched = [m for m in models if not q or q in m.slug.lower() or q in m.name.lower()]
+    matched.sort(key=lambda m: (m.prompt_price, m.slug))  # cheapest input price first
+    shown = matched[:limit]
+    return {
+        "key_present": key_present,
+        "total_matching": len(matched),
+        "shown": len(shown),
+        "models": [
+            {
+                "agent_key": f"openrouter:{m.slug}",
+                "name": m.name,
+                "context_length": m.context_length,
+                "usd_per_mtok_in": round(m.prompt_price, 4),
+                "usd_per_mtok_out": round(m.completion_price, 4),
+            }
+            for m in shown
+        ],
+    }
+
+
+async def get_available_models(
+    openrouter_query: str = "", openrouter_limit: int = 20
+) -> dict:
+    """Report every model/provider currently usable for an agent's ``agent_key``."""
+    cloud_keys = {
+        prefix: bool(os.environ.get(env)) for prefix, env in _CLOUD_KEY_ENVS.items()
+    }
+    return {
+        "acp_clis": _acp_clis(),
+        "cloud_keys": cloud_keys,
+        "local": await _local_servers(),
+        "openrouter": await _openrouter(openrouter_query, openrouter_limit),
+    }

--- a/mcp_servers/condor/tools/available_models.py
+++ b/mcp_servers/condor/tools/available_models.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import os
 import shutil
+import subprocess
+from pathlib import Path
 
 import httpx
 
@@ -40,17 +42,59 @@ _CLOUD_KEY_ENVS = {
 _LOCAL_PREFIXES = ("ollama", "lmstudio")
 
 
+def _npx_packages_installed() -> set[str]:
+    """npm packages resolvable WITHOUT a network install: local, global, npx cache.
+
+    Mirrors how npx resolves a package before falling back to downloading it.
+    ``shutil.which("npx")`` says nothing about the package — npx exists whenever
+    Node does — so probing the launcher would mark every ``npx``-run bridge
+    available on any machine with Node.
+    """
+    roots = [Path.cwd() / "node_modules"]
+    npm = shutil.which("npm")
+    if npm:
+        try:
+            proc = subprocess.run(
+                [npm, "root", "-g"], capture_output=True, text=True, timeout=10
+            )
+            if proc.returncode == 0 and proc.stdout.strip():
+                roots.append(Path(proc.stdout.strip()))
+        except (OSError, subprocess.SubprocessError):
+            pass  # npm unusable = nothing installed via it; local + cache still count
+    roots.extend((Path.home() / ".npm" / "_npx").glob("*/node_modules"))
+
+    installed: set[str] = set()
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for entry in root.iterdir():
+            if entry.name.startswith("@"):
+                installed.update(f"{entry.name}/{sub.name}" for sub in entry.iterdir())
+            else:
+                installed.add(entry.name)
+    return installed
+
+
 def _acp_clis() -> list[dict]:
-    """ACP CLI bridges and whether each launcher binary is on PATH."""
-    binary_available: dict[str, bool] = {}
+    """ACP CLI bridges and whether each one is actually installed.
+
+    A bridge launched as ``npx <package> …`` is available only if the PACKAGE is
+    already installed; a bare command is available if it is on PATH. Note that
+    ``available`` means "launchable" — every ACP bridge additionally needs its
+    own interactive login (Claude/Google/GitHub/OpenAI), which cannot be probed
+    from here, so an available bridge is not necessarily a working one.
+    """
+    npx_packages = _npx_packages_installed()
     out: list[dict] = []
     for base, cmd in ACP_COMMANDS.items():
-        binary = cmd.split()[0] if cmd else ""
-        if binary not in binary_available:
-            binary_available[binary] = shutil.which(binary) is not None
-        out.append(
-            {"agent_key": base, "command": cmd, "available": binary_available[binary]}
-        )
+        parts = cmd.split()
+        if not parts:
+            available = False
+        elif parts[0] == "npx":
+            available = parts[1] in npx_packages if len(parts) > 1 else False
+        else:
+            available = shutil.which(parts[0]) is not None
+        out.append({"agent_key": base, "command": cmd, "available": available})
     return out
 
 


### PR DESCRIPTION
## Summary

Two related changes so users can **choose, and be guided to, the right model** — both for the main Condor chat agent and for the autonomous agents they build. The commits are independent and could be split into two PRs.

### 1. Web dashboard model picker — full parity with Telegram `/agent` (`feat(web)`)
The web new-session menu filtered out every "picker" provider (agent keys ending in `:`), so **OpenRouter, Ollama, and LM Studio never appeared** — the dashboard only offered the 6 CLI/ACP agents while Telegram had the full list.

- New `GET /api/v1/chat/openrouter/models` — tool-capable catalog, reusing `fetch_models()`. Public catalog, so no key needed to browse.
- `api.getOpenRouterModels()` + `OpenRouterModelOption` type.
- `ChatPanel`: replaced the two duplicated agent dropdowns with one shared `AgentDropdown`. It now shows the **same set as the Telegram `/agent` picker**: CLI/ACP agents + **Ollama / LM Studio "Default Model"** (direct picks) + **OpenRouter — Pick Model** (searchable submenu → `openrouter:<slug>`).

### 2. Agent builder — recommend a model from what's configured (`feat(agents)`)
The `agent_builder` skill hardcoded a default model and told the assistant *not* to raise model questions, so users never got a pick suited to their setup or the agent's job.

- **New `get_available_models` MCP tool** — provider-agnostic, read-only, never returns key values. Reports installed ACP CLIs; which cloud keys are set (booleans); local Ollama/LM Studio reachability + **loaded models**; and the tool-capable OpenRouter catalog (cheapest first; works with no key — `key_present` flags runnability).
- **`agent_builder` skill** calls the tool at `agent_key` time and recommends by the agent's role: strong model for high-capital/correctness-critical; **local (`ollama:`/`lmstudio:`)** or cheap for simple/private/offline; a pydantic-ai key when the `tools` allowlist must be enforced.

---

## QA / Testing instructions

### Prerequisites
- **OpenRouter:** set `OPENROUTER_API_KEY` (web **Settings → Keys**, or `.env`), then restart Condor. (Browsing/recommending works without a key; *running* a model needs it.)
- **Local models:** have at least one running —
  - **Ollama:** `ollama serve`, then pull a **tool-capable** model, e.g. `ollama pull qwen2.5` (tool-calling is required — pure-chat models won't drive agents). Default endpoint `localhost:11434`.
  - **LM Studio:** load a tool-capable model and start its local server (default `localhost:1234`).
- Hard-refresh the dashboard (Cmd/Ctrl+Shift+R) so the new JS bundle loads.

### Part A — Switch models for the **main Condor agent** (chat assistant)

**A1 — Web, OpenRouter.** Dashboard → open chat → **＋** (or the empty-state model dropdown) → **"OpenRouter — Pick Model"** → search (e.g. `gpt-4o-mini`) → select → **Start Session** → send "hello".
*Pass:* reply streams back; the session tab/label shows the chosen model.

**A2 — Web, local.** Same dropdown → **"Ollama — Default Model"** (or **"LM Studio — Default Model"**) → Start Session → send "hello".
*Pass:* reply comes from the local model (watch `ollama`/LM Studio logs for the hit). *If the server is down you should get a clear error, not a hang.*

**A3 — Web, switch between models.** Start one session on an OpenRouter model and another on a local model; confirm each session uses its own model and you can switch the default for new sessions.
*Pass:* both run; selection is independent per session.

**A4 — Telegram parity.** `/agent` → **Change LLM** → confirm the list matches the web picker (Claude Code, ACP Opus/Sonnet, Gemini, Copilot, Codex, **Ollama — Default Model**, **LM Studio — Default Model**, **OpenRouter — Pick Model**). Pick a local model and an OpenRouter model; send a message on each.
*Pass:* web and Telegram offer the same options and both switch correctly.

### Part B — Switch models for the **agents you build** (agent_builder)

**B1 — Recommendation reflects your config.** In chat, ask: *"Build a trading agent that watches BTC funding."* When it reaches the model step it should call `get_available_models` and **recommend from what you actually have** — your loaded local model(s) and/or OpenRouter options — not a hardcoded default. With no OpenRouter key set, it should still surface options and say a key is needed to run them.
*Pass:* the recommendation names models you actually have and explains the pick by the agent's job.

**B2 — Build on an OpenRouter model.** Let it create the agent on an `openrouter:<slug>`, then **consult** it (Step 2 of the skill).
*Pass:* the consult returns a coherent answer (agent ran on that model). Verify `agents/<slug>/AGENT.md` has `agent_key: openrouter:<slug>`.

**B3 — Build on / switch to a local model.** Ask it to use a local model instead (e.g. *"use my local Ollama model"*) → it sets `agent_key: ollama:<model>` (or `lmstudio:<model>`). Consult again.
*Pass:* the agent runs on the local model; `AGENT.md` shows the local `agent_key`.

**B4 — Change an existing agent's model.** Ask Condor to switch the agent's model (`update_agent`), or override at launch via `config={"agent_key": "…"}`.
*Pass:* the new model takes effect on the next consult/run.

### Notes for testers
- Lightweight "flash" models (e.g. `deepseek-v4-flash`) may ignore instructions (observed: greeting in the wrong language). Prefer a capable model for correctness-critical agents; validate a cheap pick with a `dry_run` before going live.
- Only pydantic-ai keys (`openrouter:`/`ollama:`/`lmstudio:`/`openai:`/`groq:`) enforce an agent's `tools` allowlist; ACP bridges (claude-code/gemini/copilot) run unrestricted.

### Automated/dev verification already done
- Backend `/chat/options` returns all 9 providers; `/chat/openrouter/models` returns the catalog with and without a key.
- Frontend `tsc` clean; production build succeeds.
- `get_available_models` verified: detects configured keys, local reachability, ranked OpenRouter catalog.
- **End-to-end:** created a throwaway agent on a recommended `openrouter:openai/gpt-4o-mini`, confirmed `PydanticAI client ready: model=openrouter:openai/gpt-4o-mini`, consulted it live → correct answer. Agent deleted afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)