### PR TITLE
fix(perf): correct executor + P&L attribution for bot-mode agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,7 @@ node_modules/
 
 # Routine reports
 /reports/
+
+# Agent runtime artifacts: learnings and session journals (not committed)
+agents/**/learnings.md
+agents/**/sessions/

--- a/condor/agents/performance.py
+++ b/condor/agents/performance.py
@@ -89,9 +89,7 @@ def _executor_row(ex: dict) -> dict[str, Any]:
 
     amount = float(cfg.get("total_amount_quote") or cfg.get("amount") or 0)
     if amount <= 0:
-        amount = float(
-            custom_info.get("total_value_quote") or 0
-        )
+        amount = float(custom_info.get("total_value_quote") or 0)
 
     return {
         "id": str(ex.get("id") or ex.get("executor_id") or ""),
@@ -138,14 +136,25 @@ def _merge_bot_perf(perf: AgentPerformance, bot: dict[str, Any]) -> None:
 
     The two sources are disjoint (bot controllers tag executors with their own
     config ids, never the ``agent_id``), so the merge is plain addition — no
-    de-duplication. Fees are left untouched: the bot snapshot carries no fee field.
+    de-duplication. The bot's open positions are surfaced as executor-like rows so
+    bot-mode agents show live positions in both the executors tab and the agent's
+    own core-data view, which otherwise only see the (empty) ``agent_id`` table.
     """
+    from condor.fetchers.bot_performance import bot_executor_rows
+
     perf.realized_pnl += float(bot.get("realized_pnl_quote", 0) or 0)
     perf.unrealized_pnl += float(bot.get("unrealized_pnl_quote", 0) or 0)
     perf.total_pnl = perf.realized_pnl + perf.unrealized_pnl
     perf.volume += float(bot.get("volume_traded", 0) or 0)
+    perf.fees += float(bot.get("cum_fees_quote", 0) or 0)
     perf.bot_name = bot.get("bot_name", perf.bot_name)
     perf.controllers = bot.get("controllers", [])
+
+    rows = bot_executor_rows(bot)
+    perf.executors = perf.executors + rows
+    open_rows = [r for r in rows if r["status"] == "RUNNING"]
+    perf.open_count += len(open_rows)
+    perf.trade_count += len(rows)
 
 
 def _build_perf_from_rows(
@@ -256,7 +265,10 @@ async def fetch_agent_performance_batch(
     # shared across the whole batch since the API returns all bots at once.
     wanted = {bn for bn in (bot_names or {}).values() if bn}
     if wanted:
-        from condor.fetchers.bot_performance import fetch_all_bot_performance
+        from condor.fetchers.bot_performance import (
+            fetch_all_bot_performance,
+            resolve_bot,
+        )
 
         try:
             all_bot_perf = await fetch_all_bot_performance(client)
@@ -267,7 +279,7 @@ async def fetch_agent_performance_batch(
             if not bn or aid not in out:
                 continue
             out[aid].bot_name = bn
-            bot = all_bot_perf.get(bn)
+            bot = resolve_bot(all_bot_perf, bn)
             if bot:
                 _merge_bot_perf(out[aid], bot)
     return out

--- a/condor/fetchers/bot_performance.py
+++ b/condor/fetchers/bot_performance.py
@@ -48,7 +48,13 @@ def extract_snapshots(result: Any) -> list[dict]:
 
 
 def _aggregate_by_bot(snapshots: list[dict]) -> dict[str, dict]:
-    """Roll up per-controller snapshots into one aggregate per bot_name."""
+    """Roll up per-controller snapshots into one aggregate per bot_name.
+
+    Each controller entry keeps its ``positions_summary`` (the open positions the
+    controller holds, with per-position PnL/volume/fees) and ``status`` so callers
+    can render executor-like rows for bot-mode agents, whose executors live in the
+    bot container and never surface in the ``agent_id``-keyed executor table.
+    """
     agg: dict[str, dict] = {}
     for snap in snapshots:
         bn = snap.get("bot_name", "")
@@ -64,26 +70,41 @@ def _aggregate_by_bot(snapshots: list[dict]) -> dict[str, dict]:
                 "unrealized_pnl_quote": 0.0,
                 "global_pnl_quote": 0.0,
                 "volume_traded": 0.0,
+                "cum_fees_quote": 0.0,
                 "num_controllers": 0,
+                "timestamp": "",
                 "controllers": [],
             }
         realized = float(perf.get("realized_pnl_quote", 0) or 0)
         unrealized = float(perf.get("unrealized_pnl_quote", 0) or 0)
         volume = float(perf.get("volume_traded", 0) or 0)
+        positions = [
+            p for p in (perf.get("positions_summary") or []) if isinstance(p, dict)
+        ]
+        fees = sum(float(p.get("cum_fees_quote", 0) or 0) for p in positions)
         agg[bn]["realized_pnl_quote"] += realized
         agg[bn]["unrealized_pnl_quote"] += unrealized
         agg[bn]["global_pnl_quote"] += realized + unrealized
         agg[bn]["volume_traded"] += volume
+        agg[bn]["cum_fees_quote"] += fees
         agg[bn]["num_controllers"] += 1
+        # Track the freshest snapshot timestamp so suffix-tolerant resolution can
+        # pick the most recent deploy of a re-launched bot.
+        ts = str(snap.get("timestamp", "") or "")
+        if ts > agg[bn]["timestamp"]:
+            agg[bn]["timestamp"] = ts
         agg[bn]["controllers"].append(
             {
                 "controller_id": snap.get("controller_id", ""),
                 "controller_name": snap.get("controller_name", ""),
                 "connector": snap.get("connector", snap.get("connector_name", "")),
                 "trading_pair": snap.get("trading_pair", ""),
+                "status": str(snap.get("status", "") or ""),
                 "realized_pnl_quote": realized,
                 "unrealized_pnl_quote": unrealized,
                 "volume_traded": volume,
+                "cum_fees_quote": fees,
+                "positions_summary": positions,
             }
         )
     return agg
@@ -101,11 +122,101 @@ async def fetch_all_bot_performance(client: Any) -> dict[str, dict]:
     return _aggregate_by_bot(extract_snapshots(result))
 
 
+def resolve_bot(all_bot_perf: dict[str, dict], bot_name: str) -> dict | None:
+    """Resolve a configured ``bot_name`` to its live aggregate, suffix-tolerant.
+
+    A bot deploys under an instance name with a timestamp suffix appended
+    (``dn-CL-BRENTOIL-mm`` → ``dn-CL-BRENTOIL-mm-20260724-182221``), while the
+    strategy config only knows the stable base name. Resolution order:
+
+    1. exact match on the base name;
+    2. otherwise, among keys of the form ``<base>-<suffix>``, the one with the
+       freshest snapshot ``timestamp`` (ISO strings sort chronologically), so a
+       re-launched bot resolves to its most recent deploy.
+
+    Returns the aggregate dict (its ``bot_name`` is the full resolved name) or
+    ``None`` when nothing matches.
+    """
+    if not bot_name or not all_bot_perf:
+        return None
+    exact = all_bot_perf.get(bot_name)
+    if exact is not None:
+        return exact
+    prefix = f"{bot_name}-"
+    candidates = [agg for key, agg in all_bot_perf.items() if key.startswith(prefix)]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda a: (str(a.get("timestamp", "")), a["bot_name"]))
+
+
+def _clean_side(side: Any) -> str:
+    """Normalize a ``TradeType.SELL``-style side into a bare ``SELL``/``BUY``."""
+    s = str(side or "").upper()
+    return s.rsplit(".", 1)[-1] if "." in s else s
+
+
+def bot_executor_rows(aggregate: dict) -> list[dict[str, Any]]:
+    """Build executor-like display rows from a resolved bot aggregate.
+
+    One row per open position (from each controller's ``positions_summary``), in
+    the same shape ``condor.agents.performance._executor_row`` emits, so the web
+    executors tab and the agent's core-data view render bot-mode positions the
+    same way as direct executors. Realized PnL from already-closed positions is
+    not row-level here (the snapshot only summarizes open positions); it is still
+    reflected in the aggregate totals the caller applies.
+    """
+    from datetime import datetime
+
+    ts_epoch = 0.0
+    ts_iso = str(aggregate.get("timestamp", "") or "")
+    if ts_iso:
+        try:
+            ts_epoch = datetime.fromisoformat(ts_iso).timestamp()
+        except ValueError:
+            ts_epoch = 0.0
+
+    rows: list[dict[str, Any]] = []
+    for ctrl in aggregate.get("controllers", []):
+        controller_id = ctrl.get("controller_id", "")
+        status = str(ctrl.get("status", "") or "").upper()
+        for pos in ctrl.get("positions_summary", []):
+            pair = pos.get("trading_pair", "")
+            entry = float(pos.get("breakeven_price", 0) or 0)
+            amount = float(pos.get("amount", 0) or 0)
+            unrealized = float(pos.get("unrealized_pnl_quote", 0) or 0)
+            rows.append(
+                {
+                    "id": f"{controller_id}:{pair}" if pair else controller_id,
+                    "type": "controller",
+                    "connector": pos.get("connector_name", ctrl.get("connector", "")),
+                    "pair": pair,
+                    "side": _clean_side(pos.get("side")),
+                    "status": status,
+                    "close_type": "",
+                    # Row PnL is the live (unrealized) mark of the open position;
+                    # realized carries in the aggregate totals, not per-row.
+                    "pnl": unrealized,
+                    "volume": float(pos.get("volume_traded_quote", 0) or 0),
+                    "fees": float(pos.get("cum_fees_quote", 0) or 0),
+                    "entry_price": entry,
+                    "current_price": 0.0,
+                    "amount": abs(amount) * entry,
+                    "timestamp": ts_epoch,
+                    "close_timestamp": 0.0,
+                    "controller_id": controller_id,
+                    "custom_info": {},
+                    "config": {},
+                }
+            )
+    return rows
+
+
 async def fetch_bot_performance(client: Any, bot_name: str) -> dict | None:
     """Return the aggregate for a single bot, or ``None`` if it has no snapshot.
 
-    Resilient: swallows API errors and returns ``None`` so a caller merging this
-    into other performance never breaks on a transient bot-orchestration hiccup.
+    Suffix-tolerant (see :func:`resolve_bot`). Resilient: swallows API errors and
+    returns ``None`` so a caller merging this into other performance never breaks
+    on a transient bot-orchestration hiccup.
     """
     if not client or not bot_name:
         return None
@@ -114,4 +225,4 @@ async def fetch_bot_performance(client: Any, bot_name: str) -> dict | None:
     except Exception as e:
         logger.debug("fetch_bot_performance(%s) failed: %s", bot_name, e)
         return None
-    return all_perf.get(bot_name)
+    return resolve_bot(all_perf, bot_name)

--- a/condor/fetchers/bot_performance.py
+++ b/condor/fetchers/bot_performance.py
@@ -149,6 +149,133 @@ def resolve_bot(all_bot_perf: dict[str, dict], bot_name: str) -> dict | None:
     return max(candidates, key=lambda a: (str(a.get("timestamp", "")), a["bot_name"]))
 
 
+def resolve_bot_instances(all_bot_perf: dict[str, dict], bot_name: str) -> list[str]:
+    """Return every deployed instance name for a base ``bot_name``, newest last.
+
+    Suffix-tolerant like :func:`resolve_bot`, but returns ALL matches (a base that
+    has been re-launched several times) rather than only the freshest — used to
+    time-slice per-session PnL across every instance a strategy has operated.
+    """
+    if not bot_name or not all_bot_perf:
+        return []
+    names = [
+        key for key in all_bot_perf if key == bot_name or key.startswith(f"{bot_name}-")
+    ]
+    return sorted(names, key=lambda k: (str(all_bot_perf[k].get("timestamp", "")), k))
+
+
+# Only genuine round-trip position closes count as "trades". Everything else in
+# close_type_counts is churn or non-trades: EARLY_STOP is pmm order re-quoting
+# (thousands per session), POSITION_HOLD is a fill that built a still-open position,
+# and INSUFFICIENT_BALANCE/FAILED/EXPIRED never executed.
+_TRADE_CLOSE_TYPES = {
+    "CloseType.TAKE_PROFIT",
+    "CloseType.STOP_LOSS",
+    "CloseType.TIME_LIMIT",
+    "CloseType.TRAILING_STOP",
+    "CloseType.COMPLETED",
+}
+
+
+def _iso_to_epoch(ts: Any) -> float | None:
+    from datetime import datetime
+
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(str(ts)).timestamp()
+    except ValueError:
+        return None
+
+
+async def fetch_instance_history(
+    client: Any, instance_name: str, interval: str = "5m", limit: int = 500
+) -> list[tuple[float, float, float, float]]:
+    """Return one bot instance's cumulative history as sorted rows.
+
+    Each row is ``(ts_epoch, cum_realized_quote, cum_volume, cum_trades)`` with the
+    per-controller snapshots at each timestamp summed to a bot-instance total, so a
+    single- and multi-controller bot are handled identically. ``cum_trades`` counts
+    real closes (``close_type_counts`` minus retry/abort noise). The controller
+    performance API retains history for archived/stopped instances, so closed
+    sessions can be attributed too. Resilient: returns ``[]`` on API error.
+    """
+    try:
+        result = await client.bot_orchestration.get_controller_performance_history(
+            bot_name=instance_name, interval=interval, limit=limit
+        )
+    except Exception as e:
+        logger.debug("fetch_instance_history(%s) failed: %s", instance_name, e)
+        return []
+
+    rows = result.get("data", []) if isinstance(result, dict) else result
+    if not isinstance(rows, list):
+        return []
+
+    by_ts: dict[str, list[float]] = {}
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        ts = r.get("timestamp")
+        perf = r.get("performance") or {}
+        realized = float(perf.get("realized_pnl_quote", 0) or 0)
+        volume = float(perf.get("volume_traded", 0) or 0)
+        ctc = perf.get("close_type_counts") or {}
+        trades = sum(int(v or 0) for k, v in ctc.items() if k in _TRADE_CLOSE_TYPES)
+        acc = by_ts.setdefault(str(ts), [0.0, 0.0, 0.0])
+        acc[0] += realized
+        acc[1] += volume
+        acc[2] += trades
+
+    out: list[tuple[float, float, float, float]] = []
+    for ts, (realized, volume, trades) in by_ts.items():
+        epoch = _iso_to_epoch(ts)
+        if epoch is not None:
+            out.append((epoch, realized, volume, trades))
+    out.sort()
+    return out
+
+
+def _cum_at(
+    history: list[tuple[float, float, float, float]], t: float
+) -> tuple[float, float, float]:
+    """Cumulative (realized, volume, trades) at time ``t`` for one instance.
+
+    Zero before the instance's first snapshot; its final value at/after the last.
+    """
+    if not history or t < history[0][0]:
+        return (0.0, 0.0, 0.0)
+    chosen = history[0]
+    for row in history:
+        if row[0] <= t:
+            chosen = row
+        else:
+            break
+    return (chosen[1], chosen[2], chosen[3])
+
+
+def slice_history(
+    histories: list[list[tuple[float, float, float, float]]],
+    start: float,
+    end: float,
+) -> tuple[float, float, float]:
+    """Sum (realized, volume, trades) generated in ``[start, end)`` across instances.
+
+    Each instance contributes ``cum_at(end) − cum_at(start)`` — naturally zero for
+    an instance that lies wholly outside the window, and exact for partial overlap.
+    Because session windows tile the timeline, summing every session's slice
+    reproduces each instance's full cumulative with no double counting.
+    """
+    realized = volume = trades = 0.0
+    for h in histories:
+        r_e, v_e, t_e = _cum_at(h, end)
+        r_s, v_s, t_s = _cum_at(h, start)
+        realized += r_e - r_s
+        volume += v_e - v_s
+        trades += t_e - t_s
+    return realized, volume, trades
+
+
 def _clean_side(side: Any) -> str:
     """Normalize a ``TradeType.SELL``-style side into a bare ``SELL``/``BUY``."""
     s = str(side or "").upper()

--- a/condor/web/routes/agents.py
+++ b/condor/web/routes/agents.py
@@ -345,29 +345,15 @@ async def _get_client_for_strategy(strategy_dir: Path, default_config: dict | No
     return client, server_name
 
 
-def _bot_name_for_session(strategy, session_num: int) -> str:
-    """Resolve the bot_name a session operates in, per-session config first.
-
-    A session that records its actual deployed bot name in its own ``config.yml``
-    (e.g. a strategy that derives the name at runtime) takes precedence; otherwise
-    the strategy-level configured ``bot_name`` is used. Empty string when neither
-    is set (direct-executor strategies).
-    """
-    from condor.agents.config import load_full_config
-    from condor.agents.sessions_index import find_session_dir
-
-    session_dir = find_session_dir(strategy.dir, session_num)
-    cfg_dir = session_dir if session_dir else strategy.dir
-    return load_full_config(cfg_dir, strategy.default_config).get("bot_name", "") or ""
-
-
 def _session_bot_base(strategy_dir: Path, default_config: dict | None, num: int) -> str:
     """Bot base name a session operates: per-session config, else strategy default.
 
     A non-empty per-session ``bot_name`` wins (so runtime-named bots that record
     their deployed name resolve), but an empty/absent one falls back to the
     strategy default — early sessions predating the config's ``bot_name`` saved it
-    as ``''`` and must still map to the shared bot they operated.
+    as ``''`` and must still map to the shared bot they operated. Empty string when
+    neither is set (direct-executor strategies). Shared by the per-session PnL
+    distribution and the operator's live-executor view so both resolve identically.
     """
     from condor.agents.config import load_full_config
     from condor.agents.sessions_index import find_session_dir
@@ -1188,7 +1174,11 @@ async def get_session_executors(
         if k == "session"
     ]
     is_operator = bool(session_nums) and session_num == max(session_nums)
-    bot_name = _bot_name_for_session(strategy, session_num) if is_operator else ""
+    bot_name = (
+        _session_bot_base(strategy.dir, strategy.default_config, session_num)
+        if is_operator
+        else ""
+    )
     perf = await fetch_agent_performance(client, agent_id, bot_name=bot_name)
     model = AgentPerformanceModel(
         agent_id=agent_id,

--- a/condor/web/routes/agents.py
+++ b/condor/web/routes/agents.py
@@ -344,6 +344,22 @@ async def _get_client_for_strategy(strategy_dir: Path, default_config: dict | No
     return client, server_name
 
 
+def _bot_name_for_session(strategy, session_num: int) -> str:
+    """Resolve the bot_name a session operates in, per-session config first.
+
+    A session that records its actual deployed bot name in its own ``config.yml``
+    (e.g. a strategy that derives the name at runtime) takes precedence; otherwise
+    the strategy-level configured ``bot_name`` is used. Empty string when neither
+    is set (direct-executor strategies).
+    """
+    from condor.agents.config import load_full_config
+    from condor.agents.sessions_index import find_session_dir
+
+    session_dir = find_session_dir(strategy.dir, session_num)
+    cfg_dir = session_dir if session_dir else strategy.dir
+    return load_full_config(cfg_dir, strategy.default_config).get("bot_name", "") or ""
+
+
 async def _compute_strategy_performance(
     run_key: str, strategy_dir: Path, default_config: dict | None
 ):
@@ -363,11 +379,12 @@ async def _compute_strategy_performance(
     ids = enumerate_agent_ids(run_key, strategy_dir)
     client, _server = await _get_client_for_strategy(strategy_dir, default_config)
 
-    # Controller mode: a strategy with a configured bot_name attributes that bot's
-    # PnL to every one of its agent sessions. The bot is persistent infrastructure
-    # tied to the stable run_key, so the name is shared across sessions.
+    # Controller mode: a strategy with a configured bot_name operates ONE shared
+    # bot (persistent infrastructure tied to the stable run_key). Its aggregate is
+    # merged in ONCE below — into the totals and surfaced on each session row —
+    # rather than per-session (which would multiply the shared PnL by session
+    # count). Per-session fetches stay bot-free so closed sessions can be frozen.
     bot_name = load_full_config(strategy_dir, default_config).get("bot_name", "")
-    bot_names = {aid: bot_name for aid, _, _ in ids} if bot_name else None
 
     sessions: list[AgentPerformanceModel] = []
     if client and ids:
@@ -389,23 +406,18 @@ async def _compute_strategy_performance(
         for aid in active_ids:
             _CLOSED_PERF_CACHE.pop(aid, None)
 
-        if bot_name:
-            # Controller mode attributes the bot's live aggregate to every
-            # session, so no per-session result is immutable — fetch all.
-            fetch_ids = [aid for aid, _, _ in ids]
-        else:
-            fetch_ids = [
-                aid
-                for aid, _, _ in ids
-                if aid in active_ids or aid not in _CLOSED_PERF_CACHE
-            ]
+        fetch_ids = [
+            aid
+            for aid, _, _ in ids
+            if aid in active_ids or aid not in _CLOSED_PERF_CACHE
+        ]
 
         perf_map: dict[str, Any] = {}
         failed_ids: set[str] = set()
         if fetch_ids:
             try:
                 perf_map = await fetch_agent_performance_batch(
-                    client, fetch_ids, bot_names, failed_ids=failed_ids
+                    client, fetch_ids, None, failed_ids=failed_ids
                 )
             except Exception as e:
                 log.warning("fetch_agent_performance_batch(%s) failed: %s", run_key, e)
@@ -420,9 +432,10 @@ async def _compute_strategy_performance(
                 continue
             # Freeze immutable results: fetched fine, no engine, not the newest
             # session, and nothing still open whose unrealized PnL could move.
+            # Per-session perf is bot-free (the shared bot is merged once below),
+            # so it is immutable for a closed session even in controller mode.
             if (
-                not bot_name
-                and agent_id in perf_map
+                agent_id in perf_map
                 and agent_id not in active_ids
                 and agent_id not in failed_ids
                 and perf.open_count == 0
@@ -458,6 +471,48 @@ async def _compute_strategy_performance(
         "open_positions": sum(s.open_count for s in real_sessions),
         "trade_count": float(sum(s.trade_count for s in real_sessions)),
     }
+
+    # Controller mode: fold the ONE shared bot in exactly once — into the totals,
+    # and surfaced on each session row so the UI shows the live positions the
+    # agent operates. Session rows are display-only; totals are not re-summed from
+    # them, so counting the bot once here does not multiply by session count.
+    if bot_name and client and real_sessions:
+        from condor.fetchers.bot_performance import (
+            bot_executor_rows,
+            fetch_all_bot_performance,
+            resolve_bot,
+        )
+
+        try:
+            bot = resolve_bot(await fetch_all_bot_performance(client), bot_name)
+        except Exception as e:
+            log.warning("bot perf resolve for %s failed: %s", run_key, e)
+            bot = None
+        if bot:
+            b_real = float(bot.get("realized_pnl_quote", 0) or 0)
+            b_unreal = float(bot.get("unrealized_pnl_quote", 0) or 0)
+            b_vol = float(bot.get("volume_traded", 0) or 0)
+            b_fees = float(bot.get("cum_fees_quote", 0) or 0)
+            b_rows = bot_executor_rows(bot)
+            b_open = sum(1 for r in b_rows if r["status"] == "RUNNING")
+
+            totals["realized_pnl"] += b_real
+            totals["unrealized_pnl"] += b_unreal
+            totals["total_pnl"] += b_real + b_unreal
+            totals["volume"] += b_vol
+            totals["fees"] += b_fees
+            totals["open_positions"] += b_open
+            totals["trade_count"] += float(len(b_rows))
+
+            for s in sessions:
+                s.realized_pnl += b_real
+                s.unrealized_pnl += b_unreal
+                s.total_pnl = s.realized_pnl + s.unrealized_pnl
+                s.volume += b_vol
+                s.fees += b_fees
+                s.open_count += b_open
+                s.executors = list(s.executors) + b_rows
+
     result = (sessions, totals)
     _cache_set(f"perf:{run_key}", result)
     return result
@@ -1026,7 +1081,12 @@ async def get_session_executors(
                 agent_id=agent_id, session_num=session_num
             ).model_dump(),
         }
-    perf = await fetch_agent_performance(client, agent_id)
+    # Bot-mode: the session operates a named bot whose executors live in the bot
+    # container, not the agent_id-keyed table. Resolve the bot_name (per-session
+    # config wins, so runtime-named bots that record their name are picked up)
+    # and let fetch_agent_performance merge its live positions.
+    bot_name = _bot_name_for_session(strategy, session_num)
+    perf = await fetch_agent_performance(client, agent_id, bot_name=bot_name)
     model = AgentPerformanceModel(
         agent_id=agent_id,
         session_num=session_num,

--- a/condor/web/routes/agents.py
+++ b/condor/web/routes/agents.py
@@ -18,6 +18,7 @@ stays shared at ``agents/{slug}/``.
 from __future__ import annotations
 
 import logging
+import os
 import re
 import time
 from pathlib import Path
@@ -360,6 +361,133 @@ def _bot_name_for_session(strategy, session_num: int) -> str:
     return load_full_config(cfg_dir, strategy.default_config).get("bot_name", "") or ""
 
 
+def _session_bot_base(strategy_dir: Path, default_config: dict | None, num: int) -> str:
+    """Bot base name a session operates: per-session config, else strategy default.
+
+    A non-empty per-session ``bot_name`` wins (so runtime-named bots that record
+    their deployed name resolve), but an empty/absent one falls back to the
+    strategy default — early sessions predating the config's ``bot_name`` saved it
+    as ``''`` and must still map to the shared bot they operated.
+    """
+    from condor.agents.config import load_full_config
+    from condor.agents.sessions_index import find_session_dir
+
+    default_base = (default_config or {}).get("bot_name", "") or ""
+    sd = find_session_dir(strategy_dir, num)
+    if not sd:
+        return default_base
+    return load_full_config(sd, default_config).get("bot_name", "") or default_base
+
+
+def _session_start_epoch(strategy_dir: Path, num: int) -> float:
+    """Session start time: config.yml is written once at start, so its mtime is stable."""
+    from condor.agents.sessions_index import find_session_dir
+
+    sd = find_session_dir(strategy_dir, num)
+    if not sd:
+        return 0.0
+    cfg = sd / "config.yml"
+    target = cfg if cfg.exists() else sd
+    try:
+        return os.path.getmtime(target)
+    except OSError:
+        return 0.0
+
+
+async def _apply_bot_mode_pnl(
+    real_sessions: list, strategy_dir: Path, default_config: dict | None, client: Any
+) -> None:
+    """Distribute each operated bot's PnL across session windows (bot-mode only).
+
+    Realized PnL, volume and trade counts are attributed to whichever session was
+    operating during each slice of the bot's cumulative history; live unrealized
+    PnL and open positions go to the current operator (the latest session per bot
+    base). Session windows tile the timeline ``[start_N, start_{N+1})`` (last → now)
+    so every slice sums back to the bot's cumulative with no double counting.
+
+    Works uniformly for single- and multi-controller bots (history sums controllers
+    per instance) and for a strategy re-launched under several instances. Strategies
+    whose sessions resolve NO bot_name (direct-executor agents) are left untouched —
+    their per-session executor attribution already stands.
+    """
+    from condor.fetchers.bot_performance import (
+        bot_executor_rows,
+        fetch_all_bot_performance,
+        fetch_instance_history,
+        resolve_bot,
+        resolve_bot_instances,
+        slice_history,
+    )
+
+    if not client or not real_sessions:
+        return
+    session_base = {
+        s.session_num: _session_bot_base(strategy_dir, default_config, s.session_num)
+        for s in real_sessions
+    }
+    bases = {b for b in session_base.values() if b}
+    if not bases:
+        return  # direct-executor strategy — nothing to attribute
+
+    try:
+        all_perf = await fetch_all_bot_performance(client)
+    except Exception as e:
+        log.warning("bot perf fetch for %s failed: %s", strategy_dir.name, e)
+        return
+
+    instances_by_base = {b: resolve_bot_instances(all_perf, b) for b in bases}
+    all_instances = sorted({i for lst in instances_by_base.values() for i in lst})
+    MAX_INSTANCES = 24
+    if len(all_instances) > MAX_INSTANCES:
+        log.warning(
+            "bot history for %s: %d instances, capping at %d newest "
+            "(older sessions may under-report)",
+            strategy_dir.name,
+            len(all_instances),
+            MAX_INSTANCES,
+        )
+        all_instances = all_instances[-MAX_INSTANCES:]
+    history = {
+        inst: await fetch_instance_history(client, inst) for inst in all_instances
+    }
+
+    # Distribute realized/volume/trades per session window.
+    ordered = sorted(real_sessions, key=lambda s: s.session_num)
+    now = time.time()
+    for i, s in enumerate(ordered):
+        base = session_base[s.session_num]
+        if not base:
+            continue
+        start = _session_start_epoch(strategy_dir, s.session_num)
+        end = (
+            _session_start_epoch(strategy_dir, ordered[i + 1].session_num)
+            if i + 1 < len(ordered)
+            else now
+        )
+        insts = [history[k] for k in instances_by_base[base] if k in history]
+        realized, volume, trades = slice_history(insts, start, end)
+        s.realized_pnl += realized
+        s.volume += volume
+        s.trade_count += int(round(trades))
+        s.total_pnl = s.realized_pnl + s.unrealized_pnl
+
+    # Live unrealized + open positions → the current operator per base.
+    for base in bases:
+        bot = resolve_bot(all_perf, base)
+        if not bot:
+            continue
+        ops = [s for s in real_sessions if session_base[s.session_num] == base]
+        if not ops:
+            continue
+        operator = max(ops, key=lambda s: s.session_num)
+        b_rows = bot_executor_rows(bot)
+        operator.unrealized_pnl += float(bot.get("unrealized_pnl_quote", 0) or 0)
+        operator.fees += float(bot.get("cum_fees_quote", 0) or 0)
+        operator.open_count += sum(1 for r in b_rows if r["status"] == "RUNNING")
+        operator.executors = list(operator.executors) + b_rows
+        operator.total_pnl = operator.realized_pnl + operator.unrealized_pnl
+
+
 async def _compute_strategy_performance(
     run_key: str, strategy_dir: Path, default_config: dict | None
 ):
@@ -369,7 +497,6 @@ async def _compute_strategy_performance(
     sessions/experiments are served from ``_CLOSED_PERF_CACHE`` so only active
     ids hit the backend after the TTL expires.
     """
-    from condor.agents.config import load_full_config
     from condor.agents.performance import fetch_agent_performance_batch
 
     cached = _cache_get(f"perf:{run_key}")
@@ -379,13 +506,10 @@ async def _compute_strategy_performance(
     ids = enumerate_agent_ids(run_key, strategy_dir)
     client, _server = await _get_client_for_strategy(strategy_dir, default_config)
 
-    # Controller mode: a strategy with a configured bot_name operates ONE shared
-    # bot (persistent infrastructure tied to the stable run_key). Its aggregate is
-    # merged in ONCE below — into the totals and surfaced on each session row —
-    # rather than per-session (which would multiply the shared PnL by session
-    # count). Per-session fetches stay bot-free so closed sessions can be frozen.
-    bot_name = load_full_config(strategy_dir, default_config).get("bot_name", "")
-
+    # Per-session executor fetches stay bot-free (bot_names=None below) so closed
+    # sessions can be frozen; bot-mode PnL is distributed per session afterward by
+    # _apply_bot_mode_pnl from the controller history, which handles both fixed and
+    # runtime-named (per-session config) bots.
     sessions: list[AgentPerformanceModel] = []
     if client and ids:
         from condor.agents.engine import get_all_engines
@@ -462,6 +586,15 @@ async def _compute_strategy_performance(
             )
 
     real_sessions = [s for s in sessions if s.kind == "session"]
+
+    # Bot-mode: distribute each operated bot's PnL across the session windows that
+    # produced it (realized/volume/trades per window; live unrealized/open on the
+    # current operator). Direct-executor strategies are left untouched. Because the
+    # bot is DISTRIBUTED — not duplicated — the totals below are a plain additive
+    # sum of the rows and stay correct for both modes with no double counting.
+    if client and real_sessions:
+        await _apply_bot_mode_pnl(real_sessions, strategy_dir, default_config, client)
+
     totals = {
         "total_pnl": sum(s.total_pnl for s in real_sessions),
         "realized_pnl": sum(s.realized_pnl for s in real_sessions),
@@ -471,50 +604,6 @@ async def _compute_strategy_performance(
         "open_positions": sum(s.open_count for s in real_sessions),
         "trade_count": float(sum(s.trade_count for s in real_sessions)),
     }
-
-    # Controller mode: fold the ONE shared bot in exactly once — into the totals,
-    # and onto the CURRENT operator row only (the latest session, which deployed
-    # the resolved bot instance). Surfacing it on every session would duplicate
-    # the shared PnL across rows and, worse, show closed sessions as holding the
-    # live bot's open positions — a closed session cannot have open positions.
-    # Session rows are display-only; totals are not re-summed from them, so the
-    # single fold here does not multiply by session count.
-    if bot_name and client and real_sessions:
-        from condor.fetchers.bot_performance import (
-            bot_executor_rows,
-            fetch_all_bot_performance,
-            resolve_bot,
-        )
-
-        try:
-            bot = resolve_bot(await fetch_all_bot_performance(client), bot_name)
-        except Exception as e:
-            log.warning("bot perf resolve for %s failed: %s", run_key, e)
-            bot = None
-        if bot:
-            b_real = float(bot.get("realized_pnl_quote", 0) or 0)
-            b_unreal = float(bot.get("unrealized_pnl_quote", 0) or 0)
-            b_vol = float(bot.get("volume_traded", 0) or 0)
-            b_fees = float(bot.get("cum_fees_quote", 0) or 0)
-            b_rows = bot_executor_rows(bot)
-            b_open = sum(1 for r in b_rows if r["status"] == "RUNNING")
-
-            totals["realized_pnl"] += b_real
-            totals["unrealized_pnl"] += b_unreal
-            totals["total_pnl"] += b_real + b_unreal
-            totals["volume"] += b_vol
-            totals["fees"] += b_fees
-            totals["open_positions"] += b_open
-            totals["trade_count"] += float(len(b_rows))
-
-            operator = max(real_sessions, key=lambda s: s.session_num)
-            operator.realized_pnl += b_real
-            operator.unrealized_pnl += b_unreal
-            operator.total_pnl = operator.realized_pnl + operator.unrealized_pnl
-            operator.volume += b_vol
-            operator.fees += b_fees
-            operator.open_count += b_open
-            operator.executors = list(operator.executors) + b_rows
 
     result = (sessions, totals)
     _cache_set(f"perf:{run_key}", result)
@@ -1094,7 +1183,8 @@ async def get_session_executors(
     from condor.agents.sessions_index import enumerate_agent_ids
 
     session_nums = [
-        n for _, n, k in enumerate_agent_ids(_runkey(slug, sslug), strategy.dir)
+        n
+        for _, n, k in enumerate_agent_ids(_runkey(slug, sslug), strategy.dir)
         if k == "session"
     ]
     is_operator = bool(session_nums) and session_num == max(session_nums)

--- a/condor/web/routes/agents.py
+++ b/condor/web/routes/agents.py
@@ -473,9 +473,12 @@ async def _compute_strategy_performance(
     }
 
     # Controller mode: fold the ONE shared bot in exactly once — into the totals,
-    # and surfaced on each session row so the UI shows the live positions the
-    # agent operates. Session rows are display-only; totals are not re-summed from
-    # them, so counting the bot once here does not multiply by session count.
+    # and onto the CURRENT operator row only (the latest session, which deployed
+    # the resolved bot instance). Surfacing it on every session would duplicate
+    # the shared PnL across rows and, worse, show closed sessions as holding the
+    # live bot's open positions — a closed session cannot have open positions.
+    # Session rows are display-only; totals are not re-summed from them, so the
+    # single fold here does not multiply by session count.
     if bot_name and client and real_sessions:
         from condor.fetchers.bot_performance import (
             bot_executor_rows,
@@ -504,14 +507,14 @@ async def _compute_strategy_performance(
             totals["open_positions"] += b_open
             totals["trade_count"] += float(len(b_rows))
 
-            for s in sessions:
-                s.realized_pnl += b_real
-                s.unrealized_pnl += b_unreal
-                s.total_pnl = s.realized_pnl + s.unrealized_pnl
-                s.volume += b_vol
-                s.fees += b_fees
-                s.open_count += b_open
-                s.executors = list(s.executors) + b_rows
+            operator = max(real_sessions, key=lambda s: s.session_num)
+            operator.realized_pnl += b_real
+            operator.unrealized_pnl += b_unreal
+            operator.total_pnl = operator.realized_pnl + operator.unrealized_pnl
+            operator.volume += b_vol
+            operator.fees += b_fees
+            operator.open_count += b_open
+            operator.executors = list(operator.executors) + b_rows
 
     result = (sessions, totals)
     _cache_set(f"perf:{run_key}", result)
@@ -1084,8 +1087,18 @@ async def get_session_executors(
     # Bot-mode: the session operates a named bot whose executors live in the bot
     # container, not the agent_id-keyed table. Resolve the bot_name (per-session
     # config wins, so runtime-named bots that record their name are picked up)
-    # and let fetch_agent_performance merge its live positions.
-    bot_name = _bot_name_for_session(strategy, session_num)
+    # and let fetch_agent_performance merge its live positions — but ONLY for the
+    # current operator (the latest session that deployed the live bot instance).
+    # A closed session shows only its own direct executors, never the live bot's
+    # open positions, which belong to whoever is running the shared bot now.
+    from condor.agents.sessions_index import enumerate_agent_ids
+
+    session_nums = [
+        n for _, n, k in enumerate_agent_ids(_runkey(slug, sslug), strategy.dir)
+        if k == "session"
+    ]
+    is_operator = bool(session_nums) and session_num == max(session_nums)
+    bot_name = _bot_name_for_session(strategy, session_num) if is_operator else ""
     perf = await fetch_agent_performance(client, agent_id, bot_name=bot_name)
     model = AgentPerformanceModel(
         agent_id=agent_id,

--- a/mcp_servers/hummingbot_api/formatters/bots.py
+++ b/mcp_servers/hummingbot_api/formatters/bots.py
@@ -83,7 +83,7 @@ def format_active_bots_as_table(bots_data: dict[str, Any]) -> str:
         if not performance:
             # Bot with no controllers
             row = (
-                f"{bot_name[:20]} | "
+                f"{bot_name} | "
                 f"N/A | "
                 f"{bot_status} | "
                 f"N/A | N/A | N/A | N/A | "
@@ -104,8 +104,8 @@ def format_active_bots_as_table(bots_data: dict[str, Any]) -> str:
                 volume = format_number(get_field(ctrl_perf, "volume_traded", default=None), compact=False)
 
                 row = (
-                    f"{bot_name[:20]} | "
-                    f"{controller_name[:20]} | "
+                    f"{bot_name} | "
+                    f"{controller_name} | "
                     f"{ctrl_status} | "
                     f"{realized_pnl} | "
                     f"{unrealized_pnl} | "

--- a/tests/test_bot_mode_session_resolution.py
+++ b/tests/test_bot_mode_session_resolution.py
@@ -1,0 +1,54 @@
+"""Bot-mode session→bot_name resolution (`_session_bot_base`).
+
+The per-session PnL distribution and the operator's live-executor view share this
+one helper, so its fallback rules must hold for both: a non-empty per-session
+``bot_name`` wins (runtime-named bots), but an empty/absent one falls back to the
+strategy default — early sessions predating the config key saved ``bot_name: ''``
+and must still map to the shared bot they operated.
+"""
+
+from pathlib import Path
+
+import yaml
+
+from condor.web.routes.agents import _session_bot_base
+
+
+def _write_session(strategy_dir: Path, num: int, cfg: dict) -> None:
+    sd = strategy_dir / "sessions" / f"session_{num}"
+    sd.mkdir(parents=True)
+    (sd / "config.yml").write_text(yaml.safe_dump(cfg))
+
+
+def test_per_session_bot_name_wins(tmp_path):
+    # A session that recorded its runtime-derived deploy name takes precedence.
+    _write_session(tmp_path, 1, {"bot_name": "dn-CL-BRENTOIL-mm-20260724-182221"})
+    assert (
+        _session_bot_base(tmp_path, {"bot_name": "dn-mm"}, 1)
+        == "dn-CL-BRENTOIL-mm-20260724-182221"
+    )
+
+
+def test_empty_session_bot_name_falls_back_to_default(tmp_path):
+    # Early session saved bot_name as '' — must still resolve to the shared bot.
+    _write_session(tmp_path, 2, {"bot_name": ""})
+    assert _session_bot_base(tmp_path, {"bot_name": "dn-mm"}, 2) == "dn-mm"
+
+
+def test_missing_session_bot_name_falls_back_to_default(tmp_path):
+    # Session config predates the key entirely.
+    _write_session(tmp_path, 3, {"some_other": 1})
+    assert _session_bot_base(tmp_path, {"bot_name": "dn-mm"}, 3) == "dn-mm"
+
+
+def test_no_session_dir_uses_default(tmp_path):
+    # A session_num with no on-disk config still maps to the strategy default.
+    assert _session_bot_base(tmp_path, {"bot_name": "dn-mm"}, 99) == "dn-mm"
+
+
+def test_direct_executor_strategy_resolves_empty(tmp_path):
+    # No default and no per-session bot_name → direct-executor agent, nothing to
+    # attribute; distribution and operator merge both correctly skip it.
+    _write_session(tmp_path, 1, {"bot_name": ""})
+    assert _session_bot_base(tmp_path, {}, 1) == ""
+    assert _session_bot_base(tmp_path, None, 99) == ""

--- a/tests/test_bot_performance.py
+++ b/tests/test_bot_performance.py
@@ -317,6 +317,105 @@ def test_bot_name_round_trips_through_full_config(tmp_path):
     assert cfg2["bot_name"] == ""
 
 
+# ── Per-session history slicing ──
+
+
+def test_resolve_bot_instances_returns_all_matches_sorted():
+    from condor.fetchers.bot_performance import resolve_bot_instances
+
+    def _snap(name, ts):
+        return {
+            "bot_name": name,
+            "controller_id": "c",
+            "timestamp": ts,
+            "performance": {},
+        }
+
+    agg = _aggregate_by_bot(
+        [
+            _snap("dn-mm-20260101-000000", "2026-01-01T00:00:00"),
+            _snap("dn-mm-20260724-182221", "2026-07-24T18:22:21"),
+            _snap("dn-mmx-20260724-000000", "2026-07-24T00:00:00"),
+            _snap("other", "2026-07-24T00:00:00"),
+        ]
+    )
+    got = resolve_bot_instances(agg, "dn-mm")
+    assert got == ["dn-mm-20260101-000000", "dn-mm-20260724-182221"]  # oldest→newest
+    assert resolve_bot_instances(agg, "nope") == []
+
+
+def test_slice_history_tiles_exactly():
+    from condor.fetchers.bot_performance import slice_history
+
+    # one instance, cumulative realized/volume/trades at t=10,20,30
+    hist = [
+        (10.0, 1.0, 100.0, 1.0),
+        (20.0, 3.0, 300.0, 4.0),
+        (30.0, 5.0, 500.0, 9.0),
+    ]
+    # window fully before → 0; fully after start baseline → final delta
+    assert slice_history([hist], 0, 5) == (0.0, 0.0, 0.0)
+    # [0,20] captures rows at 10 and 20 → cum_at(20)-cum_at(0)=3
+    assert slice_history([hist], 0, 20) == (3.0, 300.0, 4.0)
+    # [20,40] → cum_at(40)=final(5) - cum_at(20)=3 → 2
+    assert slice_history([hist], 20, 40) == (2.0, 200.0, 5.0)
+    # tiling: [0,20)+[20,40) sums to the instance's full cumulative
+    a = slice_history([hist], 0, 20)
+    b = slice_history([hist], 20, 40)
+    assert (a[0] + b[0], a[1] + b[1], a[2] + b[2]) == (5.0, 500.0, 9.0)
+
+
+def test_slice_history_sums_multiple_instances():
+    from condor.fetchers.bot_performance import slice_history
+
+    h1 = [(10.0, 2.0, 20.0, 1.0)]  # instance 1: +2 at t=10
+    h2 = [(15.0, 3.0, 30.0, 2.0)]  # instance 2: +3 at t=15
+    # window covering both
+    assert slice_history([h1, h2], 0, 100) == (5.0, 50.0, 3.0)
+    # window covering only instance 1
+    assert slice_history([h1, h2], 0, 12) == (2.0, 20.0, 1.0)
+
+
+def test_fetch_instance_history_sums_controllers_and_filters_trades():
+    from condor.fetchers.bot_performance import fetch_instance_history
+
+    class _Client:
+        async def get_controller_performance_history(self, **_kw):
+            return {
+                "data": [
+                    {
+                        "timestamp": "2026-07-24T18:00:00+00:00",
+                        "performance": {
+                            "realized_pnl_quote": 1.0,
+                            "volume_traded": 100.0,
+                            # 2 real trades; EARLY_STOP churn + FAILED excluded
+                            "close_type_counts": {
+                                "CloseType.TAKE_PROFIT": 2,
+                                "CloseType.EARLY_STOP": 500,
+                                "CloseType.FAILED": 9,
+                            },
+                        },
+                    },
+                    {
+                        "timestamp": "2026-07-24T18:00:00+00:00",  # 2nd controller, same ts
+                        "performance": {
+                            "realized_pnl_quote": 0.5,
+                            "volume_traded": 40.0,
+                            "close_type_counts": {"CloseType.STOP_LOSS": 1},
+                        },
+                    },
+                ]
+            }
+
+    client = SimpleNamespace(bot_orchestration=_Client())
+    hist = asyncio.run(fetch_instance_history(client, "bot-1"))
+    assert len(hist) == 1  # both controllers summed into one timestamp
+    ts, realized, volume, trades = hist[0]
+    assert realized == 1.5  # 1.0 + 0.5
+    assert volume == 140.0  # 100 + 40
+    assert trades == 3.0  # TAKE_PROFIT 2 + STOP_LOSS 1; EARLY_STOP/FAILED excluded
+
+
 # ── Provider wiring ──
 
 

--- a/tests/test_bot_performance.py
+++ b/tests/test_bot_performance.py
@@ -16,9 +16,11 @@ from condor.agents.performance import (
 )
 from condor.fetchers.bot_performance import (
     _aggregate_by_bot,
+    bot_executor_rows,
     extract_snapshots,
     fetch_all_bot_performance,
     fetch_bot_performance,
+    resolve_bot,
 )
 
 # ── Sample payloads ──
@@ -110,6 +112,96 @@ def test_fetch_bot_performance_resilient_to_errors():
     assert asyncio.run(fetch_bot_performance(client, "river")) is None
 
 
+# ── Suffix-tolerant resolution ──
+
+
+def _snap_with_positions(
+    bot_name, controller_id, timestamp, positions, status="running"
+):
+    return {
+        "bot_name": bot_name,
+        "controller_id": controller_id,
+        "status": status,
+        "timestamp": timestamp,
+        "performance": {
+            "realized_pnl_quote": 1.0,
+            "unrealized_pnl_quote": 2.0,
+            "volume_traded": 100.0,
+            "positions_summary": positions,
+        },
+    }
+
+
+def test_resolve_bot_exact_and_suffix():
+    agg = _aggregate_by_bot(
+        [
+            _snap_with_positions(
+                "dn-mm-20260101-000000", "c", "2026-01-01T00:00:00+00:00", []
+            ),
+            _snap_with_positions(
+                "dn-mm-20260724-182221", "c", "2026-07-24T18:22:21+00:00", []
+            ),
+            _snap_with_positions(
+                "dn-mmx-20260724-000000", "c", "2026-07-24T00:00:00+00:00", []
+            ),
+            _snap_with_positions("other", "c", "2026-07-24T00:00:00+00:00", []),
+        ]
+    )
+    # exact match wins outright
+    assert resolve_bot(agg, "other")["bot_name"] == "other"
+    # base name resolves to the freshest timestamped deploy
+    assert resolve_bot(agg, "dn-mm")["bot_name"] == "dn-mm-20260724-182221"
+    # the hyphen boundary keeps a sibling base (dn-mmx) from matching dn-mm
+    assert resolve_bot(agg, "dn-mm")["bot_name"] != "dn-mmx-20260724-000000"
+    # no match → None; empty inputs → None
+    assert resolve_bot(agg, "ghost") is None
+    assert resolve_bot(agg, "") is None
+    assert resolve_bot({}, "dn-mm") is None
+
+
+# ── Executor rows from positions_summary ──
+
+
+def test_bot_executor_rows_from_positions():
+    pos = {
+        "connector_name": "hyperliquid",
+        "trading_pair": "XYZ:CL-USD",
+        "volume_traded_quote": 250.0,
+        "side": "TradeType.SELL",
+        "amount": 2.0,
+        "breakeven_price": 60.0,
+        "unrealized_pnl_quote": -1.5,
+        "realized_pnl_quote": 0.4,
+        "cum_fees_quote": 0.3,
+    }
+    agg = _aggregate_by_bot(
+        [_snap_with_positions("bot", "dn_CL_mm", "2026-07-24T18:00:00+00:00", [pos])]
+    )
+    rows = bot_executor_rows(agg["bot"])
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["controller_id"] == "dn_CL_mm"
+    assert r["pair"] == "XYZ:CL-USD"
+    assert r["side"] == "SELL"  # TradeType. prefix stripped
+    assert r["status"] == "RUNNING"
+    assert r["pnl"] == -1.5  # unrealized mark
+    assert r["volume"] == 250.0
+    assert r["fees"] == 0.3
+    assert r["entry_price"] == 60.0
+    assert r["amount"] == 120.0  # abs(2.0) * 60.0 quote notional
+    assert r["timestamp"] > 0  # ISO parsed to epoch
+
+
+def test_flat_controller_yields_no_rows_but_counts_pnl():
+    agg = _aggregate_by_bot(
+        [_snap_with_positions("bot", "c", "2026-07-24T18:00:00+00:00", [])]
+    )
+    assert bot_executor_rows(agg["bot"]) == []
+    # realized/unrealized still aggregate even with no open positions
+    assert agg["bot"]["realized_pnl_quote"] == 1.0
+    assert agg["bot"]["unrealized_pnl_quote"] == 2.0
+
+
 # ── Merge into AgentPerformance ──
 
 
@@ -143,6 +235,38 @@ def test_merge_is_disjoint_addition():
     assert len(merged.controllers) == 2
     # The bot's controller executors never appear in the executor list.
     assert all(r["id"] == "e1" for r in merged.executors)
+
+
+def test_merge_appends_bot_positions_as_rows():
+    # Bot-mode agent: its own agent_id table is empty; the bot holds one open
+    # position that must surface as an executor row with open_count bumped.
+    agent_id = "dn.sess_1"
+    pos = {
+        "connector_name": "hyperliquid",
+        "trading_pair": "XYZ:CL-USD",
+        "volume_traded_quote": 250.0,
+        "side": "TradeType.BUY",
+        "amount": 1.0,
+        "breakeven_price": 60.0,
+        "unrealized_pnl_quote": -0.5,
+        "realized_pnl_quote": 0.4,
+        "cum_fees_quote": 0.3,
+    }
+    snaps = [
+        _snap_with_positions(
+            "dn-mm-20260724-1", "dn_CL_mm", "2026-07-24T18:00:00+00:00", [pos]
+        ),
+    ]
+    client = _FakeClient(rows_by_id={}, snapshots=snaps)
+    # base name resolves suffix-tolerantly to the deployed instance
+    merged = asyncio.run(fetch_agent_performance(client, agent_id, bot_name="dn-mm"))
+    # bot_name reflects the resolved deployed instance, not just the base
+    assert merged.bot_name == "dn-mm-20260724-1"
+    assert len(merged.executors) == 1
+    assert merged.executors[0]["pair"] == "XYZ:CL-USD"
+    assert merged.open_count == 1
+    assert merged.fees == 0.3
+    assert merged.unrealized_pnl == 2.0  # controller-level aggregate
 
 
 def test_no_snapshot_leaves_executor_totals_unchanged():


### PR DESCRIPTION
## Problem

Bot-mode agents (those that `manage_bots(deploy, controllers_config=[…])`) run their executors **inside the bot container**, tagged with controller-config ids (`dn_CL_mm`) and stored in the bot-orchestration store — **never** in the `agent_id`-keyed executor table that every dashboard surface reads from. As a result all dashboard surfaces and the agent's own `[CORE DATA]` were wrong for these agents:

- **Executors tab** — empty for bot-mode sessions.
- **Agent `[CORE DATA]`** — the agent saw *no positions*, so it couldn't measure its own delta.
- **Strategy performance rollup** — lost the bot's P&L (timestamped deploy names never resolved), or multiplied it by session count, or showed the identical bot P&L on every session row (incl. closed sessions holding "live" open positions), or showed **$0 for every closed session** because the live snapshot has no per-session breakdown.

The dividing line is **bot-mode vs direct-executor**, not controller count — single- and multi-controller bot strategies are all affected.

## Fix

Framework-only, in one shared path so the live tick (`ExecutorsProvider`) and the web API always agree. **Gated entirely on a resolvable `bot_name`** — direct-executor agents keep their existing per-session executor attribution, untouched.

**1. Resolution + live positions** (`condor/fetchers/bot_performance.py`, `condor/agents/performance.py`)
- `resolve_bot` — suffix-tolerant resolution of a configured base name to the freshest deployed instance (`dn-CL-BRENTOIL-mm` → `…-20260724-210613`); hyphen-boundary guarded.
- `bot_executor_rows` — executor-like rows built from each controller's `positions_summary`, so the executors tab and the agent's core-data view show live positions.

**2. Per-session P&L via controller history** (`condor/web/routes/agents.py`, `bot_performance.py`)
- The live snapshot only carries the bot's *current cumulative* total, but `get_controller_performance_history` provides timestamped cumulative realized/volume/close-counts and **is retained for archived instances**. `_apply_bot_mode_pnl` distributes each operated bot's PnL across the session windows that produced it (`[start_N, start_{N+1})`, last → now), with live unrealized/open on the current operator.
- `slice_history` tiles the windows so per-session slices sum **exactly** to the bot cumulative — totals become a plain additive sum of the rows, no double count.
- `fetch_instance_history` sums controllers per instance (single- and multi-controller handled identically) and counts trades from genuine round-trip close types only (excludes pmm `EARLY_STOP` re-quote churn).
- Per-session bot base resolves from per-session config (runtime-named bots) with fallback to the strategy default (early sessions saved `bot_name: ''`).

**3. Untruncate names** (`mcp_servers/hummingbot_api/formatters/bots.py`)
- `format_active_bots_as_table` no longer caps `bot_name`/`controller_name` at 20 chars — the cap corrupted the identifiers the agent needs and defeated suffix-tolerant resolution.

## Verification

Unit tests: suffix-tolerant resolution + all-instance enumeration, `positions_summary`→rows, history slicing (tiling exactness, multi-instance, controller-summing, trade-type filtering), and the merge. Full suite green.

Live, end-to-end on the CL/BRENTOIL DN strategy:
- Executors tab / agent core-data: both legs render with correct per-position PnL.
- Sessions rollup: per-session slices reproduce the true history (session 2 −$5.16 / $14k vol / 383 trades, session 8 +$0.44) and **sum exactly to the bot's −$5.01 cumulative**; live unrealized/open on the running operator; totals count the bot once.

## Scope

Framework only — deliberately separated from the Hyperliquid agent-strategy examples (#165). Runtime-named bots (e.g. `pmm_mister_operator`, which derives `{base}-mm` at deploy time) are already supported here — they just need the strategy to record the deployed `bot_name` into the session config, which belongs in the strategies PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)