### PR TITLE
fix(agents): dry-run/loop bot-deploy gates, serverless memory scope, stale routine refs (#150/#151/#152)

### DIFF
--- a/agents/market_making_expert/strategies/pmm_mister_operator/strategy.md
+++ b/agents/market_making_expert/strategies/pmm_mister_operator/strategy.md
@@ -52,8 +52,7 @@ controllers. Your job is to:
 ### Step 1: Run routines
 Use the values from `[CURRENT CONFIG]` for all routine calls:
 - `market_analyzer` with `{"trading_pair": "<trading_pair>", "connector_name": "<connector_name>"}`
-- `portfolio_scanner` with `{"connector_name": "<connector_name>"}`
-- `bot_position_tracker` with `{"trading_pair": "<trading_pair>"}`
+- `mm_dashboard` with `{"connector_name": "<connector_name>", "trading_pair": "<trading_pair>"}`
 
 ### Step 2: Assess regime
 From market_analyzer output, extract:
@@ -179,7 +178,7 @@ Derive `config_name` and `bot_name` from `trading_pair` at runtime (see Naming c
 
 ### First deployment (no controller config exists):
 1. Create config: `manage_controllers(action="upsert", target="config", config_name="{config_name}", config_data={...})`
-2. Deploy bot: `manage_bots(action="deploy", bot_name="{bot_name}", controllers_config=["{config_name}"])`
+2. Deploy bot: `manage_bots(action="deploy", bot_name="{bot_name}", controllers_config=["{config_name}"], max_global_drawdown_quote=<max_position_size_quote from risk_limits>)` — the loss cap is required; deploys without it are blocked by the risk engine
 
 ### Update running controller:
 `manage_bots(action="update_config", bot_name="{bot_name}", config_name="{config_name}", config_data={...full config...}, confirm_override=true)`

--- a/condor/agents/consult.py
+++ b/condor/agents/consult.py
@@ -156,7 +156,9 @@ async def _run_agent_to_completion(
             agent_slug=slug,
         )
     else:
-        mcp_servers = build_mcp_servers_for_session(user_id, chat_id)
+        # Serverless agents still need their own memory/skill scope — without
+        # agent_slug the condor MCP tools would target the CHAT's stores.
+        mcp_servers = build_mcp_servers_for_session(user_id, chat_id, agent_slug=slug)
 
     # ``permission_callback`` is passed in: CONSULT routes dangerous-tool
     # confirmations to the user's Telegram chat; DELEGATE passes None so an ACP

--- a/condor/agents/engine.py
+++ b/condor/agents/engine.py
@@ -586,6 +586,7 @@ class TickEngine:
                 self.user_id,
                 self.chat_id,
                 execution_mode=mode,
+                agent_slug=self.agent.slug,
             )
         permission_cb = auto_approve_with_risk_check(
             self.risk, risk_state, execution_mode=mode

--- a/condor/agents/prompts.py
+++ b/condor/agents/prompts.py
@@ -17,6 +17,9 @@ You are an autonomous trading agent running inside Condor.
 
 RULES:
 - Trade ONLY via manage_executors(action="create"). NEVER use place_order.
+- If your strategy deploys a controller-based bot, manage_bots(action="deploy")
+  MUST include max_global_drawdown_quote within your risk limits — deploys
+  without a declared loss cap are blocked by the risk engine.
 - Be conservative. When in doubt, hold and journal why.
 
 ERROR RECOVERY:
@@ -29,8 +32,11 @@ BASE_PROMPT_DRY_RUN = """\
 You are an autonomous trading agent running inside Condor in 🧪 DRY RUN mode.
 
 RULES:
-- This is OBSERVATION ONLY. Do NOT create or stop executors.
-- manage_executors is available for read-only queries (performance_report).
+- This is OBSERVATION ONLY. Do NOT create or stop executors, and do NOT deploy,
+  stop, or update a controller-based bot (manage_bots with action="deploy",
+  "stop_bot", "stop_controllers", "start_controllers", or "update_config").
+- manage_executors and manage_bots are available for read-only queries
+  (performance_report; status/logs/get_config).
 - Analyze the market and describe what you WOULD do, but take NO trading action.
 
 DRY RUN MESSAGING:

--- a/condor/agents/risk.py
+++ b/condor/agents/risk.py
@@ -166,6 +166,47 @@ class RiskEngine:
 
         return True, ""
 
+    def check_bot_action(self, tool_call: dict) -> tuple[bool, str]:
+        """Check a manage_bots call against risk limits.
+
+        A bot's capital lives in saved controller configs on the API server,
+        so exposure can't be computed from the tool inputs alone. Instead,
+        bound the loss: a deploy must declare ``max_global_drawdown_quote``
+        (the platform-enforced kill switch) no larger than the strategy's
+        position limit. Stops are risk-reducing and always allowed; an
+        ``update_config`` is only gated when it declares a
+        ``total_amount_quote`` above the position limit.
+
+        Returns (allowed, reason).
+        """
+        input_data = tool_call.get("input", {})
+        action = input_data.get("action", "")
+
+        if action == "deploy":
+            cap = input_data.get("max_global_drawdown_quote")
+            if not cap:
+                return False, (
+                    "Bot deploy must declare max_global_drawdown_quote "
+                    f"(≤ ${self.limits.max_position_size_quote:.2f}) so the "
+                    "platform kill switch bounds the loss"
+                )
+            if float(cap) > self.limits.max_position_size_quote:
+                return False, (
+                    f"max_global_drawdown_quote ${float(cap):.2f} exceeds "
+                    f"position limit ${self.limits.max_position_size_quote:.2f}"
+                )
+        elif action == "update_config":
+            amount = float(
+                (input_data.get("config_data") or {}).get("total_amount_quote", 0) or 0
+            )
+            if amount > self.limits.max_position_size_quote:
+                return False, (
+                    f"update_config total_amount_quote ${amount:.2f} exceeds "
+                    f"position limit ${self.limits.max_position_size_quote:.2f}"
+                )
+
+        return True, ""
+
 
 def auto_approve_with_risk_check(
     risk_engine: RiskEngine,
@@ -173,7 +214,7 @@ def auto_approve_with_risk_check(
     execution_mode: str = "loop",
 ):
     """Build a permission callback that auto-approves safe tools and risk-checks dangerous ones."""
-    from handlers.agents._shared import is_dangerous_tool_call
+    from handlers.agents._shared import DANGEROUS_BOT_ACTIONS, is_dangerous_tool_call
 
     async def callback(tool_call: dict, options: list[dict]) -> dict:
         if is_dangerous_tool_call(tool_call):
@@ -187,6 +228,12 @@ def auto_approve_with_risk_check(
                     action = input_data.get("action", "")
                     if action in ("create", "stop"):
                         log.info("Dry-run mode: blocked manage_executors(%s)", action)
+                        return {"outcome": {"outcome": "cancelled"}}
+                elif tool_name == "manage_bots":
+                    input_data = tool_call.get("input", {})
+                    action = input_data.get("action", "")
+                    if action in DANGEROUS_BOT_ACTIONS:
+                        log.info("Dry-run mode: blocked manage_bots(%s)", action)
                         return {"outcome": {"outcome": "cancelled"}}
                 elif tool_name in (
                     "place_order",
@@ -211,6 +258,14 @@ def auto_approve_with_risk_check(
                 allowed, reason = risk_engine.check_executor_action(
                     tool_call, risk_state
                 )
+                if not allowed:
+                    log.warning("Risk engine blocked tool call: %s", reason)
+                    return {"outcome": {"outcome": "cancelled"}}
+
+            # Bot deploys place real capital via controllers — bound the loss
+            # (declared drawdown kill switch) since the amount isn't in the call
+            if tool_name == "manage_bots":
+                allowed, reason = risk_engine.check_bot_action(tool_call)
                 if not allowed:
                     log.warning("Risk engine blocked tool call: %s", reason)
                     return {"outcome": {"outcome": "cancelled"}}

--- a/handlers/agents/_shared.py
+++ b/handlers/agents/_shared.py
@@ -228,6 +228,18 @@ BLOCKED_TOOLS: set[str] = set()
 # Actions within manage_executors that require confirmation
 DANGEROUS_EXECUTOR_ACTIONS = {"create", "stop"}
 
+# Actions within manage_bots that deploy/mutate a live bot (status/logs/get_config
+# are read-only and excluded). manage_controllers itself is excluded entirely — it
+# only writes controller templates/saved configs, never a running bot (see its own
+# tool docstring: "Does NOT affect running bots").
+DANGEROUS_BOT_ACTIONS = {
+    "deploy",
+    "stop_bot",
+    "stop_controllers",
+    "start_controllers",
+    "update_config",
+}
+
 # Actions within manage_gateway_swaps that require confirmation
 DANGEROUS_SWAP_ACTIONS = {"execute"}
 
@@ -262,6 +274,13 @@ def is_dangerous_tool_call(tool_call: dict[str, Any]) -> bool:
         input_data = tool_call.get("input", {})
         action = input_data.get("action", "")
         return action in DANGEROUS_EXECUTOR_ACTIONS
+
+    # manage_bots with deploy/stop/update actions (a bot deploy places real
+    # capital via a controller, a different path than manage_executors)
+    if tool_name == "manage_bots":
+        input_data = tool_call.get("input", {})
+        action = input_data.get("action", "")
+        return action in DANGEROUS_BOT_ACTIONS
 
     return False
 
@@ -308,6 +327,7 @@ def build_mcp_servers_for_session(
     user_data: dict | None = None,
     execution_mode: str = "loop",
     server_name: str | None = None,
+    agent_slug: str | None = None,
 ) -> list[dict[str, Any]]:
     """Build dynamic MCP server configs for an agent session.
 
@@ -315,6 +335,13 @@ def build_mcp_servers_for_session(
     that override the static .mcp.json entries by name.
     Always includes the condor MCP server; hummingbot is added when a valid
     server can be resolved for the user.
+
+    ``agent_slug`` scopes the condor MCP tools' memory/skills to that Agent's
+    own stores (``agents/{slug}/``). Without it the tools target the chat
+    condor's stores — correct for chat sessions, wrong for an Agent run: a
+    serverless consult/tick would silently read and write the CHAT's memory
+    and skills instead of the Agent's own (e.g. routine_builder unable to
+    find its routine_cookbook skill).
     """
     from config_manager import get_config_manager, get_effective_server
 
@@ -333,7 +360,7 @@ def build_mcp_servers_for_session(
         "name": "condor",
         "command": "uv",
         "args": ["run", "python", "-m", "mcp_servers.condor"]
-        + _condor_mcp_args(chat_id, user_id, server_name=server_name),
+        + _condor_mcp_args(chat_id, user_id, agent_slug, server_name=server_name),
         "env": [],
     }
 

--- a/handlers/agents/confirmation.py
+++ b/handlers/agents/confirmation.py
@@ -47,6 +47,17 @@ def _format_tool_summary(tool_call: dict[str, Any]) -> str:
             return f"Stop executor {exec_id[:12]}..."
         return f"Executor: {action}"
 
+    if tool_name == "manage_bots":
+        action = input_data.get("action", "?")
+        bot_name = input_data.get("bot_name", "?")
+        if action == "deploy":
+            controllers = input_data.get("controllers_config", [])
+            return f"Deploy bot '{bot_name}' with controllers {controllers}"
+        if action == "update_config":
+            config_name = input_data.get("config_name", "?")
+            return f"Update config '{config_name}' on bot '{bot_name}'"
+        return f"Bot '{bot_name}': {action}"
+
     if tool_name == "manage_gateway_swaps":
         action = input_data.get("action", "?")
         pair = input_data.get("trading_pair", "?")

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -658,3 +658,34 @@ def test_normalize_mode_coerces_legacy_and_unknown():
     # The default mode itself is always valid and preserved.
     assert DEFAULT_MODE in AGENT_MODES
     assert normalize_mode(DEFAULT_MODE) == DEFAULT_MODE
+
+
+def test_session_mcp_servers_carry_agent_slug(monkeypatch):
+    """Serverless agent runs (consult/tick without server_name) must scope the
+    condor MCP tools to the agent's own memory/skills via --agent-slug —
+    without it, routine_builder-style agents silently read/write the CHAT's
+    stores (e.g. 'routine_cookbook not found')."""
+    import config_manager
+
+    from handlers.agents._shared import build_mcp_servers_for_session
+
+    class _NoServers:
+        def get_accessible_servers(self, user_id):
+            return []
+
+        def get_server(self, name):
+            return None
+
+    monkeypatch.setattr(config_manager, "get_config_manager", lambda: _NoServers())
+    monkeypatch.setattr(config_manager, "get_effective_server", lambda *a, **k: None)
+
+    servers = build_mcp_servers_for_session(42, 42, agent_slug="routine_builder")
+    condor = next(s for s in servers if s["name"] == "condor")
+    args = condor["args"]
+    assert "--agent-slug" in args
+    assert args[args.index("--agent-slug") + 1] == "routine_builder"
+
+    # Chat sessions (no agent_slug) keep the chat scope: no --agent-slug arg.
+    servers = build_mcp_servers_for_session(42, 42)
+    condor = next(s for s in servers if s["name"] == "condor")
+    assert "--agent-slug" not in condor["args"]

--- a/tests/test_confirmation.py
+++ b/tests/test_confirmation.py
@@ -1,0 +1,29 @@
+"""Unit tests for the human-readable confirmation-prompt formatter."""
+
+from handlers.agents.confirmation import _format_tool_summary
+
+
+def _bot_call(action: str, **extra) -> dict:
+    return {"tool": "manage_bots", "input": {"action": action, **extra}}
+
+
+def test_format_manage_bots_deploy():
+    summary = _format_tool_summary(
+        _bot_call("deploy", bot_name="mm-bot", controllers_config=["cfg_a"])
+    )
+    assert "mm-bot" in summary
+    assert "cfg_a" in summary
+
+
+def test_format_manage_bots_update_config():
+    summary = _format_tool_summary(
+        _bot_call("update_config", bot_name="mm-bot", config_name="cfg_a")
+    )
+    assert "mm-bot" in summary
+    assert "cfg_a" in summary
+
+
+def test_format_manage_bots_stop_bot():
+    summary = _format_tool_summary(_bot_call("stop_bot", bot_name="mm-bot"))
+    assert "mm-bot" in summary
+    assert "stop_bot" in summary

--- a/tests/test_risk_gate.py
+++ b/tests/test_risk_gate.py
@@ -159,3 +159,149 @@ def test_callback_cumulative_exposure_cancelled_same_tick():
     first, second = asyncio.run(_drive())
     assert first["outcome"]["outcome"] == "selected"
     assert second["outcome"]["outcome"] == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# dry_run must block manage_bots deploy/mutate actions too, not just
+# manage_executors/place_order/gateway swaps — manage_bots(deploy) places real
+# capital via a controller-based bot, a separate path from manage_executors.
+# ---------------------------------------------------------------------------
+
+
+def _bot_call(action: str, **extra) -> dict:
+    return {"tool": "mcp__mcp-hummingbot__manage_bots", "input": {"action": action, **extra}}
+
+
+def test_dry_run_blocks_manage_bots_deploy():
+    engine = RiskEngine(RiskLimits())
+    state = RiskState()
+    callback = auto_approve_with_risk_check(engine, state, execution_mode="dry_run")
+
+    result = asyncio.run(
+        callback(_bot_call("deploy", bot_name="x", controllers_config=["cfg"]), _OPTIONS)
+    )
+    assert result["outcome"]["outcome"] == "cancelled"
+
+
+def test_dry_run_blocks_manage_bots_update_config():
+    engine = RiskEngine(RiskLimits())
+    state = RiskState()
+    callback = auto_approve_with_risk_check(engine, state, execution_mode="dry_run")
+
+    result = asyncio.run(callback(_bot_call("update_config", bot_name="x"), _OPTIONS))
+    assert result["outcome"]["outcome"] == "cancelled"
+
+
+def test_dry_run_allows_manage_bots_status():
+    """Read-only manage_bots actions must not be blocked in dry_run."""
+    engine = RiskEngine(RiskLimits())
+    state = RiskState()
+    callback = auto_approve_with_risk_check(engine, state, execution_mode="dry_run")
+
+    result = asyncio.run(callback(_bot_call("status"), _OPTIONS))
+    assert result["outcome"]["outcome"] == "selected"
+
+
+# ---------------------------------------------------------------------------
+# loop mode: manage_bots(deploy) is risk-gated on a declared loss cap — the
+# capital lives in saved controller configs on the API server, so the deploy
+# must carry a max_global_drawdown_quote bounded by the position limit.
+# ---------------------------------------------------------------------------
+
+
+def test_loop_mode_blocks_bot_deploy_without_loss_cap():
+    """A deploy with no declared max_global_drawdown_quote is blocked."""
+    engine = RiskEngine(RiskLimits())
+    state = RiskState()
+    callback = auto_approve_with_risk_check(engine, state, execution_mode="loop")
+
+    result = asyncio.run(
+        callback(_bot_call("deploy", bot_name="x", controllers_config=["cfg"]), _OPTIONS)
+    )
+    assert result["outcome"]["outcome"] == "cancelled"
+
+
+def test_loop_mode_approves_bot_deploy_with_bounded_loss_cap():
+    engine = RiskEngine(RiskLimits(max_position_size_quote=500.0))
+    state = RiskState()
+    callback = auto_approve_with_risk_check(engine, state, execution_mode="loop")
+
+    result = asyncio.run(
+        callback(
+            _bot_call(
+                "deploy",
+                bot_name="x",
+                controllers_config=["cfg"],
+                max_global_drawdown_quote=400.0,
+            ),
+            _OPTIONS,
+        )
+    )
+    assert result["outcome"]["outcome"] == "selected"
+
+
+def test_loop_mode_blocks_bot_deploy_with_excessive_loss_cap():
+    engine = RiskEngine(RiskLimits(max_position_size_quote=500.0))
+    state = RiskState()
+    callback = auto_approve_with_risk_check(engine, state, execution_mode="loop")
+
+    result = asyncio.run(
+        callback(
+            _bot_call(
+                "deploy",
+                bot_name="x",
+                controllers_config=["cfg"],
+                max_global_drawdown_quote=5000.0,
+            ),
+            _OPTIONS,
+        )
+    )
+    assert result["outcome"]["outcome"] == "cancelled"
+
+
+def test_loop_mode_blocks_update_config_raising_amount_beyond_limit():
+    engine = RiskEngine(RiskLimits(max_position_size_quote=500.0))
+    state = RiskState()
+    callback = auto_approve_with_risk_check(engine, state, execution_mode="loop")
+
+    result = asyncio.run(
+        callback(
+            _bot_call(
+                "update_config",
+                bot_name="x",
+                config_name="cfg",
+                config_data={"total_amount_quote": 900.0},
+            ),
+            _OPTIONS,
+        )
+    )
+    assert result["outcome"]["outcome"] == "cancelled"
+
+
+def test_loop_mode_approves_update_config_within_limit():
+    engine = RiskEngine(RiskLimits(max_position_size_quote=500.0))
+    state = RiskState()
+    callback = auto_approve_with_risk_check(engine, state, execution_mode="loop")
+
+    result = asyncio.run(
+        callback(
+            _bot_call(
+                "update_config",
+                bot_name="x",
+                config_name="cfg",
+                config_data={"total_amount_quote": 300.0},
+            ),
+            _OPTIONS,
+        )
+    )
+    assert result["outcome"]["outcome"] == "selected"
+
+
+def test_loop_mode_still_approves_bot_stop():
+    """Stops are risk-reducing — never blocked by the loss-cap gate."""
+    engine = RiskEngine(RiskLimits())
+    state = RiskState()
+    callback = auto_approve_with_risk_check(engine, state, execution_mode="loop")
+
+    result = asyncio.run(callback(_bot_call("stop_bot", bot_name="x"), _OPTIONS))
+    assert result["outcome"]["outcome"] == "selected"

--- a/tests/trading_agent/test_risk_drawdown.py
+++ b/tests/trading_agent/test_risk_drawdown.py
@@ -1,7 +1,7 @@
 import pytest
 
-from condor.trading_agent.journal import JournalManager
-from condor.trading_agent.performance import _executor_row
+from condor.agents.journal import JournalManager
+from condor.agents.performance import _executor_row
 
 
 def test_drawdown_uses_exposure_not_peak_profit(tmp_path):


### PR DESCRIPTION
## Summary

The three **pure bug fixes** from #153, extracted onto a clean base off `main` — no MCP-harness spike, no identity/JWT work, no spike doc. These bugs are independent of the spike and affect Telegram/web users too; #153's harness validation just surfaced them.

Each file carries **only** its bug-fix delta (applied as a 3-way merge over current `main`), so `main`'s post-fork changes are preserved — notably `engine.py`'s `risk_state` exposure block, which a naïve whole-file copy from the spike branch would have regressed.

## Fixes

**#150 — stale routine references.** `pmm_mister_operator/strategy.md` Step 1 called `portfolio_scanner` and `bot_position_tracker`, which no longer exist — every tick errored. Swapped for their documented consolidation, `mm_dashboard`.

**#151 — `manage_bots(deploy)` escaped both risk gates.**
- **Dry-run:** "observation only" mode blocked `manage_executors` / `place_order` / gateway paths but **not** `manage_bots`, so an observation agent could deploy a live bot with real capital. Added `DANGEROUS_BOT_ACTIONS`, gated `manage_bots` in the dry-run branch, and taught `BASE_PROMPT_DRY_RUN` + the confirmation formatter about it (defense in depth; the prompt now names the bot/config instead of a bare tool name).
- **Loop mode:** `manage_bots(deploy)` was auto-approved with **no** risk check while `manage_executors(create)` is exposure-gated. A bot's capital lives in saved controller configs on the API server (not in the tool call), so `RiskEngine.check_bot_action` bounds the **loss** instead: a deploy must declare `max_global_drawdown_quote` ≤ the strategy's `max_position_size_quote`, and an `update_config` can't raise `total_amount_quote` above that limit. The live prompt and `pmm_mister_operator` doc instruct the model to include the cap.

**#152 — serverless agents lost their memory/skill scope.** Agents with `server_required: false` (e.g. `routine_builder`) got no `--agent-slug` in their MCP subprocess, so `manage_skill` / `manage_memory` silently targeted the **chat's** stores. `build_mcp_servers_for_session` gains `agent_slug`; both serverless call sites (`consult.py`, `engine.py`) pass it. Chat sessions still get none (unchanged).

## Scope / what's excluded

Deliberately leaves behind everything spike-specific in #153: the identity tiering (Tier A auto-bind, JWT split-brain, OpenClaw registration), `mcp-harness-spike.md`, and the install scaffolding. Those remain real and can be re-opened on their own branch — this PR is just the three low-risk, self-contained bug fixes.

## Tests

**49 pass** — the dry-run `manage_bots` gate, the loop-mode loss-cap gate (block/approve on deploy and update_config; stops stay approved), the confirmation formatter, and `--agent-slug` scoping (asserting chat sessions still get none).

## Notes for reviewers

- Fixes reach a running backend only after a `main.py` restart.
- Live-mode strategies that deploy bots must now declare `max_global_drawdown_quote` on deploy (blocked otherwise) — `pmm_mister_operator`'s instructions were updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)