### PR TITLE
chore: ignore agent dry-run and delegation runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,6 +184,9 @@ node_modules/
 # Routine reports
 /reports/
 
-# Agent runtime artifacts: learnings and session journals (not committed)
+# Agent runtime artifacts: learnings, session journals, dry-run experiments,
+# and delegation records (not committed)
 agents/**/learnings.md
 agents/**/sessions/
+agents/**/dry_runs/
+agents/**/delegations/


### PR DESCRIPTION
`dry_runs/` (dry-run experiment output) and `delegations/` (delegation records) are per-agent runtime artifacts — generated by running an agent, not authored — just like `learnings.md` and `sessions/` (already ignored). This keeps them out of version control so they stop showing up as untracked noise.

```
agents/**/dry_runs/
agents/**/delegations/
```

Verified no currently-tracked files match these patterns, so the rules take effect immediately with nothing to untrack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)