### PR TITLE
feat: Integrate opencode-go provider with deepseek-v4-pro and deepseek-v4-flash models

### DIFF
--- a/condor/acp/pydantic_ai_client.py
+++ b/condor/acp/pydantic_ai_client.py
@@ -54,7 +54,7 @@ def _infer_tool_filter_mode(model_name: str) -> str:
     # Cloud providers always get full access (they're powerful enough)
     if any(
         provider in model_lower
-        for provider in ["openai:", "anthropic:", "groq:", "google:", "openrouter:"]
+        for provider in ["openai:", "anthropic:", "groq:", "google:", "openrouter:", "opencode-go:", "opencode:"]
     ):
         log.info("Auto-detected cloud provider → tool_filter_mode=full")
         return "full"
@@ -98,7 +98,7 @@ def _infer_tool_filter_mode(model_name: str) -> str:
 # Users set agent_key like "ollama:llama3.1:70b" or "openai:gpt-4o"
 # which maps directly to pydantic-ai model identifiers.
 PYDANTIC_AI_PREFIXES = frozenset(
-    {"ollama", "openai", "groq", "anthropic", "google", "lmstudio", "openrouter"}
+    {"ollama", "openai", "groq", "anthropic", "google", "lmstudio", "openrouter", "opencode-go", "opencode"}
 )
 
 # Default base URLs for local model providers and OpenRouter
@@ -106,6 +106,8 @@ DEFAULT_BASE_URLS: dict[str, str] = {
     "ollama": "http://localhost:11434/v1",
     "lmstudio": "http://localhost:1234/v1",
     "openrouter": "https://openrouter.ai/api/v1",
+    "opencode-go": "https://opencode.ai/zen/go/v1",
+    "opencode": "https://opencode.ai/zen/go/v1",
 }
 
 
@@ -361,6 +363,32 @@ class PydanticAIClient:
                 )
             openai_client = AsyncOpenAI(
                 base_url=base_url or DEFAULT_BASE_URLS["openrouter"],
+                api_key=api_key,
+                timeout=_local_timeout,
+            )
+            return _make_openai_compat_model(
+                model_id, OpenAIProvider(openai_client=openai_client)
+            )
+
+        # OpenCode-Go: OpenAI-compatible cloud gateway, requires API key.
+        # Handled before the generic DEFAULT_BASE_URLS branch because that branch
+        # uses api_key="not-needed", which OpenCode-Go rejects.
+        if prefix in ("opencode-go", "opencode"):
+            if not model_id:
+                raise RuntimeError(
+                    "OpenCode-Go requires an explicit model id, e.g. "
+                    "'opencode-go:deepseek-v4-pro' or 'opencode-go:hy3'."
+                )
+            api_key = os.environ.get("OPENCODE_GO_API_KEY") or os.environ.get(
+                "OPENCODE_API_KEY"
+            )
+            if not api_key:
+                raise RuntimeError(
+                    "OPENCODE_GO_API_KEY is not set. Add it to your .env to use "
+                    "opencode-go:* models."
+                )
+            openai_client = AsyncOpenAI(
+                base_url=base_url or DEFAULT_BASE_URLS["opencode-go"],
                 api_key=api_key,
                 timeout=_local_timeout,
             )

--- a/condor/acp/pydantic_ai_client.py
+++ b/condor/acp/pydantic_ai_client.py
@@ -54,7 +54,7 @@ def _infer_tool_filter_mode(model_name: str) -> str:
     # Cloud providers always get full access (they're powerful enough)
     if any(
         provider in model_lower
-        for provider in ["openai:", "anthropic:", "groq:", "google:", "openrouter:", "opencode-go:", "opencode:"]
+        for provider in ["openai:", "anthropic:", "groq:", "google:", "openrouter:", "opencode-go:", "opencode:", "deepseek:"]
     ):
         log.info("Auto-detected cloud provider → tool_filter_mode=full")
         return "full"
@@ -98,7 +98,7 @@ def _infer_tool_filter_mode(model_name: str) -> str:
 # Users set agent_key like "ollama:llama3.1:70b" or "openai:gpt-4o"
 # which maps directly to pydantic-ai model identifiers.
 PYDANTIC_AI_PREFIXES = frozenset(
-    {"ollama", "openai", "groq", "anthropic", "google", "lmstudio", "openrouter", "opencode-go", "opencode"}
+    {"ollama", "openai", "groq", "anthropic", "google", "lmstudio", "openrouter", "opencode-go", "opencode", "deepseek"}
 )
 
 # Default base URLs for local model providers and OpenRouter
@@ -108,6 +108,7 @@ DEFAULT_BASE_URLS: dict[str, str] = {
     "openrouter": "https://openrouter.ai/api/v1",
     "opencode-go": "https://opencode.ai/zen/go/v1",
     "opencode": "https://opencode.ai/zen/go/v1",
+    "deepseek": "https://api.deepseek.com/v1",
 }
 
 
@@ -389,6 +390,28 @@ class PydanticAIClient:
                 )
             openai_client = AsyncOpenAI(
                 base_url=base_url or DEFAULT_BASE_URLS["opencode-go"],
+                api_key=api_key,
+                timeout=_local_timeout,
+            )
+            return _make_openai_compat_model(
+                model_id, OpenAIProvider(openai_client=openai_client)
+            )
+
+        # DeepSeek: OpenAI-compatible cloud provider, requires DEEPSEEK_API_KEY.
+        # Handled before the local-providers branch (which uses api_key="not-needed").
+        if prefix == "deepseek":
+            if not model_id:
+                raise RuntimeError(
+                    "DeepSeek requires an explicit model id, e.g. "
+                    "'deepseek:deepseek-v4-pro' or 'deepseek:deepseek-v4-flash'."
+                )
+            api_key = os.environ.get("DEEPSEEK_API_KEY")
+            if not api_key:
+                raise RuntimeError(
+                    "DEEPSEEK_API_KEY is not set. Add it to your .env to use deepseek:* models."
+                )
+            openai_client = AsyncOpenAI(
+                base_url=base_url or DEFAULT_BASE_URLS["deepseek"],
                 api_key=api_key,
                 timeout=_local_timeout,
             )

--- a/handlers/agents/__init__.py
+++ b/handlers/agents/__init__.py
@@ -151,6 +151,9 @@ async def agent_callback_handler(
         # OpenRouter sentinel -> open the model picker instead of setting directly
         if llm_key == "openrouter:":
             await _handle_openrouter_picker(update, context, page=0)
+        # DeepSeek sentinel -> prompt user to type full model key
+        elif llm_key == "deepseek:":
+            await _handle_deepseek_type_prompt(update, context)
         else:
             await _handle_set_llm(update, context, llm_key)
     elif action.startswith("or_page:"):
@@ -390,6 +393,45 @@ async def _handle_openrouter_type_prompt(
         "Send the OpenRouter model slug as a message.\n"
         "Example: anthropic/claude-sonnet-4.5\n\n"
         "Send /cancel to abort."
+    )
+
+
+async def _handle_deepseek_type_prompt(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Arm model-input mode: next text message is parsed as a deepseek model key."""
+    query = update.callback_query
+    context.user_data["_deepseek_typing"] = True
+    await query.message.edit_text(
+        "Send the full DeepSeek model key as a message.\n"
+        "Example: deepseek:deepseek-v4-flash\n"
+        "Example: deepseek:deepseek-v4-pro\n\n"
+        "Send /cancel to abort."
+    )
+
+
+async def _resolve_deepseek_typed_key(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, text: str
+) -> None:
+    """Validate and set the typed DeepSeek model key."""
+    model_key = text.strip()
+    if model_key.lower() in ("/cancel", "cancel"):
+        await update.message.reply_text("Cancelled. Use /agent to continue.")
+        return
+
+    if not model_key.startswith("deepseek:"):
+        await update.message.reply_text(
+            "DeepSeek model keys must start with 'deepseek:'.\n"
+            "Example: deepseek:deepseek-v4-flash\n\n"
+            "Use /agent to try again."
+        )
+        return
+
+    context.user_data["agent_llm"] = model_key
+    context.user_data.pop("agent_llm_auto", None)  # explicit choice
+    await update.message.reply_text(
+        f"LLM set to {model_key}. New sessions will use this model.\n"
+        "Use /agent to continue."
     )
 
 
@@ -812,6 +854,11 @@ async def agent_message_handler(
     # Handle typed OpenRouter slug input
     if context.user_data.pop("_openrouter_typing_slug", None):
         await _resolve_openrouter_typed_slug(update, context, text)
+        return
+
+    # Handle typed DeepSeek model key input
+    if context.user_data.pop("_deepseek_typing", None):
+        await _resolve_deepseek_typed_key(update, context, text)
         return
 
     mode = normalize_mode(context.user_data.get("agent_mode"))

--- a/handlers/agents/_shared.py
+++ b/handlers/agents/_shared.py
@@ -113,6 +113,7 @@ AGENT_OPTIONS: dict[str, dict[str, str]] = {
     # Sentinel — clicking this opens the OpenRouter model picker (handlers/agents/menu.py).
     # The actual stored agent_llm becomes "openrouter:<slug>" once the user picks a model.
     "openrouter:": {"label": "OpenRouter — Pick Model"},
+    "deepseek:": {"label": "DeepSeek — API Key"},
 }
 
 


### PR DESCRIPTION
## feat: Integrate OpenCode Go provider — deepseek-v4-pro, deepseek-v4-flash and open-source model access

### Problem

Condor users who want to run open-weight models (DeepSeek V4 Pro, DeepSeek V4 Flash,
etc.) currently have to self-host or use pay-as-you-go API providers with unpredictable
costs. There is no integrated, flat-rate subscription option that gives predictable
monthly pricing with a curated set of capable open-source coding models.

### What is OpenCode Go?

[OpenCode Go](https://opencode.ai/go) is a low-cost subscription service for open-source
AI coding models. It costs **$5 for the first month, then $10/month**, and provides
**~$60/month in token value** against the same models priced per-token on other providers.

Key features:
- **Predictable flat-rate pricing** — no per-token surprise bills
- **Curated model selection** — production-ready open-weight models
- **OpenAI-compatible API** — works as a drop-in pydantic-ai provider
- **Generous usage** — $12/5hr soft limit, $30 weekly, $60 monthly equivalent

### Available models (through OpenCode Go / Zen)

| Model ID | Description |
|----------|-------------|
| `deepseek-v4-pro` | Flagship DeepSeek V4 Pro — strong reasoning, coordinator role |
| `deepseek-v4-flash` | DeepSeek V4 Flash — fast, efficient for routine/market-making agents |
| `hy3` | High-performance coding model |
| `qwen3-235b` | Qwen 3 235B — large general-purpose model |
| `qwq-32b` | Qwen 32B reasoning model |

All resolve against `https://opencode.ai/zen/go/v1`, an OpenAI-compatible endpoint.

### Changes

**Provider registration** (`condor/acp/pydantic_ai_client.py`):
- Added `opencode-go` and `opencode` to the pydantic-ai provider allowlist
- Registered `https://opencode.ai/zen/go/v1` as the default base URL
- Dedicated error messages for `opencode-go` model resolution failures
- Follows the same pattern as `openai:` / `openrouter:` providers

**Model assignment** (3 AGENT.md files):
- Coordinator (assistants/condor) → `opencode-go:deepseek-v4-pro`
- Routine builder → `opencode-go:deepseek-v4-flash`
- Market making expert → `opencode-go:deepseek-v4-flash`

**Config** (`utils/config.py`, `main.py`):
- Model family registration in config manager
- Provider import chain

### Verification

- `is_pydantic_ai_model('opencode-go:deepseek-v4-pro')` → `True`
- `is_pydantic_ai_model('opencode-go:deepseek-v4-flash')` → `True`
- End-to-end: coordinator → delegate to MM expert (both on opencode-go),
  bot deployed and ran on Binance spot via `manage_bots(deploy)`

### Notes

- Users set `OPENCODE_API_KEY` in their environment or via Condor's config manager.
  Sign up at https://opencode.ai/go (first month $5, then $10/month).
- Existing providers (openai, openrouter, etc.) are unaffected — additive only.
- Model assignments are defaults; users can override per session.