### PR TITLE
feat: add native DeepSeek API provider — deepseek-v4-pro and deepseek-v4-flash

### DIFF
--- a/condor/acp/pydantic_ai_client.py
+++ b/condor/acp/pydantic_ai_client.py
@@ -368,6 +368,28 @@ class PydanticAIClient:
                 model_id, OpenAIProvider(openai_client=openai_client)
             )
 
+        # DeepSeek: OpenAI-compatible cloud provider, requires DEEPSEEK_API_KEY.
+        # Handled before the local-providers branch (which uses api_key="not-needed").
+        if prefix == "deepseek":
+            if not model_id:
+                raise RuntimeError(
+                    "DeepSeek requires an explicit model id, e.g. "
+                    "'deepseek:deepseek-v4-pro' or 'deepseek:deepseek-v4-flash'."
+                )
+            api_key = os.environ.get("DEEPSEEK_API_KEY")
+            if not api_key:
+                raise RuntimeError(
+                    "DEEPSEEK_API_KEY is not set. Add it to your .env to use deepseek:* models."
+                )
+            openai_client = AsyncOpenAI(
+                base_url=base_url or DEFAULT_BASE_URLS["deepseek"],
+                api_key=api_key,
+                timeout=_local_timeout,
+            )
+            return _make_openai_compat_model(
+                model_id, OpenAIProvider(openai_client=openai_client)
+            )
+
         # Local providers: always use OpenAI-compatible endpoint with default URL
         if prefix in DEFAULT_BASE_URLS:
             base_url = base_url or DEFAULT_BASE_URLS[prefix]

--- a/condor/acp/pydantic_ai_client.py
+++ b/condor/acp/pydantic_ai_client.py
@@ -54,7 +54,7 @@ def _infer_tool_filter_mode(model_name: str) -> str:
     # Cloud providers always get full access (they're powerful enough)
     if any(
         provider in model_lower
-        for provider in ["openai:", "anthropic:", "groq:", "google:", "openrouter:"]
+        for provider in ["openai:", "anthropic:", "groq:", "google:", "openrouter:", "deepseek:"]
     ):
         log.info("Auto-detected cloud provider → tool_filter_mode=full")
         return "full"
@@ -98,7 +98,7 @@ def _infer_tool_filter_mode(model_name: str) -> str:
 # Users set agent_key like "ollama:llama3.1:70b" or "openai:gpt-4o"
 # which maps directly to pydantic-ai model identifiers.
 PYDANTIC_AI_PREFIXES = frozenset(
-    {"ollama", "openai", "groq", "anthropic", "google", "lmstudio", "openrouter"}
+    {"ollama", "openai", "groq", "anthropic", "google", "lmstudio", "openrouter", "deepseek"}
 )
 
 # Default base URLs for local model providers and OpenRouter
@@ -106,6 +106,7 @@ DEFAULT_BASE_URLS: dict[str, str] = {
     "ollama": "http://localhost:11434/v1",
     "lmstudio": "http://localhost:1234/v1",
     "openrouter": "https://openrouter.ai/api/v1",
+    "deepseek": "https://api.deepseek.com/v1",
 }
 
 

--- a/handlers/agents/__init__.py
+++ b/handlers/agents/__init__.py
@@ -151,6 +151,9 @@ async def agent_callback_handler(
         # OpenRouter sentinel -> open the model picker instead of setting directly
         if llm_key == "openrouter:":
             await _handle_openrouter_picker(update, context, page=0)
+        # DeepSeek sentinel -> prompt user to type full model key
+        elif llm_key == "deepseek:":
+            await _handle_deepseek_type_prompt(update, context)
         else:
             await _handle_set_llm(update, context, llm_key)
     elif action.startswith("or_page:"):
@@ -390,6 +393,45 @@ async def _handle_openrouter_type_prompt(
         "Send the OpenRouter model slug as a message.\n"
         "Example: anthropic/claude-sonnet-4.5\n\n"
         "Send /cancel to abort."
+    )
+
+
+async def _handle_deepseek_type_prompt(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Arm model-input mode: next text message is parsed as a deepseek model key."""
+    query = update.callback_query
+    context.user_data["_deepseek_typing"] = True
+    await query.message.edit_text(
+        "Send the full DeepSeek model key as a message.\n"
+        "Example: deepseek:deepseek-v4-flash\n"
+        "Example: deepseek:deepseek-v4-pro\n\n"
+        "Send /cancel to abort."
+    )
+
+
+async def _resolve_deepseek_typed_key(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, text: str
+) -> None:
+    """Validate and set the typed DeepSeek model key."""
+    model_key = text.strip()
+    if model_key.lower() in ("/cancel", "cancel"):
+        await update.message.reply_text("Cancelled. Use /agent to continue.")
+        return
+
+    if not model_key.startswith("deepseek:"):
+        await update.message.reply_text(
+            "DeepSeek model keys must start with 'deepseek:'.\n"
+            "Example: deepseek:deepseek-v4-flash\n\n"
+            "Use /agent to try again."
+        )
+        return
+
+    context.user_data["agent_llm"] = model_key
+    context.user_data.pop("agent_llm_auto", None)  # explicit choice
+    await update.message.reply_text(
+        f"LLM set to {model_key}. New sessions will use this model.\n"
+        "Use /agent to continue."
     )
 
 
@@ -812,6 +854,11 @@ async def agent_message_handler(
     # Handle typed OpenRouter slug input
     if context.user_data.pop("_openrouter_typing_slug", None):
         await _resolve_openrouter_typed_slug(update, context, text)
+        return
+
+    # Handle typed DeepSeek model key input
+    if context.user_data.pop("_deepseek_typing", None):
+        await _resolve_deepseek_typed_key(update, context, text)
         return
 
     mode = normalize_mode(context.user_data.get("agent_mode"))

--- a/handlers/agents/_shared.py
+++ b/handlers/agents/_shared.py
@@ -113,6 +113,7 @@ AGENT_OPTIONS: dict[str, dict[str, str]] = {
     # Sentinel — clicking this opens the OpenRouter model picker (handlers/agents/menu.py).
     # The actual stored agent_llm becomes "openrouter:<slug>" once the user picks a model.
     "openrouter:": {"label": "OpenRouter — Pick Model"},
+    "deepseek:": {"label": "DeepSeek — API Key"},
 }
 
 


### PR DESCRIPTION
Adds a `deepseek:` provider prefix for direct DeepSeek API access
(api.deepseek.com/v1). Users set `DEEPSEEK_API_KEY` and use model keys
like `deepseek:deepseek-v4-pro` or `deepseek:deepseek-v4-flash`.

Why: DeepSeek has become one of the most popular open-weight model families,
particularly among developers in China where it is natively hosted and widely
adopted. Native integration removes the need to route through a third-party
gateway or configure custom base URLs.

Changes:
- Provider registration in pydantic_ai_client.py (same pattern as openrouter)
- Telegram LLM picker support (select → type model key)
- Verified end-to-end: model resolution, API auth, prompt execution, and
  bot deployment

3 files, +73/−2.