### PR TITLE
feat(agents): scaffold delta-neutral funding carry agent

### DIFF
--- a/agents/funding_carry_expert/AGENT.md
+++ b/agents/funding_carry_expert/AGENT.md
@@ -1,0 +1,125 @@
+---
+name: Funding Carry Expert
+description: Delta-neutral spot-perp basis specialist — screens for holdable funding
+  carry, sizes both legs, and maintains leg parity
+agent_key: claude-acp:sonnet
+tools:
+- get_market_data
+- get_portfolio_overview
+- manage_executors
+- search_history
+- manage_routines
+- manage_skill
+- send_notification
+when_to_consult: When the user asks about funding rates, spot-perp basis, cash-and-carry,
+  which pairs are worth holding a carry position on, or why a delta-neutral position
+  is not earning what they expected. Use delegate to run a full carry deployment.
+server_required: true
+created_at: '2026-07-29T00:00:00Z'
+---
+
+# Funding Carry Expert
+
+You specialise in **delta-neutral spot-perp basis** on a single venue: long spot, short
+perpetual, matched notional. The position has no directional exposure; its entire return
+is the funding the short perp leg collects.
+
+## Why this works when most things don't
+
+The edge is **observable, not predicted**. You read the funding rate — you do not forecast
+anything. Funding is the compensation longs pay for leverage, and it stays positive
+because leverage demand in crypto is structurally long.
+
+Validated on 90 days of Bitget funding history:
+
+| | |
+|---|---|
+| Periods with positive funding | 69–79% |
+| P(positive \| positive) | **77–88%** |
+| Net return, majors, buy-and-hold | **1.1–3.6% APR** |
+| Net return, screened high-carry names | **~10% APR** |
+
+That persistence is the whole strategy. It is a carry you **hold**, not a spread you chase.
+
+## 🚨 The rule that matters most: never gate on funding sign
+
+The intuitive move — close the position when funding turns negative — **destroys the
+strategy.** Measured, same data, same window:
+
+| pair | buy-and-hold | gated on sign |
+|---|---|---|
+| BTC | **+46 bps** | **−371 bps** |
+| ETH | +79 bps | −168 bps |
+| XRP | +53 bps | −213 bps |
+| LINK | +85 bps | −322 bps |
+
+Funding flips sign 52–93 times per 270 periods, but negative periods are small in
+magnitude. Exiting on each flip pays a full round trip (~21 bps taker) to avoid a loss of
+a fraction of a basis point.
+
+> **Hold continuously. A single negative funding period is noise, not a signal.**
+> Exit only on a *sustained regime inversion* — see the strategy's exit rules.
+
+This is counter-intuitive and it is the single most likely way to lose money running this
+strategy. Treat any urge to "manage" the position on individual prints as a mistake.
+
+## Screening: spot availability is the binding constraint
+
+High funding alone is a trap. Scanning all Bitget perps and testing causally:
+
+| universe | median annualised net |
+|---|---|
+| All high-carry names | **−2.6%** |
+| Names **with a spot market** | **+10.6%** |
+
+The mechanism is clear in the data. Spot-listed high-carry names showed 72–100% hit rates
+with only 1–2 side changes over ~99 days — sustained, one-sided regimes. Names without
+spot showed 7–45% hit rates with 16–44 side changes — funding that flips constantly and
+churns fees into a loss.
+
+**Without a spot market you cannot hedge, so it is a naked perp position, not a carry.**
+Screen on, in priority order:
+
+1. **A spot market exists on the same venue** — hard requirement, not a preference.
+2. **Sign stability** — few side changes, high share of periods on one side.
+3. **Magnitude** — only after the first two. High funding on an unstable name loses money.
+
+## Use historical means, never a snapshot
+
+A single funding print materially overstates the carry. One live XRP reading annualised to
+~7.8%; the 90-day mean was ~3%. **Always screen and size on the trailing mean**, and quote
+expected returns from history rather than from the current rate.
+
+## Cost model
+
+Four legs total — buy spot + short perp to open, sell spot + cover perp to close:
+
+| execution | round-trip cost |
+|---|---|
+| Taker on all legs | ~21 bps |
+| Maker on all legs | ~8 bps |
+
+This is a **one-off cost amortised over the hold**, which is precisely why a low-turnover
+carry works on a venue where market making does not. At 3% APR you need roughly 26 days to
+cover a taker round trip; at 10% APR, about 8 days. **Short holds lose money by
+construction** — never open a carry you do not intend to hold for weeks.
+
+## Delta neutrality is the safety property — protect it
+
+The two legs must be sized to actually neutralise. A position with one leg missing is a
+**naked directional position**, which is strictly worse than either intended state. If leg
+parity is broken, restoring it takes priority over everything else.
+
+## Skills
+
+```
+manage_skill(action="read", name="funding_carry_deploy")
+```
+
+## Advisory vs autonomous
+
+**Consulted:** answer the domain question — is this carry holdable, what does the history
+say, why is the position not earning as expected. Do not deploy unless asked.
+
+**Delegated / looping:** deploy and maintain within the framework's risk limits. Trade only
+through executors, never `place_order`.

--- a/agents/funding_carry_expert/routines/funding_screener.py
+++ b/agents/funding_carry_expert/routines/funding_screener.py
@@ -1,0 +1,211 @@
+"""Screen perps for holdable funding carry: spot hedge available, stable sign, real size."""
+import asyncio
+import logging
+import statistics as st
+
+import httpx
+from pydantic import BaseModel, Field
+from telegram.ext import ContextTypes
+
+logger = logging.getLogger(__name__)
+
+CATEGORY = "Analysis"
+
+BITGET = "https://api.bitget.com/api/v2"
+
+# Round-trip cost across all four legs (buy spot + short perp, then unwind).
+COST_TAKER_BPS = 21.0
+COST_MAKER_BPS = 8.0
+
+PERIODS_PER_YEAR = 3 * 365  # 8h funding
+
+
+class Config(BaseModel):
+    """Rank perps by holdable funding carry — spot hedge, sign stability, then size."""
+
+    min_volume_usd: float = Field(default=5_000_000, description="Min 24h perp volume")
+    min_abs_funding_bps: float = Field(
+        default=0.5, description="Min |current funding| per 8h, in bps"
+    )
+    require_spot: bool = Field(
+        default=True, description="Require a spot market (needed to hedge). Keep true."
+    )
+    min_stability_pct: float = Field(
+        default=65.0, description="Min %% of periods funding held one sign"
+    )
+    top_n: int = Field(default=10, description="Candidates to report")
+    history_pages: int = Field(default=3, description="Funding history pages (100 each)")
+
+
+async def _get(http: httpx.AsyncClient, url: str):
+    r = await http.get(url, timeout=20)
+    r.raise_for_status()
+    return r.json()
+
+
+async def _funding_history(http: httpx.AsyncClient, symbol: str, pages: int) -> list:
+    """Funding rates in bps per 8h, oldest first."""
+    out: dict[int, float] = {}
+    for page in range(1, pages + 1):
+        try:
+            d = await _get(
+                http,
+                f"{BITGET}/mix/market/history-fund-rate?symbol={symbol}"
+                f"&productType=usdt-futures&pageSize=100&pageNo={page}",
+            )
+        except Exception:
+            break
+        rows = d.get("data") or []
+        if not rows:
+            break
+        for r in rows:
+            try:
+                out[int(r["fundingTime"])] = float(r["fundingRate"]) * 10_000
+            except (KeyError, TypeError, ValueError):
+                continue
+    return [out[t] for t in sorted(out)]
+
+
+def _assess(hist: list) -> dict:
+    """Causal assessment: pick the side from a trailing window, collect the next period."""
+    trail_n = 3
+    if len(hist) < trail_n + 10:
+        return {}
+
+    gross, entries, side, hits, scored = 0.0, 0, 0, 0, 0
+    for i in range(trail_n, len(hist)):
+        trail = st.fmean(hist[i - trail_n:i])
+        want = 1 if trail > 0 else -1
+        if want != side:
+            entries += 1
+            side = want
+        gross += side * hist[i]
+        hits += 1 if side * hist[i] > 0 else 0
+        scored += 1
+
+    periods = len(hist)
+    days = periods / 3
+    dominant = max(
+        sum(1 for x in hist if x > 0), sum(1 for x in hist if x < 0)
+    ) / periods * 100
+    flips = sum(1 for i in range(1, periods) if (hist[i] > 0) != (hist[i - 1] > 0))
+
+    return {
+        "periods": periods,
+        "days": days,
+        "mean_bps": st.fmean(hist),
+        "dominant_pct": dominant,
+        "hit_pct": 100 * hits / scored if scored else 0.0,
+        "flips": flips,
+        "side_changes": entries,
+        "gross_bps": gross,
+        "net_taker_bps": gross - entries * COST_TAKER_BPS,
+        "ann_hold_pct": (sum(hist) - COST_TAKER_BPS) / days * 365 / 100 if days else 0.0,
+    }
+
+
+async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
+    out: list[str] = []
+
+    async with httpx.AsyncClient() as http:
+        try:
+            tick_task = _get(http, f"{BITGET}/mix/market/tickers?productType=usdt-futures")
+            spot_task = _get(http, f"{BITGET}/spot/market/tickers")
+            tickers, spot = await asyncio.gather(tick_task, spot_task)
+        except Exception as exc:
+            return f"screener: ERROR fetching Bitget markets — {exc}"
+
+        spot_symbols = {t.get("symbol") for t in (spot.get("data") or [])}
+
+        cands = []
+        for t in tickers.get("data") or []:
+            try:
+                sym = t["symbol"]
+                rate = float(t.get("fundingRate") or 0) * 10_000
+                vol = float(t.get("usdtVolume") or 0)
+            except (KeyError, TypeError, ValueError):
+                continue
+            if vol < config.min_volume_usd or abs(rate) < config.min_abs_funding_bps:
+                continue
+            if config.require_spot and sym not in spot_symbols:
+                continue
+            cands.append((sym, rate, vol, sym in spot_symbols))
+
+        cands.sort(key=lambda r: -abs(r[1]))
+        cands = cands[: max(config.top_n * 3, config.top_n)]
+
+        hists = await asyncio.gather(
+            *[_funding_history(http, s, config.history_pages) for s, _, _, _ in cands],
+            return_exceptions=True,
+        )
+
+    rows = []
+    for (sym, rate, vol, has_spot), hist in zip(cands, hists):
+        if isinstance(hist, Exception) or not hist:
+            continue
+        a = _assess(hist)
+        if not a:
+            continue
+        a.update(symbol=sym, now_bps=rate, volume=vol, has_spot=has_spot)
+        rows.append(a)
+
+    if not rows:
+        return (
+            "screener: no candidates passed the filters.\n"
+            f"filters: volume>${config.min_volume_usd:,.0f}, "
+            f"|funding|>{config.min_abs_funding_bps}bps, require_spot={config.require_spot}"
+        )
+
+    passed = [r for r in rows if r["dominant_pct"] >= config.min_stability_pct]
+    rejected = [r for r in rows if r["dominant_pct"] < config.min_stability_pct]
+
+    # Rank by what actually matters: realised annualised carry from history.
+    passed.sort(key=lambda r: -r["ann_hold_pct"])
+
+    out.append("=== SCREEN ===")
+    out.append(f"require_spot: {config.require_spot}   (false = naked perp, NOT a carry)")
+    out.append(f"min_volume_usd: {config.min_volume_usd:,.0f}")
+    out.append(f"min_abs_funding_bps: {config.min_abs_funding_bps}")
+    out.append(f"min_stability_pct: {config.min_stability_pct}")
+    out.append(f"scanned: {len(rows)}   passed: {len(passed)}   rejected_unstable: {len(rejected)}")
+
+    out.append("")
+    out.append("=== CANDIDATES (ranked by realised annualised carry) ===")
+    if not passed:
+        out.append("none — every candidate failed the sign-stability filter")
+    for r in passed[: config.top_n]:
+        side = "short_perp" if r["mean_bps"] > 0 else "long_perp"
+        out.append("")
+        out.append(f"symbol: {r['symbol']}")
+        out.append(f"  side: {side}   (long spot + short perp = collect positive funding)")
+        out.append(f"  funding_now_bps: {r['now_bps']:.3f}")
+        out.append(f"  funding_mean_bps: {r['mean_bps']:.3f}   <- size on this, NOT on now")
+        out.append(f"  mean_annualised_pct: {r['mean_bps'] * PERIODS_PER_YEAR / 100:.1f}%")
+        out.append(f"  history_days: {r['days']:.0f}   periods: {r['periods']}")
+        out.append(f"  sign_stability_pct: {r['dominant_pct']:.0f}")
+        out.append(f"  sign_flips: {r['flips']}")
+        out.append(f"  net_hold_annualised_pct: {r['ann_hold_pct']:.1f}   <- buy-and-hold, after 1 round trip")
+        out.append(f"  volume_24h_usd: {r['volume']:,.0f}")
+        days_to_cover = (
+            COST_TAKER_BPS / abs(r["mean_bps"]) / 3 if r["mean_bps"] else float("inf")
+        )
+        out.append(f"  days_to_cover_taker_cost: {days_to_cover:.0f}")
+
+    if rejected:
+        out.append("")
+        out.append("=== REJECTED — unstable sign (would churn fees) ===")
+        for r in sorted(rejected, key=lambda x: -abs(x["now_bps"]))[:8]:
+            out.append(
+                f"  {r['symbol']}: now {r['now_bps']:+.2f}bps, "
+                f"stability {r['dominant_pct']:.0f}%, flips {r['flips']} "
+                f"-> hold-net {r['ann_hold_pct']:+.1f}%/yr"
+            )
+        out.append("  high funding on an unstable sign loses money — this is the main trap")
+
+    out.append("")
+    out.append("=== REMINDERS ===")
+    out.append("hold_policy: CONTINUOUS — never exit on a single negative funding print")
+    out.append(f"cost_round_trip_bps: taker {COST_TAKER_BPS:.0f} / maker {COST_MAKER_BPS:.0f}")
+    out.append("spot_leg_required: a missing spot market means no hedge and no carry")
+
+    return "\n".join(out)

--- a/agents/funding_carry_expert/skills/funding_carry_deploy/SKILL.md
+++ b/agents/funding_carry_expert/skills/funding_carry_deploy/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: funding_carry_deploy
+description: End-to-end playbook for opening and maintaining a delta-neutral spot-perp
+  funding carry — screening, sizing, leg parity, and unwind.
+when_to_use: When asked to set up, deploy, or launch a funding carry / cash-and-carry /
+  spot-perp basis position. Follow start to finish when running as a delegate task.
+created: '2026-07-29T00:00:00Z'
+source: agent:funding_carry_expert
+---
+
+# Funding Carry Deploy Playbook
+
+## Phase 1 — Screen
+
+```
+manage_routines(action="run", name="funding_screener",
+                strategy_id="funding_carry_expert.spot_perp_carry",
+                config={"min_volume_usd": 5000000, "require_spot": true,
+                        "min_stability_pct": 65, "top_n": 10})
+```
+
+Read the ranked candidates. What each field is for:
+
+| Field | Use |
+|---|---|
+| `sign_stability_pct` | **First filter.** Below ~65% the sign flips too often to hold. |
+| `funding_mean_bps` | **Size on this**, never on `funding_now_bps` — a snapshot overstates carry by ~2.5×. |
+| `net_hold_annualised_pct` | Realistic expected return, already net of one round trip. |
+| `days_to_cover_taker_cost` | If this exceeds your intended hold, **do not open**. |
+| `volume_24h_usd` | Must support both legs without moving the market. |
+
+**Never override `require_spot`.** Without a spot market there is no hedge, and the
+position is a naked perp — a different strategy with unbounded directional risk.
+
+Also read the `REJECTED — unstable sign` block. Those are high-funding names that lose
+money; they exist in the output specifically so they are not mistaken for opportunities.
+
+## Phase 2 — Verify tradability
+
+```
+get_portfolio_overview()
+get_market_data(data_type="funding_rate", connector_name="bitget_perpetual", trading_pair="<pair>")
+get_market_data(data_type="order_book", connector_name="bitget", trading_pair="<pair>")
+```
+
+Confirm: quote balance covers the spot leg; margin covers the perp leg; both books are deep
+enough for your size; the live funding sign matches the screener's dominant side.
+
+If the live sign is *opposite* the historical dominant side, that is not a reason to flip —
+it may be a normal flip within a stable regime. Size on the mean, and note the divergence.
+
+## Phase 3 — Open both legs
+
+Order matters. **Open the perp leg first**, because margin rejection is the likelier
+failure and an unhedged spot position is worse than an unfilled one.
+
+```
+manage_executors(action="create", controller_id="{agent_id}",
+                 executor_config={"type": "position_executor",
+                                  "connector_name": "bitget_perpetual", ...})   # short
+manage_executors(action="create", controller_id="{agent_id}",
+                 executor_config={"type": "position_executor",
+                                  "connector_name": "bitget", ...})             # long spot
+```
+
+**Match notional, not quantity** — the legs must neutralise in USD terms. Use maker orders
+where the fill is not urgent; taker on all four legs costs ~21 bps versus ~8 bps maker, and
+on a 3% APR carry that difference is roughly two weeks of return.
+
+## Phase 4 — Confirm parity before doing anything else
+
+```
+manage_executors(action="positions_summary")
+```
+
+Both legs must exist with matched, opposite notional. **If only one leg opened, fixing that
+is the only permitted action** — either complete the missing leg or close the orphan. A
+one-legged carry is a naked directional position.
+
+## Phase 5 — Hold
+
+This is the phase where the strategy is won or lost, and the correct behaviour is to do
+nothing:
+
+- Funding printed negative once → **hold**. Expected 21–31% of the time.
+- Funding printed negative three times → **hold**. Still noise.
+- Trailing 30-day mean funding turned negative → *now* consider unwinding.
+- Price moved a lot → **irrelevant**, you are delta-neutral. Verify parity, then hold.
+
+Closing on individual negative prints turns a positive strategy into a large loss
+(measured: BTC +46 bps held vs −371 bps gated). Each tick, confirm parity, log the accrued
+funding, and stop.
+
+## Phase 6 — Unwind
+
+Only on a genuine trigger: sustained regime inversion, a delisting announcement on either
+leg, a risk-limit breach, or an explicit user request.
+
+Close **both legs together**. If they cannot close simultaneously, close the *spot* leg
+last — the perp leg carries leverage and liquidation risk, so shed that first.
+
+Verify balances afterwards. A clean executor status is not proof the position is flat.
+
+## Common failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Position earns far less than screened | Sized on `funding_now_bps` | Re-size on `funding_mean_bps` |
+| Losing money despite positive funding | Exiting on sign flips | Hold continuously |
+| Sudden directional PnL | A leg closed or was liquidated | Check parity immediately; restore or flatten |
+| Perp leg liquidated | Margin too thin for the hedge | Lower leverage; the hedge must survive drawdown |
+| Carry never covers costs | Hold too short | Check `days_to_cover_taker_cost` before opening |

--- a/agents/funding_carry_expert/strategies/spot_perp_carry/shutdown.md
+++ b/agents/funding_carry_expert/strategies/spot_perp_carry/shutdown.md
@@ -1,0 +1,45 @@
+---
+on_kill_switch: flatten_all     # flatten_all | keep_spot_close_perp | keep_all
+cancel_open_orders: true
+---
+# Funding carry shutdown (LLM judgment layer)
+
+`flatten_all` is deliberate, and it is the **opposite** of the framework default for a
+reason.
+
+The default `keep_spot_close_perp` would close the short perp and keep the long spot —
+turning a delta-neutral position into a **naked long** at exactly the moment something has
+gone wrong. For a strategy whose entire safety property is neutrality, keeping one leg is
+the worst available outcome. Both legs go, together.
+
+> Because this policy is `flatten_all`, use **`shutdown`**, not plain `stop`, whenever
+> positions are open. `stop` will return 409 with open risk.
+
+The deterministic pass has already stopped this session's executors and attempted to close
+positions per the policy. Your job now:
+
+**1. Verify both legs are actually flat.** Check spot and perp separately:
+
+```
+manage_executors(action="positions_summary")
+get_portfolio_overview()
+```
+
+A clean executor status is **not** proof. Confirm against balances.
+
+**2. If exactly one leg remains, close it immediately.** This is the highest-priority item
+here — a surviving single leg is unhedged directional exposure. Do not deliberate about
+price or wait for a better level.
+
+**3. Shed leverage first.** If both legs somehow remain, close the **perp** leg first — it
+carries liquidation risk. The spot leg does not.
+
+**4. Leave dust.** Residual spot worth less than ~$5 is not worth the fees. Note it.
+
+**5. Notify the owner** via `send_notification` with:
+- realized PnL, separating **funding collected** from **price PnL on the legs**
+  (they should roughly offset — that is the strategy working)
+- confirmation that **both** legs are closed, stated explicitly
+- any leg that could not be closed, and why
+
+Be quick. The safety-critical work is eliminating unhedged exposure; tidying comes after.

--- a/agents/funding_carry_expert/strategies/spot_perp_carry/strategy.md
+++ b/agents/funding_carry_expert/strategies/spot_perp_carry/strategy.md
@@ -1,0 +1,170 @@
+---
+name: Spot Perp Carry
+description: Delta-neutral long spot / short perp funding carry on Bitget — screens for
+  holdable carry, opens matched legs, and holds continuously.
+agent_key: null
+skills:
+- funding_carry_deploy
+default_config:
+  frequency_sec: 3600
+  total_amount_quote: 200
+  execution_mode: dry_run
+  spot_connector: bitget
+  perp_connector: bitget_perpetual
+  trading_pair: ''
+  min_volume_usd: 5000000
+  min_stability_pct: 65
+  min_net_annualised_pct: 3.0
+  max_concurrent_carries: 2
+  leverage: 3
+  parity_tolerance_pct: 5
+  unwind_trailing_periods: 90
+  risk_limits:
+    max_position_size_quote: 250
+    max_open_executors: 6
+    max_drawdown_pct: 8
+    shutdown_drawdown_pct: 15
+default_trading_context: ''
+created_at: '2026-07-29T00:00:00Z'
+---
+
+# Spot Perp Carry
+
+You hold **delta-neutral funding carry**: long spot, short perpetual, matched notional, on
+one venue. The position has no directional exposure. Its entire return is the funding the
+short perp leg collects, so your job is mostly to open it well and then *leave it alone*.
+
+## Configuration at launch
+
+Read all runtime values from `[CURRENT CONFIG]`:
+
+`spot_connector` · `perp_connector` · `trading_pair` · `total_amount_quote` ·
+`min_volume_usd` · `min_stability_pct` · `min_net_annualised_pct` ·
+`max_concurrent_carries` · `leverage` · `parity_tolerance_pct` · `unwind_trailing_periods`
+
+If `trading_pair` is empty, select candidates via the screener. If it is set, operate only
+that pair.
+
+Default `frequency_sec` is 3600 — this is a **low-turnover strategy** and there is nothing
+useful to do minute by minute.
+
+## Each tick
+
+**1. Check parity first — before anything else.**
+
+```
+manage_executors(action="positions_summary")
+```
+
+For each open carry, compare spot and perp notional. If they differ by more than
+`parity_tolerance_pct`, **fixing parity is the only action this tick.** Restore the missing
+or undersized leg, or close the orphan. Then stop.
+
+A one-legged carry is a naked directional position — strictly worse than either holding or
+being flat.
+
+**2. If parity is clean and a carry is open → HOLD.**
+
+Log accrued funding and stop. Read the hold policy below before considering anything else.
+
+**3. If capacity remains (`< max_concurrent_carries`) → screen.**
+
+```
+manage_routines(action="run", name="funding_screener",
+                strategy_id="funding_carry_expert.spot_perp_carry",
+                config={"min_volume_usd": <config>, "require_spot": true,
+                        "min_stability_pct": <config>, "top_n": 10})
+```
+
+Open a new carry only if the top candidate satisfies **all** of:
+
+- `sign_stability_pct` ≥ `min_stability_pct`
+- `net_hold_annualised_pct` ≥ `min_net_annualised_pct`
+- `days_to_cover_taker_cost` well below your intended hold
+- `volume_24h_usd` ≥ `min_volume_usd`
+- a spot market exists (the screener enforces this — never disable it)
+
+Otherwise **HOLD** and journal that nothing qualified. That is a normal outcome.
+
+**4. Journal** one action entry per tick.
+
+## 🚨 Hold policy — the rule that decides whether this works
+
+**Never close a carry because funding printed negative.**
+
+| pair | buy-and-hold | closing on sign flips |
+|---|---|---|
+| BTC | **+46 bps** | **−371 bps** |
+| ETH | +79 bps | −168 bps |
+| XRP | +53 bps | −213 bps |
+
+Funding is negative 21–31% of periods and flips sign 52–93 times per 270 periods, but the
+negative prints are small. Each exit costs a full round trip (~21 bps taker) to dodge a
+fraction of a basis point.
+
+| Observation | Correct action |
+|---|---|
+| One negative funding print | **HOLD** |
+| Several negative prints in a row | **HOLD** |
+| Price moved sharply | **HOLD** — you are delta-neutral. Verify parity. |
+| Unrealised PnL on one leg looks alarming | **HOLD** — the other leg offsets it. Check parity, not PnL. |
+| Trailing mean over `unwind_trailing_periods` turned negative | Consider unwinding |
+| Delisting announced on either leg | Unwind |
+| Risk limit breached | Unwind |
+
+The urge to manage this position on individual prints is the main way it loses money.
+
+## Sizing
+
+- Both legs sized in **matched notional**, not matched quantity.
+- Per carry: `total_amount_quote / max_concurrent_carries`.
+- Total exposure across carries must stay within `max_position_size_quote`.
+- Keep `leverage` low. The perp leg must survive drawdown without liquidation — a
+  liquidated hedge converts a neutral position into a naked long at the worst moment.
+- Prefer maker fills. Taker on all four legs is ~21 bps versus ~8 bps maker; on a 3% APR
+  carry that gap is roughly two weeks of return.
+
+## Expected returns — calibrate against these
+
+| universe | realistic net |
+|---|---|
+| Majors (BTC/ETH/XRP/SOL) | **1–4% APR** |
+| Screened high-carry names with spot | **~10% APR** |
+
+If a projection materially exceeds these, you are probably annualising a snapshot rather
+than a mean. Always size and report from `funding_mean_bps`, never `funding_now_bps`.
+
+## Guardrails
+
+- **Never** open a perp leg without the matching spot leg available — no spot means no
+  hedge and no carry.
+- **Never** disable `require_spot` in the screener.
+- **Never** size from the current funding print. Use the trailing mean.
+- **Never** close on individual negative prints.
+- **Never** call `place_order` — use `manage_executors` only.
+- Pass `controller_id="{agent_id}"` as a top-level argument to `manage_executors`.
+- Open the perp leg **first** (margin rejection is the likelier failure); close the spot leg
+  **last** (shed leverage risk first).
+- Do not open a carry you do not intend to hold for weeks. Short holds lose to fees by
+  construction.
+
+## Error recovery
+
+| Tell | Meaning | Action |
+|---|---|---|
+| Perp create fails, spot filled | Naked long spot | Close spot immediately or complete the hedge — highest priority |
+| Insufficient margin | Leverage or size too high | Reduce size; do not raise leverage to force the fit |
+| Position appears on one connector only | Leg parity broken | `positions_summary`, then restore or flatten |
+| Screener returns no candidates | Filters correctly rejected everything | HOLD and journal — a normal outcome |
+
+On create failure: fetch the schema, fix fields, retry **once**, then journal a
+`category="execution"` learning. Never loop retries within a tick.
+
+## Rollout
+
+Ships as `execution_mode: dry_run`. Progress to `run_once`, then `loop`. Bitget paper
+trading is available and should be used before live capital.
+
+Note this strategy needs **weeks** to demonstrate anything — carry accrues in fractions of
+a basis point per 8h. A short live test proves the plumbing works, not that the strategy
+works.


### PR DESCRIPTION
Adds `funding_carry_expert` with the `spot_perp_carry` strategy: long spot, short perp, matched notional, on a single venue. Price moves cancel between the legs, so the entire return is the funding the short leg collects.

Ships as `dry_run`, \$200 default, 3600s ticks. Additive only — no existing behaviour touched.

## Why this strategy

Validated on 90 days of Bitget funding history (BTC/ETH/XRP/SOL/DOGE/LINK): funding is positive 69–79% of periods with P(pos|pos) of 77–88%. That persistence is what makes it a carry you hold rather than a spread you chase — and is exactly why the cross-venue *differential* version failed while this one doesn't.

Expected net: **1–4% APR on majors, ~10% on screened names.** Modest, and stated plainly in the docs rather than dressed up.

## Three findings encoded in the scaffold

### Never gate on funding sign

The intuitive move — close when funding turns negative — destroys the strategy:

| pair | buy-and-hold | closing on sign flips |
|---|---|---|
| BTC | **+46 bps** | **−371 bps** |
| ETH | +79 bps | −168 bps |
| XRP | +53 bps | −213 bps |
| LINK | +85 bps | −322 bps |

Funding flips sign 52–93 times per 270 periods, but negative prints are tiny — each exit pays ~21 bps to dodge a fraction of one. This appears in `AGENT.md`, `strategy.md`, **and** the deploy skill, because an LLM's instinct is to actively manage the position and here that instinct is the primary failure mode. The strategy's decision table answers "HOLD" to five separate alarming-looking observations.

### A spot market is a hard requirement, enforced in code

Screening all Bitget perps causally (side chosen from a trailing window, then forward funding collected):

| universe | median annualised net |
|---|---|
| All high-carry names | **−2.6%** |
| Names **with** a spot market | **+10.6%** |

Spot-listed names showed 72–100% hit rates with 1–2 side changes over ~99 days. Non-spot names showed 7–45% with 16–44 changes — funding that flips constantly and churns fees into a loss. Without a spot leg there is no hedge, so it is a naked perp rather than a carry.

`require_spot` defaults true and the docs say never to disable it. The screener also **reports rejected unstable names with their negative hold-net** — those are the highest-funding symbols on the board, so surfacing them stops the agent rediscovering them as opportunities.

### Size on the trailing mean, never a snapshot

One live XRP funding print annualised to ~7.8%; the 90-day mean was nearer 3%. The screener emits both `funding_now_bps` and `funding_mean_bps` and the strategy is instructed to size from the mean.

`shutdown.md` inverts the framework default

Uses `flatten_all` rather than `keep_spot_close_perp`. The default would close the hedge and leave a **naked long** — for a strategy whose entire safety property is neutrality, that is the worst available outcome. Both legs go together, perp first to shed liquidation risk.

Consequence documented: use `shutdown`, not plain `stop`, when positions are open, or the API returns 409.

## Known limitations

- Returns are small in absolute terms: at \$200 and 3% APR, roughly \$6/year. Worth running small to learn two-leg coordination safely, not for income.
- The ~10% figure rests on **n=4** spot-listed high-carry names in a single snapshot; the universe rotates.
- Extreme funding often signals distress (low float, delisting risk). The stability filter helps but does not eliminate it.
- 90 days of history per name; longer regimes aren't captured.
- **Do not extend this to cross-venue** — that variant was tested and failed.

