### PR TITLE
feat(agents): add Bollinger Band Trader agent

### DIFF
--- a/agents/bollinger_band_trader/AGENT.md
+++ b/agents/bollinger_band_trader/AGENT.md
@@ -2,8 +2,9 @@
 name: Bollinger Band Trader
 description: Bollinger Band specialist — squeeze/expansion cycles, band-walk vs mean-reversion
   classification, and %B-driven directional entries with band-derived stops
-agent_key: claude-acp:sonnet
+agent_key: openrouter:nvidia/nemotron-3-super-120b-a12b:free
 tools:
+- manage_routines
 - get_market_data
 - get_portfolio_overview
 - manage_executors
@@ -78,9 +79,8 @@ Run these before you answer. They are the difference between a real read and a g
 
 ### `band_state` — the primary read
 ```
-manage_trading_agent(action="run_routine", strategy_id="bollinger_band_trader",
-                     name="band_state",
-                     config={"trading_pair": "SOL-USDT", "connector_name": "binance_perpetual"})
+manage_routines(action="run", name="band_state", strategy_id="bollinger_band_trader",
+                config={"trading_pair": "SOL-USDT", "connector_name": "binance_perpetual"})
 ```
 Returns, per timeframe (15m entry / 1h context / 4h trend):
 - `pct_b` — 0.0 = at the lower band, 0.5 = middle band, 1.0 = upper band. Values outside

--- a/agents/bollinger_band_trader/AGENT.md
+++ b/agents/bollinger_band_trader/AGENT.md
@@ -1,0 +1,215 @@
+---
+name: Bollinger Band Trader
+description: Bollinger Band specialist — squeeze/expansion cycles, band-walk vs mean-reversion
+  classification, and %B-driven directional entries with band-derived stops
+agent_key: claude-acp:sonnet
+tools:
+- get_market_data
+- get_portfolio_overview
+- manage_executors
+- manage_bots
+- search_history
+- manage_memory
+- manage_skill
+when_to_consult: When the user asks about Bollinger Bands, a squeeze, band width, %B,
+  a band touch or band walk, whether price is overextended, or whether to fade or follow
+  a move at the upper/lower band — use consult. When the user wants a Bollinger setup
+  traded end-to-end on a pair, use delegate so the agent scans, sizes, and deploys the
+  position executor in the background.
+server_required: true
+created_at: '2026-07-29T00:00:00+00:00'
+---
+
+# Bollinger Band Trader
+
+You are a Bollinger Band specialist. Your domain is the **volatility band structure** of a
+market: squeeze/expansion cycles, band walks, mean reversion at the bands, and the
+%B / bandwidth readings that separate them.
+
+## What you handle
+- Reading BB(20, 2) state on a pair: where price sits in the band (%B), how wide the band
+  is (bandwidth), and whether that width is historically tight or stretched
+- Detecting a **squeeze** (bandwidth in the bottom decile of its own history, or Bollinger
+  Bands contained inside the Keltner Channel) and calling the breakout when it fires
+- Distinguishing a **band walk** (trend riding the band — do NOT fade) from a **range
+  reversion** (band touch snaps back to the middle band — fade it)
+- Deriving concrete entry / stop / target levels from the bands themselves
+- Sizing a position from the band-derived stop so risk per trade is fixed
+- Deploying and managing `position_executor` trades for the setup
+
+## What you do NOT handle
+- Market making spreads, quoting, or inventory skew → that is the **Market Making Expert**
+- Authoring or debugging routines → that is **routine_builder**
+- Portfolio-level capital allocation across strategies
+
+## Two modes
+
+**Consulted (advisory):** Answer a band question inline. Run the routines, classify, and
+recommend. Do NOT deploy anything unless explicitly asked.
+
+**Delegated (execution):** You were given a task to trade a setup autonomously. Read the
+playbook and follow it end-to-end without asking for confirmation mid-flow.
+
+```
+manage_skill(action="read", name="bollinger_playbook")
+```
+
+---
+
+## The one rule that matters
+
+**A band touch is not a signal.** The same touch of the upper band means the opposite
+thing in two different regimes:
+
+| Regime | Price tags the upper band | Correct action |
+|---|---|---|
+| Bandwidth wide and flat, ADX < 25 | Range extreme | **Fade it** — target the middle band |
+| Bandwidth expanding out of a squeeze | Breakout | **Follow it** — never short |
+| Price walking the band, ADX > 25 | Trend | **Follow or stand aside** |
+
+So the sequence is always: **classify the volatility regime first, read %B second.**
+Any recommendation that skips the classification step is wrong by construction.
+
+---
+
+## Routines
+
+Run these before you answer. They are the difference between a real read and a guess.
+
+### `band_state` — the primary read
+```
+manage_trading_agent(action="run_routine", strategy_id="bollinger_band_trader",
+                     name="band_state",
+                     config={"trading_pair": "SOL-USDT", "connector_name": "binance_perpetual"})
+```
+Returns, per timeframe (15m entry / 1h context / 4h trend):
+- `pct_b` — 0.0 = at the lower band, 0.5 = middle band, 1.0 = upper band. Values outside
+  [0, 1] mean price closed *beyond* the band.
+- `bandwidth_pct` — `(upper − lower) / middle`, as a percent. Absolute width.
+- `bw_rank` — percentile rank of the current bandwidth within its own lookback history.
+  **This is the squeeze detector.** `bw_rank ≤ 20` = compressed; `bw_rank ≥ 80` = stretched.
+- `squeeze_on` — Bollinger Bands are inside the Keltner Channel (the classic TTM squeeze).
+- `verdict` — `squeeze | expansion_up | expansion_down | band_walk_up | band_walk_down |
+  reversion_range | neutral`
+
+And a combined `setup` with `bias`, `entry`, `stop`, `target`, `rr`.
+
+### `squeeze_screener` — where a setup is brewing
+Ranks a list of pairs by `bw_rank` ascending, so the tightest compressions come first.
+Use it when the user asks "what's setting up?" rather than about one pair.
+
+### `band_trade_sizer` — before any deploy
+Converts a band-derived stop into a base-currency `amount` for a `position_executor`,
+enforcing fixed risk per trade, a max position cap, and a portfolio reserve. It also
+checks the exchange minimum notional. **Never deploy without running it** — an unsized
+trade is how a good setup becomes a bad loss.
+
+---
+
+## Domain knowledge
+
+### Reading the bands
+
+**Middle band** = SMA(20). It is the mean the market reverts to, and it is also the
+trailing stop in a trending move. Almost every target and stop below is expressed
+relative to it.
+
+**Bandwidth** = `(upper − lower) / middle`. Absolute bandwidth is meaningless across
+assets — BTC at 1.2% and a small-cap at 1.2% are entirely different states. Always read
+`bw_rank` (the percentile within the pair's own history) instead.
+
+**%B** = `(price − lower) / (upper − lower)`. The normalized position in the band.
+- `%B > 1.0` — closed above the upper band. In a squeeze breakout this is confirmation;
+  in a flat range it is exhaustion.
+- `%B ≈ 0.5` — at the mean. No edge either way.
+- `%B < 0.0` — closed below the lower band. Same two readings, mirrored.
+
+### The four setups
+
+**1. Squeeze breakout** — `bw_rank ≤ 20` or `squeeze_on = true`, then bandwidth expands
+and price closes outside the band with volume above average.
+- Bands are coiled; the direction is unknown until the break. **Do not pre-position.**
+- Entry on the close beyond the band, in the break direction.
+- Stop at the **middle band** — a squeeze breakout that gives back the mean has failed.
+- First target = `entry + 2 × (entry − stop)`. Trail the middle band after that.
+- The tighter the squeeze (`bw_rank ≤ 10`), the more violent the expansion. Size normally
+  anyway; the stop distance already accounts for it.
+
+**2. Band walk (continuation)** — 3+ of the last 6 closes in the same extreme decile of
+the band (`%B ≥ 0.90` for an up-walk, `≤ 0.10` for a down-walk) with ADX above 25.
+- This is the setup that destroys mean-reversion traders. **Never fade a band walk.**
+- Enter on a pullback to the middle band that holds, in the direction of the walk.
+- Stop below the middle band (for an up-walk). The walk is over when price closes on the
+  other side of the mean.
+- Exit when %B crosses back through 0.5, or on the first close beyond the *opposite* band.
+
+**3. Range reversion** — `bw_rank ≥ 40`, bandwidth flat or contracting, ADX < 25, and
+price tags a band.
+- Fade the touch. Entry at the band, stop 0.5 × ATR beyond it, target the middle band.
+- R:R is naturally around 1.5–2.0 because the middle band is half a bandwidth away.
+- **Veto:** if the higher timeframe is in a band walk or an expansion in the opposite
+  direction, skip it. Fading a trend at a band is the single most expensive mistake in
+  this strategy.
+
+**4. Failed breakout (the W/M reversal)** — price closes outside the band, then closes
+back inside within 1–2 candles.
+- This is a high-quality reversal signal: the break had no follow-through.
+- Enter opposite the failed break, stop beyond the failure extreme, target the middle
+  band and then the opposite band.
+- Confirmed by the second low/high having a *higher* %B on a lower price (bullish W) or a
+  *lower* %B on a higher price (bearish M) — a band-relative divergence.
+
+### Confirmation and veto rules
+- **Volume:** a breakout with volume below its 20-period average is suspect. Downgrade it
+  to `no_trade` and wait for the retest.
+- **ADX:** the routine reports Wilder's smoothed ADX, and **25 is the dividing line** —
+  below it reversion is allowed, above it only continuation. Readings within a few points
+  of 25 are noise; require the higher timeframe to agree, or stand aside.
+- **Higher timeframe alignment:** never take a reversion trade against a 4h band walk, and
+  never take a breakout against a 4h expansion in the opposite direction.
+- **Funding (perps):** on a long band walk with funding above 0.01% per 8h, the carry cost
+  is real. Shorten the hold or tighten the target.
+
+### Risk defaults
+- Fixed risk per trade: **0.5% of portfolio**, never above 1%.
+- Max single position: **10% of portfolio** notional.
+- Portfolio reserve: keep **20%** of quote balance unallocated at all times.
+- Minimum R:R: **1.5** for breakouts, **1.2** for reversions. Below that, no trade.
+- Max concurrent BB positions: **3**, and never two on correlated majors in the same
+  direction.
+- Leverage: 1–3x default, 5x maximum, and only on a confirmed squeeze breakout.
+
+### Parameter reference
+`BB(20, 2)` is the default and should stay the default. Only deviate when you can say why:
+
+| Setting | When to use |
+|---|---|
+| `period=20, std=2.0` | Default. ~89% of closes inside the band. |
+| `period=20, std=2.5` | Very noisy pairs where 2.0 gives constant false touches. |
+| `period=50, std=2.1` | Higher-timeframe positional reads; smoother, fewer signals. |
+| `period=10, std=1.9` | Fast scalping on 1m/5m. Expect many more false breaks. |
+
+Changing the period changes what "the mean" means. Do not mix periods across timeframes
+in a single analysis and then compare the %B readings — they are not the same scale.
+
+---
+
+## Memory & skills
+Check `manage_memory` and `manage_skill` before answering — you may have already learned
+which pairs whipsaw on band touches or which squeeze thresholds work on this operator's
+markets. Update them when a setup resolves, so the next read is sharper.
+
+## Response format
+Always key: value lines, not prose. Lead with the recommendation.
+
+```
+setup: squeeze_breakout
+bias: long
+regime: expansion_up (bw_rank 8 → 34 over 3 candles)
+entry: 148.20
+stop: 145.10 (middle band)
+target: 154.40
+rr: 2.0
+confidence: high
+reason: 1h squeeze at bw_rank 8 fired with 1.9x average volume; 4h in expansion_up, no conflict.
+```

--- a/agents/bollinger_band_trader/AGENT.md
+++ b/agents/bollinger_band_trader/AGENT.md
@@ -5,6 +5,11 @@ description: Bollinger Band specialist — squeeze/expansion cycles, band-walk v
 agent_key: openrouter:nvidia/nemotron-3-super-120b-a12b:free
 tools:
 - manage_routines
+# The loop runtime instructs every tick to journal via trading_agent_journal_write.
+# Omitting these strips them from the toolset, so the tick calls a tool that does not
+# exist, burns its whole retry budget, and reports an error after doing all its work.
+- trading_agent_journal_write
+- trading_agent_journal_read
 - get_market_data
 - get_portfolio_overview
 - manage_executors

--- a/agents/bollinger_band_trader/HOW_IT_WORKS.md
+++ b/agents/bollinger_band_trader/HOW_IT_WORKS.md
@@ -1,0 +1,209 @@
+# How the Bollinger Band Trader works
+
+A walkthrough of the data, the math, and the decision path — enough to audit the agent
+without reading the code.
+
+## The problem this agent solves
+
+Bollinger Bands are the most widely misused indicator in retail trading, and the failure
+mode is always the same: **treating a band touch as a signal.** "Price hit the upper band,
+sell it" works in a range and is ruinous in a trend, and the touch itself is identical in
+both cases. Most losses from this indicator come from fading a band walk.
+
+So the agent is built around a two-stage decision instead of a one-stage one:
+
+```
+1. What volatility regime is this?   →  squeeze / expansion / band walk / range
+2. Given the regime, what does %B mean?  →  follow it, fade it, or stand aside
+```
+
+Every routine, veto, and exit rule below serves that ordering.
+
+## Components
+
+```
+agents/bollinger_band_trader/
+  AGENT.md                                  # identity, domain knowledge, response format
+  HOW_IT_WORKS.md                           # this file
+  validation.md                             # what was verified and how
+  routines/
+    band_state.py                           # primary read: classify + derive levels
+    squeeze_screener.py                     # rank a watchlist by squeeze tightness
+    band_trade_sizer.py                     # risk sizing + pre-trade guardrails
+  skills/bollinger_playbook/SKILL.md        # the act-on-it procedure
+  strategies/bb_squeeze_breakout/strategy.md # optional loop: tick playbook
+```
+
+The agent is useful at every layer. Consulted with no loop running, it answers band
+questions using the routines. Given a strategy, it can run the same logic unattended.
+
+## Data sources
+
+Everything comes from the Hummingbot API through the standard routine client — no
+external feeds, no API keys beyond the exchange connection already configured.
+
+| Call | Used for |
+|---|---|
+| `market_data.get_candles(connector, pair, interval, max_records)` | Bands, %B, bandwidth history, ATR, ADX, volume |
+| `market_data.get_prices(connector, [pair])` | Live entry price in the sizer |
+| `portfolio.get_total_value()` | Risk budget and the reserve check |
+
+`band_state` requests 300 candles on each of 15m / 1h / 4h. The depth matters: the
+bandwidth percentile rank is only meaningful against a long history of that same pair's
+bandwidth, and 300 candles gives roughly three days of 15m context and fifty days of 4h.
+
+## The math
+
+All indicators are computed in plain Python inside the routines — no pandas, no TA
+library, so the definitions are auditable in place.
+
+**Middle band** — `SMA(close, period)`, default period 20.
+
+**Standard deviation** — population (divide by `n`, not `n − 1`), matching the standard
+Bollinger definition. Using the sample deviation would widen the bands slightly and shift
+every %B reading.
+
+**Upper / lower band** — `mid ± std_mult × σ`, default multiplier 2.0.
+
+**%B** — `(close − lower) / (upper − lower)`. Normalized position in the band: 0 = lower,
+0.5 = middle, 1.0 = upper. Deliberately **not** clamped — values outside [0, 1] are the
+signal that price closed beyond the band.
+
+**Bandwidth** — `(upper − lower) / mid × 100`. Absolute width as a percentage of the mean.
+
+**Bandwidth rank (`bw_rank`)** — the percentile of the current bandwidth within the
+previous 200 bandwidth readings for the same pair and timeframe, with ties counted at
+half weight. **This is the squeeze detector, and it is the reason the agent works across
+assets.** Raw bandwidth of 1.2% is a tight coil on a major and a dead-flat range on a
+small-cap; the percentile normalizes that away.
+
+**Keltner containment (TTM squeeze)** — Keltner Channel is `EMA(close, 20) ± 1.5 × ATR(20)`
+where ATR is a simple rolling mean of true range. `squeeze_on` is true when the Bollinger
+Bands sit entirely inside the Keltner Channel. This is a second, independent squeeze test:
+`bw_rank` is relative to the pair's own history, Keltner containment is relative to
+current range. Either one firing marks a squeeze.
+
+**ADX** — Wilder's ADX: true range and directional movement are Wilder-smoothed over 14
+periods, DX is computed from the resulting ±DI, and DX itself is smoothed again over 14.
+**The second smoothing is load-bearing.** A raw single-window DX — which is what the
+first draft of this routine used, and what the repo's `market_analyzer` still uses —
+saturates near 100 on any sustained directional push. Since price reaching a Bollinger
+band *is* a directional push, raw DX made every band tag read as a trend and left
+`reversion_range` unreachable in practice. That is measured, not assumed: over 600
+synthetic ranges, no band tag ever produced a reversion verdict before the fix, and the
+regression is pinned by `test_adx_does_not_pin_at_100_in_a_range`.
+
+## Classification
+
+Per timeframe, in this order (first match wins):
+
+| Verdict | Condition |
+|---|---|
+| `expansion_up` | bandwidth grew > 15% over 3 candles **and** `%B > 1.0` |
+| `expansion_down` | bandwidth grew > 15% over 3 candles **and** `%B < 0.0` |
+| `squeeze` | `squeeze_on` **or** `bw_rank ≤ 20` |
+| `band_walk_up` | ≥ 3 of the last 6 closes at `%B ≥ 0.90` **and** ADX > 25 |
+| `band_walk_down` | ≥ 3 of the last 6 closes at `%B ≤ 0.10` **and** ADX > 25 |
+| `reversion_range` | `bw_rank ≥ 40`, bandwidth **not** expanding, **and** ADX < 25 |
+| `neutral` | none of the above |
+
+**Expansion is tested before the squeeze, and the order is not cosmetic.** Bandwidth rank
+is computed from history, so on the very candle a coil breaks, the rank is still low — a
+squeeze-first ordering reports `squeeze_pending` on exactly the bar the setup exists to
+trade. `test_firing_coil_reads_as_expansion_not_squeeze` pins this.
+
+ADX splits the remaining space cleanly at 25: above it only continuation setups are
+reachable, below it only reversion.
+
+A **failed breakout** is tracked separately: the last close is back inside the band while
+one of the two closes before it was outside. It is checked before everything else because
+it is the highest-quality signal in the set — a break with no follow-through.
+
+## From classification to levels
+
+`band_state` combines the entry timeframe (15m) with the trend timeframe (4h) and emits
+one setup with concrete prices:
+
+| Setup | Entry | Stop | Target |
+|---|---|---|---|
+| `squeeze_pending` | — (reports both triggers) | — | — |
+| `squeeze_breakout_long` | current price | middle band | `entry + 2 × (entry − stop)` |
+| `squeeze_breakout_short` | current price | middle band | `entry − 2 × (stop − entry)` |
+| `band_walk_long` | middle band (pullback) | `mid − 1 ATR` | upper band |
+| `band_walk_short` | middle band (pullback) | `mid + 1 ATR` | lower band |
+| `reversion_long` | lower band | `lower − 0.5 ATR` | middle band |
+| `reversion_short` | upper band | `upper + 0.5 ATR` | middle band |
+| `failed_breakout_long` | current price | 3-candle low − 0.25 ATR | halfway above the mean |
+| `failed_breakout_short` | current price | 3-candle high + 0.25 ATR | halfway below the mean |
+
+Then three gates can still turn any of them into `no_trade`:
+
+1. **Higher-timeframe veto** — a reversion against a 4h band walk or expansion is
+   rejected outright. This is the single most valuable rule in the agent.
+2. **Reward:risk floor** — 1.5 for continuation setups, 1.2 for reversions.
+3. **Volume filter** — a squeeze breakout on below-average volume is rejected with
+   "wait for the retest".
+
+## Sizing
+
+`band_trade_sizer` is the only path to a position size. Fixed fractional risk:
+
+```
+risk_quote     = portfolio × risk_pct / 100          (default 0.5%)
+stop_pct       = |entry − stop| / entry
+raw_notional   = risk_quote / stop_pct
+notional       = min(raw_notional,
+                     portfolio × max_position_pct/100,      (default 10%)
+                     portfolio × (1 − reserve_pct/100))     (default 20% reserved)
+amount_base    = notional / entry
+```
+
+The stop distance drives the size, so a wide-stop setup automatically gets a smaller
+position and every trade risks the same amount. Seven guardrails run afterwards
+(portfolio known, stop on the protective side, stop distance between 0.05% and 20%, risk
+within policy, leverage ≤ 5, notional above the exchange minimum, margin inside the
+reserve). Any `FAIL` blocks the trade and no payload is emitted.
+
+When the size is capped by the position limit or the reserve, the routine reports it as a
+`WARN` — the trade is still valid, it just risks less than the target.
+
+## Tick flow (loop mode)
+
+```
+band_state ──► setup == no_trade / squeeze_pending ──► HOLD, journal
+           └─► tradeable setup
+                  ├─ position already open on this pair? ──► manage / close only
+                  └─ band_trade_sizer ──► FAIL ──► HOLD, journal blocked_by
+                                      └─► PASS ──► manage_executors(create, position_executor)
+```
+
+Default frequency is 900s to match the 15m entry candle. Running faster re-reads the same
+candle and produces duplicate signals rather than new information.
+
+## Cost
+
+The routines are pure Python over candle data — no LLM tokens, no paid data. Only the
+agent's reasoning costs anything. At the default 15m tick with a compact model, a loop
+session runs at a few cents a day; most ticks resolve to HOLD after a single routine call,
+which is the cheapest possible path.
+
+## Known limitations
+
+- **`bw_rank` needs history.** A pair with fewer than ~50 candles gives an unreliable
+  percentile. Both routines skip pairs that are too thin rather than guessing.
+- **ADX differs from `market_analyzer`.** This agent smooths; the Market Making Expert's
+  routine does not. The two will report different ADX values for the same market, and
+  this one is the textbook figure. Do not compare them directly.
+- **Reversion is the rarest verdict.** Over 400 synthetic ranges it fires on roughly 29%
+  of readings, and the subset that also tags a band — the tradeable case — is a few
+  percent. That is intended: fading is the setup with the worst failure mode, so the gates
+  are the tightest. It does mean a live agent will spend most of its time on breakouts.
+- **Squeeze direction is unknowable.** The agent deliberately refuses to pre-position
+  during a squeeze. Some of the move is always given up waiting for the break to confirm.
+- **No cross-pair correlation model.** The 3-position cap and the "no two same-direction
+  majors" rule are crude proxies. Three correlated longs are three copies of one trade.
+- **Whipsaws around the threshold.** A pair oscillating at `bw_rank ≈ 20` will flip
+  between `squeeze` and `reversion_range` on consecutive ticks. The strategy's one-position
+  -per-pair rule absorbs this, but the readings will look inconsistent.
+- **Fees are not in the R:R.** A 1.2 R:R reversion on a spot pair with 0.075% maker fees
+  is thinner than it looks. On spot, prefer the 1.5 floor.

--- a/agents/bollinger_band_trader/HOW_IT_WORKS.md
+++ b/agents/bollinger_band_trader/HOW_IT_WORKS.md
@@ -183,9 +183,32 @@ candle and produces duplicate signals rather than new information.
 ## Cost
 
 The routines are pure Python over candle data — no LLM tokens, no paid data. Only the
-agent's reasoning costs anything. At the default 15m tick with a compact model, a loop
-session runs at a few cents a day; most ticks resolve to HOLD after a single routine call,
-which is the cheapest possible path.
+agent's reasoning costs anything, and **that cost is much larger than it looks.**
+
+Measured on a real 19-tick session:
+
+| | |
+|---|---|
+| System prompt | ~5,600 tokens |
+| Tool schemas (25 tools, 2 MCP servers) | ~15,000 tokens |
+| Base, **resent on every model call** | ~20,600 tokens |
+| Round-trips per tick | 1–10 (a tick is an agentic loop, not one call) |
+| **Measured input per tick** | **~101,000 tokens** (range 20.8k–214.8k) |
+| Signal the model reasons over | **110 tokens** — the `band_state` output |
+
+So ~99.9% of what you pay for is overhead. On a Sonnet-class model that is ~$0.43/tick,
+or ~$41/day at a 15m cadence. On the free model this agent now defaults to it is $0.00.
+
+Two consequences worth internalising:
+
+- **Pick the model deliberately.** "Cheap Anthropic" is not cheap here: at ~101k
+  tokens/tick, Haiku-class runs ~$20/day. A free or sub-cent model is the sane default
+  for a loop whose ticks are overwhelmingly HOLD.
+- **The LLM is not doing the analysis.** `band_state` already emits `setup`, `bias`,
+  `entry`, `stop`, `target`, `rr` and the veto outcome; `band_trade_sizer` emits PASS/FAIL
+  and a ready payload. On a HOLD tick the model reads `no_trade` and writes a paragraph
+  meaning `no_trade`. Gating the model behind a verdict-changed check, or removing it from
+  the hot path entirely, removes most of the cost without changing behaviour.
 
 ## Known limitations
 

--- a/agents/bollinger_band_trader/routines/band_state.py
+++ b/agents/bollinger_band_trader/routines/band_state.py
@@ -13,7 +13,7 @@ is built to tell those two apart before any level is quoted.
 
 import logging
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from telegram.ext import ContextTypes
 
 from condor.reports.footprint import candle_timestamps
@@ -49,6 +49,11 @@ _CONTINUATION_SETUPS = {
 
 class Config(BaseModel):
     """Classify Bollinger Band state and derive entry/stop/target for one pair."""
+
+    # Reject unknown keys. Without this, a model passing `symbol` instead of
+    # `trading_pair` would silently fall back to the default pair/connector and
+    # return a confident answer about the wrong market.
+    model_config = ConfigDict(extra="forbid")
 
     trading_pair: str = Field(default="BTC-USDT", description="Trading pair to analyze")
     connector_name: str = Field(

--- a/agents/bollinger_band_trader/routines/band_state.py
+++ b/agents/bollinger_band_trader/routines/band_state.py
@@ -1,0 +1,742 @@
+"""Bollinger Band state across timeframes: squeeze, expansion, band walk, or reversion.
+
+The primary read for the Bollinger Band Trader. For each of three timeframes it
+computes BB(period, std), %B, bandwidth, the percentile rank of that bandwidth within
+its own history (the squeeze detector), and a Keltner-containment check (the classic
+TTM squeeze). It then classifies each timeframe and combines them into ONE setup with
+concrete entry / stop / target levels derived from the bands themselves.
+
+The classification exists because a band touch is ambiguous on its own: tagging the
+upper band is a fade in a flat range and a buy signal out of a squeeze. Everything here
+is built to tell those two apart before any level is quoted.
+"""
+
+import logging
+
+from pydantic import BaseModel, Field
+from telegram.ext import ContextTypes
+
+from condor.reports.footprint import candle_timestamps
+from config_manager import get_client
+
+logger = logging.getLogger(__name__)
+
+CATEGORY = "Analysis"
+
+# (label, interval, candles to request) — entry / context / trend
+_TIMEFRAMES = [
+    ("entry_15m", "15m", 300),
+    ("context_1h", "1h", 300),
+    ("trend_4h", "4h", 300),
+]
+
+_KELTNER_MULT = 1.5
+_EXPANSION_LOOKBACK = 3  # candles back used to detect bandwidth expansion
+_EXPANSION_FACTOR = 1.15  # bandwidth must grow this much to count as expanding
+_RANK_LOOKBACK = 200  # bandwidth history depth for the percentile rank
+_TREND_ADX = 25.0  # above this the market trends (walk); below it reverts
+_WALK_PCT_B = 0.90  # a close in the top/bottom decile of the band counts toward a walk
+
+_CONTINUATION_SETUPS = {
+    "squeeze_breakout_long",
+    "squeeze_breakout_short",
+    "band_walk_long",
+    "band_walk_short",
+    "failed_breakout_long",
+    "failed_breakout_short",
+}
+
+
+class Config(BaseModel):
+    """Classify Bollinger Band state and derive entry/stop/target for one pair."""
+
+    trading_pair: str = Field(default="BTC-USDT", description="Trading pair to analyze")
+    connector_name: str = Field(
+        default="binance_perpetual", description="Exchange connector"
+    )
+    bb_period: int = Field(default=20, description="Bollinger moving-average period")
+    bb_std: float = Field(
+        default=2.0, description="Bollinger standard-deviation multiplier"
+    )
+    squeeze_rank: float = Field(
+        default=20.0, description="bw_rank at or below which the band is squeezed"
+    )
+    walk_window: int = Field(default=6, description="Candles inspected for a band walk")
+    walk_min_closes: int = Field(
+        default=3, description="Closes outside the band needed to call a walk"
+    )
+    min_rr_continuation: float = Field(
+        default=1.5, description="Minimum reward:risk for breakout / walk setups"
+    )
+    min_rr_reversion: float = Field(
+        default=1.2, description="Minimum reward:risk for reversion setups"
+    )
+
+
+# ── Series helpers ───────────────────────────────────────────────────────────
+
+
+def _sma_series(values: list, period: int) -> list:
+    if period <= 0:
+        return [None] * len(values)
+    out, running = [], 0.0
+    for i, v in enumerate(values):
+        running += v
+        if i >= period:
+            running -= values[i - period]
+        out.append(running / period if i >= period - 1 else None)
+    return out
+
+
+def _ema_series(values: list, period: int) -> list:
+    if len(values) < period or period <= 0:
+        return [None] * len(values)
+    mult = 2 / (period + 1)
+    ema = sum(values[:period]) / period
+    out = [None] * (period - 1) + [ema]
+    for v in values[period:]:
+        ema = (v - ema) * mult + ema
+        out.append(ema)
+    return out
+
+
+def _stdev(window: list) -> float:
+    n = len(window)
+    if n < 2:
+        return 0.0
+    mean = sum(window) / n
+    return (sum((x - mean) ** 2 for x in window) / n) ** 0.5
+
+
+def _bollinger_series(closes: list, period: int, k: float) -> list:
+    """Per-index {mid, upper, lower, bandwidth_pct, pct_b}, None until the window fills."""
+    mids = _sma_series(closes, period)
+    out = []
+    for i, mid in enumerate(mids):
+        if mid is None or mid <= 0:
+            out.append(None)
+            continue
+        std = _stdev(closes[i - period + 1 : i + 1])
+        upper, lower = mid + k * std, mid - k * std
+        width = upper - lower
+        out.append(
+            {
+                "mid": mid,
+                "upper": upper,
+                "lower": lower,
+                "bandwidth_pct": width / mid * 100,
+                "pct_b": (closes[i] - lower) / width if width > 0 else 0.5,
+            }
+        )
+    return out
+
+
+def _true_range_series(candles: list) -> list:
+    trs = []
+    for i, c in enumerate(candles):
+        high, low = float(c.get("high", 0)), float(c.get("low", 0))
+        if i == 0:
+            trs.append(high - low)
+            continue
+        prev_close = float(candles[i - 1].get("close", 0))
+        trs.append(max(high - low, abs(high - prev_close), abs(low - prev_close)))
+    return trs
+
+
+def _keltner_series(closes: list, atrs: list, period: int, mult: float) -> list:
+    emas = _ema_series(closes, period)
+    out = []
+    for ema, atr in zip(emas, atrs):
+        if ema is None or atr is None:
+            out.append(None)
+        else:
+            out.append({"upper": ema + mult * atr, "lower": ema - mult * atr})
+    return out
+
+
+def _percentile_rank(history: list, value: float) -> float:
+    """Where `value` sits inside `history`, 0–100. 0 = tightest ever seen."""
+    if not history:
+        return 50.0
+    below = sum(1 for h in history if h < value)
+    ties = sum(1 for h in history if h == value)
+    return (below + 0.5 * ties) / len(history) * 100
+
+
+def _calc_adx(candles: list, period: int = 14) -> float:
+    """Wilder's ADX — the DX smoothed over `period`, not the raw single-window DX.
+
+    The smoothing is what makes the textbook 20 / 25 thresholds mean anything. Raw DX
+    pins near 100 on any sustained directional push, and price reaching a Bollinger band
+    is *always* a directional push — so with raw DX the `reversion_range` verdict is
+    unreachable in practice and every band tag reads as a trend.
+    """
+    if len(candles) < period * 2 + 1:
+        return 0.0
+
+    plus_dms, minus_dms, trs = [], [], []
+    for i in range(1, len(candles)):
+        high, low = float(candles[i].get("high", 0)), float(candles[i].get("low", 0))
+        prev_high = float(candles[i - 1].get("high", 0))
+        prev_low = float(candles[i - 1].get("low", 0))
+        prev_close = float(candles[i - 1].get("close", 0))
+        up_move, down_move = high - prev_high, prev_low - low
+        plus_dms.append(up_move if up_move > down_move and up_move > 0 else 0.0)
+        minus_dms.append(down_move if down_move > up_move and down_move > 0 else 0.0)
+        trs.append(max(high - low, abs(high - prev_close), abs(low - prev_close)))
+
+    if len(trs) < period * 2:
+        return 0.0
+
+    # Wilder smoothing: seed with the first `period` sum, then decay one period's worth.
+    smooth_tr = sum(trs[:period])
+    smooth_plus = sum(plus_dms[:period])
+    smooth_minus = sum(minus_dms[:period])
+
+    dxs = []
+    for i in range(period, len(trs)):
+        smooth_tr = smooth_tr - smooth_tr / period + trs[i]
+        smooth_plus = smooth_plus - smooth_plus / period + plus_dms[i]
+        smooth_minus = smooth_minus - smooth_minus / period + minus_dms[i]
+        if smooth_tr <= 0:
+            continue
+        plus_di = smooth_plus / smooth_tr * 100
+        minus_di = smooth_minus / smooth_tr * 100
+        di_sum = plus_di + minus_di
+        dxs.append(abs(plus_di - minus_di) / di_sum * 100 if di_sum else 0.0)
+
+    if len(dxs) < period:
+        return sum(dxs) / len(dxs) if dxs else 0.0
+
+    adx = sum(dxs[:period]) / period
+    for dx in dxs[period:]:
+        adx = (adx * (period - 1) + dx) / period
+    return adx
+
+
+def _fmt(value) -> str:
+    """Price formatting that survives both BTC and 8-decimal micro-caps."""
+    if value is None:
+        return "n/a"
+    av = abs(value)
+    if av >= 1000:
+        return f"{value:,.2f}"
+    if av >= 1:
+        return f"{value:,.4f}"
+    if av >= 0.01:
+        return f"{value:.6f}"
+    return f"{value:.8f}"
+
+
+# ── Classification ───────────────────────────────────────────────────────────
+
+
+def _band_walk(bbs: list, window: int, min_closes: int) -> tuple:
+    """Closes clustered in the top/bottom decile of the band — the trend-riding tell."""
+    recent = [b for b in bbs[-window:] if b]
+    up = sum(1 for b in recent if b["pct_b"] >= _WALK_PCT_B)
+    down = sum(1 for b in recent if b["pct_b"] <= 1 - _WALK_PCT_B)
+    return up >= min_closes, down >= min_closes
+
+
+def _failed_breakout(bbs: list) -> str:
+    """Closed back inside the band after breaking out — the W/M reversal tell."""
+    recent = [b for b in bbs[-3:] if b]
+    if len(recent) < 3:
+        return ""
+    if not 0.0 <= recent[-1]["pct_b"] <= 1.0:
+        return ""
+    if any(b["pct_b"] > 1.0 for b in recent[:-1]):
+        return "bearish"
+    if any(b["pct_b"] < 0.0 for b in recent[:-1]):
+        return "bullish"
+    return ""
+
+
+def _verdict(
+    bb,
+    bb_prev,
+    bw_rank: float,
+    squeeze_on: bool,
+    walk_up: bool,
+    walk_down: bool,
+    adx: float,
+    squeeze_rank: float,
+) -> str:
+    expanding = (
+        bool(bb_prev)
+        and bb["bandwidth_pct"] > bb_prev["bandwidth_pct"] * _EXPANSION_FACTOR
+    )
+
+    # Expansion is checked BEFORE the squeeze: a coil that is firing right now is no
+    # longer a coil, and its bandwidth rank is still low on the candle that breaks.
+    # Ordering this the other way round reports `squeeze_pending` on the exact bar the
+    # trade should be taken.
+    if expanding and bb["pct_b"] > 1.0:
+        return "expansion_up"
+    if expanding and bb["pct_b"] < 0.0:
+        return "expansion_down"
+    if squeeze_on or bw_rank <= squeeze_rank:
+        return "squeeze"
+    if walk_up and adx > _TREND_ADX:
+        return "band_walk_up"
+    if walk_down and adx > _TREND_ADX:
+        return "band_walk_down"
+    # Reversion needs a wide band that is NOT growing, in a non-trending market.
+    if bw_rank >= 40 and not expanding and adx < _TREND_ADX:
+        return "reversion_range"
+    return "neutral"
+
+
+def _analyze_timeframe(candles: list, label: str, cfg: Config) -> dict:
+    """Full band read for one timeframe. Returns {'error': ...} when data is too thin."""
+    if not candles or len(candles) < cfg.bb_period + _EXPANSION_LOOKBACK + 1:
+        return {"timeframe": label, "error": "insufficient candles"}
+
+    closes = [float(c.get("close", 0)) for c in candles]
+    volumes = [float(c.get("volume", 0)) for c in candles]
+
+    bbs = _bollinger_series(closes, cfg.bb_period, cfg.bb_std)
+    bb = bbs[-1]
+    if bb is None:
+        return {"timeframe": label, "error": "band not formed"}
+    bb_prev = bbs[-1 - _EXPANSION_LOOKBACK] if len(bbs) > _EXPANSION_LOOKBACK else None
+
+    history = [b["bandwidth_pct"] for b in bbs[:-1] if b][-_RANK_LOOKBACK:]
+    bw_rank = _percentile_rank(history, bb["bandwidth_pct"])
+
+    atrs = _sma_series(_true_range_series(candles), cfg.bb_period)
+    kcs = _keltner_series(closes, atrs, cfg.bb_period, _KELTNER_MULT)
+    kc = kcs[-1]
+    squeeze_on = bool(kc) and bb["upper"] < kc["upper"] and bb["lower"] > kc["lower"]
+
+    walk_up, walk_down = _band_walk(bbs, cfg.walk_window, cfg.walk_min_closes)
+    adx = _calc_adx(candles)
+
+    avg_vol = sum(volumes[-cfg.bb_period :]) / cfg.bb_period if volumes else 0.0
+    vol_ratio = volumes[-1] / avg_vol if avg_vol > 0 else 1.0
+
+    window = candles[-3:]
+    return {
+        "timeframe": label,
+        "verdict": _verdict(
+            bb, bb_prev, bw_rank, squeeze_on, walk_up, walk_down, adx, cfg.squeeze_rank
+        ),
+        "price": closes[-1],
+        "upper": bb["upper"],
+        "mid": bb["mid"],
+        "lower": bb["lower"],
+        "pct_b": bb["pct_b"],
+        "bandwidth_pct": bb["bandwidth_pct"],
+        "bw_rank": bw_rank,
+        "squeeze_on": squeeze_on,
+        "walk_up": walk_up,
+        "walk_down": walk_down,
+        "failed_breakout": _failed_breakout(bbs),
+        "adx": adx,
+        "vol_ratio": vol_ratio,
+        "atr": atrs[-1] or 0.0,
+        "recent_low": min(float(c.get("low", 0)) for c in window),
+        "recent_high": max(float(c.get("high", 0)) for c in window),
+        "bb_series": bbs,
+        "candles": candles,
+    }
+
+
+# ── Setup derivation ─────────────────────────────────────────────────────────
+
+
+def _no_trade(reason: str) -> dict:
+    return {"setup": "no_trade", "bias": "none", "reason": reason}
+
+
+def _derive_setup(entry: dict, trend: dict, cfg: Config) -> dict:
+    """Combine the entry timeframe verdict with the trend timeframe veto into one setup."""
+    if "error" in entry:
+        return _no_trade(f"entry timeframe unavailable: {entry['error']}")
+
+    verdict = entry["verdict"]
+    trend_verdict = trend.get("verdict", "neutral")
+    price, mid, upper, lower = (
+        entry["price"],
+        entry["mid"],
+        entry["upper"],
+        entry["lower"],
+    )
+    atr = entry["atr"] or (upper - lower) / 4
+
+    # 1. Failed breakout — highest-quality signal, it overrides the rest.
+    if entry["failed_breakout"] == "bullish" and trend_verdict != "band_walk_down":
+        setup = {
+            "setup": "failed_breakout_long",
+            "bias": "long",
+            "entry": price,
+            "stop": entry["recent_low"] - 0.25 * atr,
+            "target": mid + (mid - lower) * 0.5,
+            "reason": "closed back inside the band after breaking below it — no follow-through on the break",
+        }
+    elif entry["failed_breakout"] == "bearish" and trend_verdict != "band_walk_up":
+        setup = {
+            "setup": "failed_breakout_short",
+            "bias": "short",
+            "entry": price,
+            "stop": entry["recent_high"] + 0.25 * atr,
+            "target": mid - (upper - mid) * 0.5,
+            "reason": "closed back inside the band after breaking above it — no follow-through on the break",
+        }
+
+    # 2. Squeeze — coiled, direction unknown. Report the triggers, do not pre-position.
+    elif verdict == "squeeze":
+        return {
+            "setup": "squeeze_pending",
+            "bias": "none",
+            "long_trigger": upper,
+            "short_trigger": lower,
+            "invalidation": mid,
+            "reason": f"bandwidth at rank {entry['bw_rank']:.0f} (squeeze_on={entry['squeeze_on']}) — wait for a close outside the band",
+        }
+
+    # 3. Squeeze fired — expansion with price outside the band.
+    elif verdict == "expansion_up" and trend_verdict not in (
+        "expansion_down",
+        "band_walk_down",
+    ):
+        stop = mid
+        setup = {
+            "setup": "squeeze_breakout_long",
+            "bias": "long",
+            "entry": price,
+            "stop": stop,
+            "target": price + 2 * (price - stop),
+            "reason": "bandwidth expanding with a close above the upper band",
+        }
+    elif verdict == "expansion_down" and trend_verdict not in (
+        "expansion_up",
+        "band_walk_up",
+    ):
+        stop = mid
+        setup = {
+            "setup": "squeeze_breakout_short",
+            "bias": "short",
+            "entry": price,
+            "stop": stop,
+            "target": price - 2 * (stop - price),
+            "reason": "bandwidth expanding with a close below the lower band",
+        }
+
+    # 4. Band walk — enter on the pullback to the mean, never fade it.
+    elif verdict == "band_walk_up":
+        setup = {
+            "setup": "band_walk_long",
+            "bias": "long",
+            "entry": mid,
+            "stop": mid - 1.0 * atr,
+            "target": upper,
+            "reason": "price walking the upper band — buy the pullback to the middle band",
+        }
+    elif verdict == "band_walk_down":
+        setup = {
+            "setup": "band_walk_short",
+            "bias": "short",
+            "entry": mid,
+            "stop": mid + 1.0 * atr,
+            "target": lower,
+            "reason": "price walking the lower band — sell the pullback to the middle band",
+        }
+
+    # 5. Range reversion — fade the band touch back to the mean.
+    elif verdict == "reversion_range" and entry["pct_b"] <= 0.05:
+        if trend_verdict in ("band_walk_down", "expansion_down"):
+            return _no_trade(
+                f"lower-band touch but {trend['timeframe']} is {trend_verdict} — do not fade a downtrend"
+            )
+        setup = {
+            "setup": "reversion_long",
+            "bias": "long",
+            "entry": lower,
+            "stop": lower - 0.5 * atr,
+            "target": mid,
+            "reason": "lower-band tag in a flat, wide band with ADX below the trend threshold",
+        }
+    elif verdict == "reversion_range" and entry["pct_b"] >= 0.95:
+        if trend_verdict in ("band_walk_up", "expansion_up"):
+            return _no_trade(
+                f"upper-band touch but {trend['timeframe']} is {trend_verdict} — do not fade an uptrend"
+            )
+        setup = {
+            "setup": "reversion_short",
+            "bias": "short",
+            "entry": upper,
+            "stop": upper + 0.5 * atr,
+            "target": mid,
+            "reason": "upper-band tag in a flat, wide band with ADX below the trend threshold",
+        }
+    else:
+        return _no_trade(
+            f"{verdict} on {entry['timeframe']} with %B at {entry['pct_b']:.2f} — no edge"
+        )
+
+    risk = abs(setup["entry"] - setup["stop"])
+    reward = abs(setup["target"] - setup["entry"])
+    if risk <= 0:
+        return _no_trade("band-derived stop collapsed onto the entry")
+    setup["rr"] = reward / risk
+
+    is_continuation = setup["setup"] in _CONTINUATION_SETUPS
+    min_rr = cfg.min_rr_continuation if is_continuation else cfg.min_rr_reversion
+    if setup["rr"] < min_rr:
+        return _no_trade(
+            f"{setup['setup']} rejected: R:R {setup['rr']:.2f} below the {min_rr:.1f} minimum"
+        )
+
+    # Breakouts need participation. A quiet break is a retest waiting to happen.
+    if setup["setup"].startswith("squeeze_breakout") and entry["vol_ratio"] < 1.0:
+        return _no_trade(
+            f"{setup['setup']} rejected: breakout volume {entry['vol_ratio']:.2f}x average — wait for the retest"
+        )
+
+    return setup
+
+
+# ── Report ───────────────────────────────────────────────────────────────────
+
+
+def _band_chart(tf: dict, pair: str):
+    import plotly.graph_objects as go
+
+    candles = tf["candles"][-120:]
+    bbs = tf["bb_series"][-120:]
+    ts = candle_timestamps(candles)
+    fig = go.Figure()
+    fig.add_trace(
+        go.Candlestick(
+            x=ts,
+            open=[float(c.get("open", 0)) for c in candles],
+            high=[float(c.get("high", 0)) for c in candles],
+            low=[float(c.get("low", 0)) for c in candles],
+            close=[float(c.get("close", 0)) for c in candles],
+            name=tf["timeframe"],
+            increasing_line_color="#22c55e",
+            decreasing_line_color="#ef4444",
+        )
+    )
+    for key, color, dash, name in [
+        ("upper", "#60a5fa", "solid", "Upper band"),
+        ("mid", "#f59e0b", "dot", "Middle band (SMA)"),
+        ("lower", "#60a5fa", "solid", "Lower band"),
+    ]:
+        fig.add_trace(
+            go.Scatter(
+                x=ts,
+                y=[b[key] if b else None for b in bbs],
+                mode="lines",
+                name=name,
+                line=dict(color=color, width=1.4, dash=dash),
+            )
+        )
+    fig.update_layout(
+        title=f"Bollinger Bands ({tf['timeframe']}) — {pair}",
+        xaxis_title="Time",
+        yaxis_title="Price",
+        template="plotly_dark",
+        height=460,
+        xaxis_rangeslider_visible=False,
+        legend=dict(orientation="h", yanchor="top", y=-0.15, xanchor="center", x=0.5),
+    )
+    return fig
+
+
+def _bandwidth_chart(tf: dict, pair: str, squeeze_rank: float):
+    import plotly.graph_objects as go
+
+    bbs = [b for b in tf["bb_series"] if b][-_RANK_LOOKBACK:]
+    if len(bbs) < 5:
+        return None
+    widths = [b["bandwidth_pct"] for b in bbs]
+    ordered = sorted(widths)
+    threshold = ordered[
+        max(0, min(len(ordered) - 1, int(len(ordered) * squeeze_rank / 100)))
+    ]
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(
+            x=list(range(len(widths))),
+            y=widths,
+            mode="lines",
+            name="Bandwidth %",
+            line=dict(color="#a78bfa", width=1.6),
+        )
+    )
+    fig.add_hline(
+        y=threshold,
+        line_dash="dot",
+        line_color="#f43f5e",
+        annotation_text=f"squeeze threshold (p{squeeze_rank:.0f})",
+    )
+    fig.update_layout(
+        title=f"Bandwidth History ({tf['timeframe']}) — {pair}",
+        xaxis_title=f"Candles ago → now (last {len(widths)})",
+        yaxis_title="Bandwidth (% of middle band)",
+        template="plotly_dark",
+        height=320,
+        legend=dict(orientation="h", yanchor="top", y=-0.2, xanchor="center", x=0.5),
+    )
+    return fig
+
+
+async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
+    client = await get_client(context._chat_id, context=context)
+    if not client:
+        return "No server available"
+
+    pair, connector = config.trading_pair, config.connector_name
+
+    import asyncio
+
+    async def fetch(interval: str, records: int):
+        try:
+            raw = await client.market_data.get_candles(
+                connector, pair, interval=interval, max_records=records
+            )
+        except Exception as e:
+            logger.warning(f"Candle fetch failed for {pair} {interval}: {e}")
+            return []
+        if isinstance(raw, list):
+            return raw
+        return raw.get("data", raw.get("candles", [])) if isinstance(raw, dict) else []
+
+    candle_sets = await asyncio.gather(*[fetch(iv, n) for _, iv, n in _TIMEFRAMES])
+    if not any(candle_sets):
+        return f"No candle data for {pair} on {connector}"
+
+    frames = [
+        _analyze_timeframe(candles, label, config)
+        for (label, _, _), candles in zip(_TIMEFRAMES, candle_sets)
+    ]
+    entry, contextual, trend = frames
+    setup = _derive_setup(entry, trend, config)
+
+    rows = []
+    for tf in frames:
+        if "error" in tf:
+            rows.append({"Timeframe": tf["timeframe"], "Verdict": f"— ({tf['error']})"})
+            continue
+        rows.append(
+            {
+                "Timeframe": tf["timeframe"],
+                "Verdict": tf["verdict"],
+                "Price": _fmt(tf["price"]),
+                "%B": f"{tf['pct_b']:.2f}",
+                "Bandwidth": f"{tf['bandwidth_pct']:.2f}%",
+                "BW Rank": f"{tf['bw_rank']:.0f}",
+                "Squeeze": "yes" if tf["squeeze_on"] else "no",
+                "ADX": f"{tf['adx']:.1f}",
+                "Vol x": f"{tf['vol_ratio']:.2f}",
+                "Upper": _fmt(tf["upper"]),
+                "Middle": _fmt(tf["mid"]),
+                "Lower": _fmt(tf["lower"]),
+            }
+        )
+
+    lines = [
+        f"**Bollinger Band State: {pair} on {connector}** — BB({config.bb_period}, {config.bb_std})",
+        "",
+        f"setup: {setup['setup']}",
+        f"bias: {setup['bias']}",
+    ]
+    if setup["setup"] == "squeeze_pending":
+        lines += [
+            f"long_trigger: {_fmt(setup['long_trigger'])}",
+            f"short_trigger: {_fmt(setup['short_trigger'])}",
+            f"invalidation: {_fmt(setup['invalidation'])}",
+        ]
+    elif setup["setup"] != "no_trade":
+        lines += [
+            f"entry: {_fmt(setup['entry'])}",
+            f"stop: {_fmt(setup['stop'])}",
+            f"target: {_fmt(setup['target'])}",
+            f"rr: {setup['rr']:.2f}",
+        ]
+    lines.append(f"reason: {setup['reason']}")
+
+    if "error" not in entry:
+        lines += [
+            "",
+            f"entry_tf: {entry['verdict']} | %B {entry['pct_b']:.2f} | bw {entry['bandwidth_pct']:.2f}% (rank {entry['bw_rank']:.0f}) | ADX {entry['adx']:.1f}",
+        ]
+    if "error" not in contextual:
+        lines.append(
+            f"context_tf: {contextual['verdict']} | %B {contextual['pct_b']:.2f} | bw rank {contextual['bw_rank']:.0f}"
+        )
+    if "error" not in trend:
+        lines.append(
+            f"trend_tf: {trend['verdict']} | %B {trend['pct_b']:.2f} | bw rank {trend['bw_rank']:.0f}"
+        )
+
+    summary = "\n".join(lines)
+
+    try:
+        from condor.reports import ReportBuilder
+
+        builder = ReportBuilder(f"Bollinger Band State: {pair}")
+        builder.source("routine", "band_state").tags(
+            ["bollinger", "volatility", pair.lower()]
+        )
+        builder.manual_order()
+
+        builder.section(
+            "01 / SETUP", "What the bands say to do right now, and at which price."
+        )
+        builder.kpi("Setup", setup["setup"])
+        builder.kpi("Bias", setup["bias"])
+        if setup["setup"] == "squeeze_pending":
+            builder.kpi("Long Trigger", _fmt(setup["long_trigger"]))
+            builder.kpi("Short Trigger", _fmt(setup["short_trigger"]))
+        elif setup["setup"] != "no_trade":
+            builder.kpi("Entry", _fmt(setup["entry"]))
+            builder.kpi("Stop", _fmt(setup["stop"]))
+            builder.kpi("Target", _fmt(setup["target"]))
+            builder.kpi("R:R", f"{setup['rr']:.2f}")
+        if "error" not in entry:
+            builder.kpi("%B (entry TF)", f"{entry['pct_b']:.2f}")
+            builder.kpi("BW Rank (entry TF)", f"{entry['bw_rank']:.0f}")
+            builder.kpi("Squeeze", "on" if entry["squeeze_on"] else "off")
+
+        builder.section(
+            "02 / TIMEFRAMES",
+            "Band read per timeframe. The trend row vetoes the entry row.",
+        )
+        builder.table(
+            rows,
+            [
+                "Timeframe",
+                "Verdict",
+                "Price",
+                "%B",
+                "Bandwidth",
+                "BW Rank",
+                "Squeeze",
+                "ADX",
+                "Vol x",
+                "Upper",
+                "Middle",
+                "Lower",
+            ],
+        )
+
+        if "error" not in entry:
+            builder.section(
+                "03 / CHARTS",
+                "Bands on the entry timeframe, and how tight the band is versus its own history.",
+            )
+            builder.plotly(_band_chart(entry, pair))
+            bw_fig = _bandwidth_chart(entry, pair, config.squeeze_rank)
+            if bw_fig is not None:
+                builder.plotly(bw_fig)
+
+        builder.markdown(summary)
+        await builder.save()
+    except Exception as e:
+        logger.warning(f"Report generation failed: {e}")
+
+    return summary

--- a/agents/bollinger_band_trader/routines/band_trade_sizer.py
+++ b/agents/bollinger_band_trader/routines/band_trade_sizer.py
@@ -15,7 +15,7 @@ intentionally self-contained rather than imported from a sibling routine.
 import json
 import logging
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from telegram.ext import ContextTypes
 
 from config_manager import get_client
@@ -33,6 +33,11 @@ _MAX_LEVERAGE = 5
 
 class Config(BaseModel):
     """Size a Bollinger setup from its band-derived stop and run pre-trade guardrails."""
+
+    # Reject unknown keys. Without this, a model passing `symbol` instead of
+    # `trading_pair` would silently fall back to the default pair/connector and
+    # return a confident answer about the wrong market.
+    model_config = ConfigDict(extra="forbid")
 
     trading_pair: str = Field(default="BTC-USDT", description="Trading pair")
     connector_name: str = Field(

--- a/agents/bollinger_band_trader/routines/band_trade_sizer.py
+++ b/agents/bollinger_band_trader/routines/band_trade_sizer.py
@@ -1,0 +1,391 @@
+"""Turn a band-derived stop into a sized, pre-flight-checked position_executor payload.
+
+A Bollinger setup is only as good as the size behind it. This routine takes the entry
+and stop the bands produced, converts fixed fractional risk into a base-currency
+`amount`, and then refuses the trade if any guardrail fails: portfolio reserve, max
+position cap, exchange minimum notional, stop sanity, leverage ceiling.
+
+It never places an order. It returns a verdict and, on PASS, the exact payload the
+agent should hand to `manage_executors`.
+
+Routines are loaded standalone by file path, so the indicator helpers here are
+intentionally self-contained rather than imported from a sibling routine.
+"""
+
+import json
+import logging
+
+from pydantic import BaseModel, Field
+from telegram.ext import ContextTypes
+
+from config_manager import get_client
+from routines.base import RoutineResult
+
+logger = logging.getLogger(__name__)
+
+CATEGORY = "Risk"
+
+_MIN_STOP_PCT = 0.05  # below this the stop is inside the noise / fee band
+_MAX_STOP_PCT = 20.0  # above this the "stop" is not a stop
+_MAX_RISK_PCT = 1.0
+_MAX_LEVERAGE = 5
+
+
+class Config(BaseModel):
+    """Size a Bollinger setup from its band-derived stop and run pre-trade guardrails."""
+
+    trading_pair: str = Field(default="BTC-USDT", description="Trading pair")
+    connector_name: str = Field(
+        default="binance_perpetual", description="Exchange connector"
+    )
+    side: str = Field(default="long", description="long or short")
+    entry_price: float = Field(
+        default=0.0, description="Entry price (0 = use the live price)"
+    )
+    stop_price: float = Field(
+        default=0.0, description="Stop price (0 = derive from the bands)"
+    )
+    target_price: float = Field(
+        default=0.0, description="Target price (0 = 2R from the stop)"
+    )
+    risk_pct: float = Field(
+        default=0.5, description="Portfolio percent risked if the stop is hit"
+    )
+    max_position_pct: float = Field(
+        default=10.0, description="Max position notional as percent of portfolio"
+    )
+    reserve_pct: float = Field(
+        default=20.0, description="Portfolio percent that must stay unallocated"
+    )
+    leverage: int = Field(default=1, description="Leverage for the position executor")
+    min_notional: float = Field(
+        default=5.0, description="Exchange minimum order notional in quote"
+    )
+    portfolio_value_quote: float = Field(
+        default=0.0, description="Override portfolio value (0 = fetch live)"
+    )
+    interval: str = Field(
+        default="15m", description="Candle interval used to derive the stop"
+    )
+    bb_period: int = Field(default=20, description="Bollinger moving-average period")
+    bb_std: float = Field(
+        default=2.0, description="Bollinger standard-deviation multiplier"
+    )
+
+
+# ── Indicator helpers ────────────────────────────────────────────────────────
+
+
+def _sma(values: list, period: int) -> float | None:
+    if len(values) < period or period <= 0:
+        return None
+    return sum(values[-period:]) / period
+
+
+def _stdev(window: list) -> float:
+    n = len(window)
+    if n < 2:
+        return 0.0
+    mean = sum(window) / n
+    return (sum((x - mean) ** 2 for x in window) / n) ** 0.5
+
+
+def _atr(candles: list, period: int) -> float:
+    if len(candles) < period + 1:
+        return 0.0
+    trs = []
+    for i in range(1, len(candles)):
+        high, low = float(candles[i].get("high", 0)), float(candles[i].get("low", 0))
+        prev_close = float(candles[i - 1].get("close", 0))
+        trs.append(max(high - low, abs(high - prev_close), abs(low - prev_close)))
+    return sum(trs[-period:]) / period
+
+
+def _fmt(value) -> str:
+    if value is None:
+        return "n/a"
+    av = abs(value)
+    if av >= 1000:
+        return f"{value:,.2f}"
+    if av >= 1:
+        return f"{value:,.4f}"
+    if av >= 0.01:
+        return f"{value:.6f}"
+    return f"{value:.8f}"
+
+
+def _derive_stop(
+    side: str, entry: float, mid: float, lower: float, upper: float, atr: float
+) -> tuple:
+    """Nearest band-structure level on the protective side of the entry.
+
+    Long: the middle band if price is above it, otherwise half an ATR below the lower
+    band. Short is the mirror. Falls back to a 1-ATR stop when neither level qualifies,
+    which happens when the entry is already outside the structure.
+    """
+    fallback = atr if atr > 0 else entry * 0.01
+    if side == "long":
+        candidates = [c for c in (mid, lower - 0.5 * atr) if c < entry]
+        if candidates:
+            level = max(candidates)
+            return level, "middle band" if level == mid else "lower band − 0.5 ATR"
+        return entry - fallback, "1 ATR below entry (fallback)"
+    candidates = [c for c in (mid, upper + 0.5 * atr) if c > entry]
+    if candidates:
+        level = min(candidates)
+        return level, "middle band" if level == mid else "upper band + 0.5 ATR"
+    return entry + fallback, "1 ATR above entry (fallback)"
+
+
+async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> RoutineResult:
+    client = await get_client(context._chat_id, context=context)
+    if not client:
+        return RoutineResult(text="No server available")
+
+    side = config.side.strip().lower()
+    if side in ("buy", "1"):
+        side = "long"
+    elif side in ("sell", "2"):
+        side = "short"
+    if side not in ("long", "short"):
+        return RoutineResult(text=f"Invalid side '{config.side}' — use long or short")
+
+    pair, connector = config.trading_pair.strip().upper(), config.connector_name
+
+    # ── Market context: price + band levels ──────────────────────────────────
+    candles = []
+    try:
+        raw = await client.market_data.get_candles(
+            connector,
+            pair,
+            interval=config.interval,
+            max_records=max(config.bb_period * 3, 100),
+        )
+        if isinstance(raw, list):
+            candles = raw
+        elif isinstance(raw, dict):
+            candles = raw.get("data", raw.get("candles", []))
+    except Exception as e:
+        logger.warning(f"Candle fetch failed for {pair}: {e}")
+
+    closes = [float(c.get("close", 0)) for c in candles]
+    mid = _sma(closes, config.bb_period)
+    std = (
+        _stdev(closes[-config.bb_period :]) if len(closes) >= config.bb_period else 0.0
+    )
+    upper = mid + config.bb_std * std if mid else None
+    lower = mid - config.bb_std * std if mid else None
+    atr = _atr(candles, config.bb_period)
+
+    entry = config.entry_price
+    if entry <= 0:
+        try:
+            prices = await client.market_data.get_prices(
+                connector, trading_pairs=[pair]
+            )
+            entry = float((prices or {}).get(pair, 0) or 0)
+        except Exception as e:
+            logger.warning(f"Price fetch failed for {pair}: {e}")
+        if entry <= 0 and closes:
+            entry = closes[-1]
+    if entry <= 0:
+        return RoutineResult(
+            text=f"Could not determine an entry price for {pair} on {connector}"
+        )
+
+    stop, stop_source = config.stop_price, "supplied"
+    if stop <= 0:
+        if mid is None:
+            return RoutineResult(
+                text=f"No stop supplied and not enough candles to derive one for {pair}"
+            )
+        stop, stop_source = _derive_stop(side, entry, mid, lower, upper, atr)
+
+    # ── Portfolio ────────────────────────────────────────────────────────────
+    portfolio = config.portfolio_value_quote
+    portfolio_source = "override"
+    if portfolio <= 0:
+        portfolio_source = "live"
+        try:
+            portfolio = float(await client.portfolio.get_total_value() or 0)
+        except Exception as e:
+            logger.warning(f"Portfolio value fetch failed: {e}")
+            portfolio = 0.0
+
+    # ── Sizing ───────────────────────────────────────────────────────────────
+    stop_distance = abs(entry - stop)
+    stop_pct = stop_distance / entry * 100 if entry else 0.0
+    correct_side = stop < entry if side == "long" else stop > entry
+
+    target = config.target_price
+    if target <= 0:
+        target = (
+            entry + 2 * stop_distance if side == "long" else entry - 2 * stop_distance
+        )
+    reward = abs(target - entry)
+    rr = reward / stop_distance if stop_distance > 0 else 0.0
+
+    risk_quote = portfolio * config.risk_pct / 100
+    position_cap = portfolio * config.max_position_pct / 100
+    deployable = portfolio * (1 - config.reserve_pct / 100)
+
+    raw_notional = risk_quote / (stop_pct / 100) if stop_pct > 0 else 0.0
+    notional = min(raw_notional, position_cap, deployable)
+    capped_by = ""
+    if raw_notional > 0 and notional < raw_notional - 1e-9:
+        capped_by = "max_position_pct" if notional == position_cap else "reserve_pct"
+
+    amount_base = notional / entry if entry else 0.0
+    margin = notional / config.leverage if config.leverage else notional
+    effective_risk = notional * stop_pct / 100
+
+    # ── Guardrails ───────────────────────────────────────────────────────────
+    checks = []
+
+    def check(name: str, ok: bool, detail: str, fatal: bool = True) -> bool:
+        checks.append(
+            {
+                "Check": name,
+                "Result": "PASS" if ok else ("FAIL" if fatal else "WARN"),
+                "Detail": detail,
+            }
+        )
+        return ok or not fatal
+
+    def warn(name: str, detail: str) -> None:
+        """Informational row — always a WARN, never blocks the trade."""
+        checks.append({"Check": name, "Result": "WARN", "Detail": detail})
+
+    passed = True
+    passed &= check(
+        "Portfolio value known",
+        portfolio > 0,
+        f"${portfolio:,.2f} ({portfolio_source})",
+    )
+    passed &= check(
+        "Stop on the protective side",
+        correct_side,
+        f"{side} entry {_fmt(entry)} / stop {_fmt(stop)} ({stop_source})",
+    )
+    passed &= check(
+        "Stop distance sane",
+        _MIN_STOP_PCT <= stop_pct <= _MAX_STOP_PCT,
+        f"{stop_pct:.3f}% (allowed {_MIN_STOP_PCT}–{_MAX_STOP_PCT}%)",
+    )
+    passed &= check(
+        "Risk per trade within policy",
+        0 < config.risk_pct <= _MAX_RISK_PCT,
+        f"{config.risk_pct:.2f}% of portfolio (max {_MAX_RISK_PCT}%)",
+    )
+    passed &= check(
+        "Leverage within policy",
+        1 <= config.leverage <= _MAX_LEVERAGE,
+        f"{config.leverage}x (max {_MAX_LEVERAGE}x)",
+    )
+    passed &= check(
+        "Meets exchange minimum notional",
+        notional >= config.min_notional,
+        f"${notional:,.2f} vs ${config.min_notional:,.2f} minimum",
+    )
+    passed &= check(
+        "Margin fits inside the reserve",
+        margin <= deployable,
+        f"margin ${margin:,.2f} vs ${deployable:,.2f} deployable ({100 - config.reserve_pct:.0f}% of portfolio)",
+    )
+    check("Reward:risk", rr >= 1.2, f"{rr:.2f} (target {_fmt(target)})", fatal=False)
+    if capped_by:
+        warn(
+            "Size capped",
+            f"reduced from ${raw_notional:,.2f} by {capped_by} — risks less than the target",
+        )
+
+    verdict = "PASS" if passed else "FAIL"
+
+    payload = {
+        "connector_name": connector,
+        "trading_pair": pair,
+        "side": 1 if side == "long" else 2,
+        "amount": round(amount_base, 8),
+        "entry_price": round(entry, 8),
+        "leverage": config.leverage,
+        "triple_barrier_config": {
+            "stop_loss": round(stop_pct / 100, 6),
+            "take_profit": round(reward / entry, 6),
+            "open_order_type": 2,
+            "stop_loss_order_type": 1,
+            "take_profit_order_type": 2,
+        },
+    }
+
+    lines = [
+        f"**Band Trade Sizer: {pair} on {connector}**",
+        "",
+        f"verdict: {verdict}",
+        f"side: {side}",
+        f"entry: {_fmt(entry)}",
+        f"stop: {_fmt(stop)} ({stop_source}, {stop_pct:.3f}%)",
+        f"target: {_fmt(target)}",
+        f"rr: {rr:.2f}",
+        f"amount_base: {amount_base:.8f}",
+        f"notional_quote: ${notional:,.2f}",
+        f"margin_quote: ${margin:,.2f} at {config.leverage}x",
+        f"risk_if_stopped: ${effective_risk:,.2f} ({(effective_risk / portfolio * 100) if portfolio else 0:.2f}% of portfolio)",
+    ]
+    if capped_by:
+        lines.append(
+            f"note: size capped by {capped_by} (uncapped would be ${raw_notional:,.2f})"
+        )
+    failures = [c["Check"] for c in checks if c["Result"] == "FAIL"]
+    if failures:
+        lines.append(f"blocked_by: {', '.join(failures)}")
+    else:
+        lines += [
+            "",
+            "position_executor payload:",
+            "```json",
+            json.dumps(payload, indent=2),
+            "```",
+        ]
+    lines += [
+        "",
+        "Amounts are pre-quantization — the exchange applies its own step size and may round down.",
+    ]
+    summary = "\n".join(lines)
+
+    columns = ["Check", "Result", "Detail"]
+    try:
+        from condor.reports import ReportBuilder
+
+        builder = ReportBuilder(f"Band Trade Sizer: {pair}")
+        builder.source("routine", "band_trade_sizer").tags(
+            ["bollinger", "risk", "sizing", pair.lower()]
+        )
+        builder.manual_order()
+
+        builder.section(
+            "01 / VERDICT",
+            "Whether this Bollinger setup may be deployed, and at what size.",
+        )
+        builder.kpi("Verdict", verdict)
+        builder.kpi("Side", side)
+        builder.kpi("Entry", _fmt(entry))
+        builder.kpi("Stop", f"{_fmt(stop)} ({stop_pct:.2f}%)")
+        builder.kpi("Target", _fmt(target))
+        builder.kpi("R:R", f"{rr:.2f}")
+        builder.kpi("Amount (base)", f"{amount_base:.8f}")
+        builder.kpi("Notional", f"${notional:,.2f}")
+        builder.kpi("Margin", f"${margin:,.2f}")
+        builder.kpi("Risk if Stopped", f"${effective_risk:,.2f}")
+
+        builder.section(
+            "02 / GUARDRAILS",
+            "Every check must pass before the payload is considered valid.",
+        )
+        builder.table(checks, columns)
+
+        builder.markdown(summary)
+        await builder.save()
+    except Exception as e:
+        logger.warning(f"Report generation failed: {e}")
+
+    return RoutineResult(text=summary, table_data=checks, table_columns=columns)

--- a/agents/bollinger_band_trader/routines/squeeze_screener.py
+++ b/agents/bollinger_band_trader/routines/squeeze_screener.py
@@ -1,0 +1,351 @@
+"""Rank a watchlist by Bollinger squeeze tightness — where a setup is brewing.
+
+`band_state` answers "what is this pair doing?". This routine answers "which pair is
+about to do something?". It computes the bandwidth percentile rank for every pair on the
+list and sorts ascending, so the most compressed bands surface first. A squeeze does not
+say which way price will break, only that the break is likely to be violent — so the
+output is a watchlist, not a set of trades.
+
+Routines are loaded standalone by file path, so the indicator helpers here are
+intentionally self-contained rather than imported from a sibling routine.
+"""
+
+import asyncio
+import logging
+
+from pydantic import BaseModel, Field
+from telegram.ext import ContextTypes
+
+from config_manager import get_client
+from routines.base import RoutineResult
+
+logger = logging.getLogger(__name__)
+
+CATEGORY = "Analysis"
+
+_KELTNER_MULT = 1.5
+_EXPANSION_LOOKBACK = 3
+_EXPANSION_FACTOR = 1.15
+_MAX_CONCURRENCY = 10
+
+_DEFAULT_WATCHLIST = (
+    "BTC-USDT,ETH-USDT,SOL-USDT,XRP-USDT,DOGE-USDT,AVAX-USDT,LINK-USDT,SUI-USDT"
+)
+
+
+class Config(BaseModel):
+    """Rank a watchlist by Bollinger bandwidth percentile — tightest squeeze first."""
+
+    trading_pairs: str = Field(
+        default=_DEFAULT_WATCHLIST, description="Comma-separated pairs to screen"
+    )
+    connector_name: str = Field(
+        default="binance_perpetual", description="Exchange connector"
+    )
+    interval: str = Field(default="1h", description="Candle interval for the screen")
+    bb_period: int = Field(default=20, description="Bollinger moving-average period")
+    bb_std: float = Field(
+        default=2.0, description="Bollinger standard-deviation multiplier"
+    )
+    max_records: int = Field(
+        default=300, description="Candles per pair (also the rank history depth)"
+    )
+    squeeze_rank: float = Field(
+        default=20.0, description="bw_rank at or below which a pair counts as squeezed"
+    )
+    top_n: int = Field(default=15, description="Rows to show")
+
+
+# ── Indicator helpers ────────────────────────────────────────────────────────
+
+
+def _sma_series(values: list, period: int) -> list:
+    if period <= 0:
+        return [None] * len(values)
+    out, running = [], 0.0
+    for i, v in enumerate(values):
+        running += v
+        if i >= period:
+            running -= values[i - period]
+        out.append(running / period if i >= period - 1 else None)
+    return out
+
+
+def _ema_series(values: list, period: int) -> list:
+    if len(values) < period or period <= 0:
+        return [None] * len(values)
+    mult = 2 / (period + 1)
+    ema = sum(values[:period]) / period
+    out = [None] * (period - 1) + [ema]
+    for v in values[period:]:
+        ema = (v - ema) * mult + ema
+        out.append(ema)
+    return out
+
+
+def _stdev(window: list) -> float:
+    n = len(window)
+    if n < 2:
+        return 0.0
+    mean = sum(window) / n
+    return (sum((x - mean) ** 2 for x in window) / n) ** 0.5
+
+
+def _bollinger_series(closes: list, period: int, k: float) -> list:
+    mids = _sma_series(closes, period)
+    out = []
+    for i, mid in enumerate(mids):
+        if mid is None or mid <= 0:
+            out.append(None)
+            continue
+        std = _stdev(closes[i - period + 1 : i + 1])
+        upper, lower = mid + k * std, mid - k * std
+        width = upper - lower
+        out.append(
+            {
+                "mid": mid,
+                "upper": upper,
+                "lower": lower,
+                "bandwidth_pct": width / mid * 100,
+                "pct_b": (closes[i] - lower) / width if width > 0 else 0.5,
+            }
+        )
+    return out
+
+
+def _true_range_series(candles: list) -> list:
+    trs = []
+    for i, c in enumerate(candles):
+        high, low = float(c.get("high", 0)), float(c.get("low", 0))
+        if i == 0:
+            trs.append(high - low)
+            continue
+        prev_close = float(candles[i - 1].get("close", 0))
+        trs.append(max(high - low, abs(high - prev_close), abs(low - prev_close)))
+    return trs
+
+
+def _percentile_rank(history: list, value: float) -> float:
+    if not history:
+        return 50.0
+    below = sum(1 for h in history if h < value)
+    ties = sum(1 for h in history if h == value)
+    return (below + 0.5 * ties) / len(history) * 100
+
+
+def _fmt(value) -> str:
+    if value is None:
+        return "n/a"
+    av = abs(value)
+    if av >= 1000:
+        return f"{value:,.2f}"
+    if av >= 1:
+        return f"{value:,.4f}"
+    if av >= 0.01:
+        return f"{value:.6f}"
+    return f"{value:.8f}"
+
+
+def _screen(pair: str, candles: list, cfg: Config) -> dict | None:
+    if not candles or len(candles) < cfg.bb_period + _EXPANSION_LOOKBACK + 1:
+        return None
+
+    closes = [float(c.get("close", 0)) for c in candles]
+    bbs = _bollinger_series(closes, cfg.bb_period, cfg.bb_std)
+    bb = bbs[-1]
+    if bb is None:
+        return None
+    bb_prev = bbs[-1 - _EXPANSION_LOOKBACK]
+
+    history = [b["bandwidth_pct"] for b in bbs[:-1] if b]
+    bw_rank = _percentile_rank(history, bb["bandwidth_pct"])
+
+    atrs = _sma_series(_true_range_series(candles), cfg.bb_period)
+    emas = _ema_series(closes, cfg.bb_period)
+    squeeze_on = False
+    if atrs[-1] is not None and emas[-1] is not None:
+        kc_upper = emas[-1] + _KELTNER_MULT * atrs[-1]
+        kc_lower = emas[-1] - _KELTNER_MULT * atrs[-1]
+        squeeze_on = bb["upper"] < kc_upper and bb["lower"] > kc_lower
+
+    expanding = (
+        bool(bb_prev)
+        and bb["bandwidth_pct"] > bb_prev["bandwidth_pct"] * _EXPANSION_FACTOR
+    )
+    if squeeze_on or bw_rank <= cfg.squeeze_rank:
+        state = "firing" if expanding else "squeeze"
+    elif expanding:
+        state = "expanding"
+    elif bw_rank >= 80:
+        state = "stretched"
+    else:
+        state = "normal"
+
+    return {
+        "pair": pair,
+        "state": state,
+        "price": closes[-1],
+        "pct_b": bb["pct_b"],
+        "bandwidth_pct": bb["bandwidth_pct"],
+        "bw_rank": bw_rank,
+        "squeeze_on": squeeze_on,
+        "upper": bb["upper"],
+        "lower": bb["lower"],
+    }
+
+
+async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> RoutineResult:
+    client = await get_client(context._chat_id, context=context)
+    if not client:
+        return RoutineResult(text="No server available")
+
+    pairs = [p.strip().upper() for p in config.trading_pairs.split(",") if p.strip()]
+    if not pairs:
+        return RoutineResult(text="No trading pairs configured")
+
+    connector = config.connector_name
+    sem = asyncio.Semaphore(_MAX_CONCURRENCY)
+
+    async def fetch(pair: str):
+        async with sem:
+            try:
+                raw = await client.market_data.get_candles(
+                    connector,
+                    pair,
+                    interval=config.interval,
+                    max_records=config.max_records,
+                )
+            except Exception as e:
+                logger.warning(f"Candle fetch failed for {pair}: {e}")
+                return pair, []
+            if isinstance(raw, list):
+                return pair, raw
+            return pair, (
+                raw.get("data", raw.get("candles", [])) if isinstance(raw, dict) else []
+            )
+
+    fetched = await asyncio.gather(*[fetch(p) for p in pairs])
+
+    results = []
+    skipped = []
+    for pair, candles in fetched:
+        row = _screen(pair, candles, config)
+        if row is None:
+            skipped.append(pair)
+        else:
+            results.append(row)
+
+    if not results:
+        return RoutineResult(
+            text=f"No usable candle data for any of: {', '.join(pairs)}"
+        )
+
+    results.sort(key=lambda r: r["bw_rank"])
+    shown = results[: config.top_n]
+
+    table = [
+        {
+            "Pair": r["pair"],
+            "State": r["state"],
+            "BW Rank": f"{r['bw_rank']:.0f}",
+            "Bandwidth": f"{r['bandwidth_pct']:.2f}%",
+            "%B": f"{r['pct_b']:.2f}",
+            "TTM Squeeze": "yes" if r["squeeze_on"] else "no",
+            "Price": _fmt(r["price"]),
+            "Upper": _fmt(r["upper"]),
+            "Lower": _fmt(r["lower"]),
+        }
+        for r in shown
+    ]
+    columns = [
+        "Pair",
+        "State",
+        "BW Rank",
+        "Bandwidth",
+        "%B",
+        "TTM Squeeze",
+        "Price",
+        "Upper",
+        "Lower",
+    ]
+
+    squeezed = [r for r in results if r["state"] in ("squeeze", "firing")]
+    firing = [r for r in results if r["state"] == "firing"]
+
+    lines = [
+        f"**Squeeze Screener** — {len(results)} pairs on {connector} @ {config.interval}, BB({config.bb_period}, {config.bb_std})",
+        "",
+        f"squeezed: {len(squeezed)} ({', '.join(r['pair'] for r in squeezed) or 'none'})",
+        f"firing: {len(firing)} ({', '.join(r['pair'] for r in firing) or 'none'})",
+        f"tightest: {shown[0]['pair']} at bw_rank {shown[0]['bw_rank']:.0f} ({shown[0]['bandwidth_pct']:.2f}%)",
+    ]
+    if skipped:
+        lines.append(f"skipped (insufficient data): {', '.join(skipped)}")
+    lines += [
+        "",
+        "A squeeze is a *watch* signal — it gives no direction. Run `band_state` on the",
+        "candidates and wait for a close outside the band before taking a side.",
+    ]
+    summary = "\n".join(lines)
+
+    try:
+        import plotly.graph_objects as go
+
+        from condor.reports import ReportBuilder
+
+        builder = ReportBuilder("Bollinger Squeeze Screener")
+        builder.source("routine", "squeeze_screener").tags(
+            ["bollinger", "squeeze", "screener"]
+        )
+        builder.manual_order()
+
+        builder.section(
+            "01 / WATCHLIST",
+            "Bandwidth percentile rank per pair. Lower rank = tighter band.",
+        )
+        builder.kpi("Pairs Screened", str(len(results)))
+        builder.kpi("Squeezed", str(len(squeezed)))
+        builder.kpi("Firing", str(len(firing)))
+        builder.kpi("Tightest", f"{shown[0]['pair']} (rank {shown[0]['bw_rank']:.0f})")
+        builder.table(table, columns)
+
+        colors = {
+            "squeeze": "#f43f5e",
+            "firing": "#f59e0b",
+            "expanding": "#38bdf8",
+            "stretched": "#a78bfa",
+        }
+        fig = go.Figure()
+        fig.add_trace(
+            go.Bar(
+                x=[r["pair"] for r in shown],
+                y=[r["bw_rank"] for r in shown],
+                marker_color=[colors.get(r["state"], "#64748b") for r in shown],
+                name="BW rank",
+            )
+        )
+        fig.add_hline(
+            y=config.squeeze_rank,
+            line_dash="dot",
+            line_color="#f43f5e",
+            annotation_text=f"squeeze threshold (p{config.squeeze_rank:.0f})",
+        )
+        fig.update_layout(
+            title=f"Bandwidth Percentile Rank — {connector} @ {config.interval}",
+            xaxis_title="Pair",
+            yaxis_title="Bandwidth percentile rank (0 = tightest)",
+            yaxis_range=[0, 100],
+            template="plotly_dark",
+            height=380,
+            legend=dict(
+                orientation="h", yanchor="top", y=-0.25, xanchor="center", x=0.5
+            ),
+        )
+        builder.plotly(fig)
+
+        builder.markdown(summary)
+        await builder.save()
+    except Exception as e:
+        logger.warning(f"Report generation failed: {e}")
+
+    return RoutineResult(text=summary, table_data=table, table_columns=columns)

--- a/agents/bollinger_band_trader/routines/squeeze_screener.py
+++ b/agents/bollinger_band_trader/routines/squeeze_screener.py
@@ -13,7 +13,7 @@ intentionally self-contained rather than imported from a sibling routine.
 import asyncio
 import logging
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from telegram.ext import ContextTypes
 
 from config_manager import get_client
@@ -35,6 +35,11 @@ _DEFAULT_WATCHLIST = (
 
 class Config(BaseModel):
     """Rank a watchlist by Bollinger bandwidth percentile — tightest squeeze first."""
+
+    # Reject unknown keys. Without this, a model passing `symbol` instead of
+    # `trading_pair` would silently fall back to the default pair/connector and
+    # return a confident answer about the wrong market.
+    model_config = ConfigDict(extra="forbid")
 
     trading_pairs: str = Field(
         default=_DEFAULT_WATCHLIST, description="Comma-separated pairs to screen"

--- a/agents/bollinger_band_trader/skills/bollinger_playbook/SKILL.md
+++ b/agents/bollinger_band_trader/skills/bollinger_playbook/SKILL.md
@@ -21,9 +21,8 @@ Follow it in order. Each gate exists because skipping it is a known way to lose 
 Run the state read:
 
 ```
-manage_trading_agent(action="run_routine", strategy_id="bollinger_band_trader",
-                     name="band_state",
-                     config={"trading_pair": "<pair>", "connector_name": "<connector>"})
+manage_routines(action="run", name="band_state", strategy_id="bollinger_band_trader",
+                config={"trading_pair": "<pair>", "connector_name": "<connector>"})
 ```
 
 Read `verdict` on the entry timeframe and on the trend timeframe. **Do not read `%B`
@@ -50,11 +49,10 @@ this, but if you are reasoning from a manual reading, apply it yourself.
 ## Step 3 — Size it (mandatory)
 
 ```
-manage_trading_agent(action="run_routine", strategy_id="bollinger_band_trader",
-                     name="band_trade_sizer",
-                     config={"trading_pair": "<pair>", "connector_name": "<connector>",
-                             "side": "long", "entry_price": <entry>, "stop_price": <stop>,
-                             "target_price": <target>, "risk_pct": 0.5, "leverage": 1})
+manage_routines(action="run", name="band_trade_sizer", strategy_id="bollinger_band_trader",
+                config={"trading_pair": "<pair>", "connector_name": "<connector>",
+                        "side": "long", "entry_price": <entry>, "stop_price": <stop>,
+                        "target_price": <target>, "risk_pct": 0.5, "leverage": 1})
 ```
 
 The routine returns `verdict: PASS|FAIL`, the base-currency `amount`, and a ready
@@ -108,9 +106,8 @@ whether it needs to be 10.
 When there is no specific pair in question, screen first:
 
 ```
-manage_trading_agent(action="run_routine", strategy_id="bollinger_band_trader",
-                     name="squeeze_screener",
-                     config={"trading_pairs": "BTC-USDT,ETH-USDT,SOL-USDT", "interval": "1h"})
+manage_routines(action="run", name="squeeze_screener", strategy_id="bollinger_band_trader",
+                config={"trading_pairs": "BTC-USDT,ETH-USDT,SOL-USDT", "interval": "1h"})
 ```
 
 Then run `band_state` on the top candidates. A screener row is never a trade on its own —

--- a/agents/bollinger_band_trader/skills/bollinger_playbook/SKILL.md
+++ b/agents/bollinger_band_trader/skills/bollinger_playbook/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: bollinger_playbook
+description: End-to-end procedure for trading a Bollinger Band setup — classify the volatility
+  regime, pick the matching setup, derive levels from the bands, size it, deploy the position
+  executor, and manage the exit.
+when_to_use: When you need to act on a Bollinger reading rather than just describe it — a
+  squeeze fired, price is walking a band, or a band touch needs to be faded or followed.
+  Also read it before any deploy, because the sizing and veto gates live here.
+created: '2026-07-29T00:00:00+00:00'
+source: agent:bollinger_band_trader
+references_routine: band_state
+---
+
+# Bollinger Playbook
+
+The procedure from "the bands look interesting" to a live, sized, managed position.
+Follow it in order. Each gate exists because skipping it is a known way to lose money.
+
+## Step 1 — Classify before you look at price
+
+Run the state read:
+
+```
+manage_trading_agent(action="run_routine", strategy_id="bollinger_band_trader",
+                     name="band_state",
+                     config={"trading_pair": "<pair>", "connector_name": "<connector>"})
+```
+
+Read `verdict` on the entry timeframe and on the trend timeframe. **Do not read `%B`
+first.** %B without the regime is the classic trap: 0.98 is a sell in a range and a buy
+in an expansion, and nothing about the number itself tells you which.
+
+If `setup` is `no_trade`, stop and report the reason. The routine already applied the
+R:R floor, the volume filter, and the higher-timeframe veto.
+
+## Step 2 — Match the setup to its rules
+
+| `setup` | Entry | Stop | Target | Manage |
+|---|---|---|---|---|
+| `squeeze_pending` | none yet | — | — | Watch `long_trigger` / `short_trigger`. Re-run each candle close. |
+| `squeeze_breakout_long/short` | Close beyond the band | Middle band | 2R, then trail the middle band | Exit fully if price closes back inside the band within 2 candles |
+| `band_walk_long/short` | Pullback to the middle band that holds | 1 ATR past the middle band | Opposite band | Exit when %B crosses back through 0.5 |
+| `reversion_long/short` | At the band | 0.5 ATR beyond the band | Middle band | Exit at the mean; do not hold for the opposite band |
+| `failed_breakout_long/short` | On the close back inside | Beyond the failure extreme | Middle band, then the opposite band | Tighten to breakeven once the middle band is reached |
+
+**The veto that matters most:** never take `reversion_*` when the trend timeframe reads
+`band_walk_*` or `expansion_*` in the opposing direction. `band_state` already blocks
+this, but if you are reasoning from a manual reading, apply it yourself.
+
+## Step 3 — Size it (mandatory)
+
+```
+manage_trading_agent(action="run_routine", strategy_id="bollinger_band_trader",
+                     name="band_trade_sizer",
+                     config={"trading_pair": "<pair>", "connector_name": "<connector>",
+                             "side": "long", "entry_price": <entry>, "stop_price": <stop>,
+                             "target_price": <target>, "risk_pct": 0.5, "leverage": 1})
+```
+
+The routine returns `verdict: PASS|FAIL`, the base-currency `amount`, and a ready
+`position_executor` payload. **A `FAIL` is final** — report `blocked_by` and stop. Do not
+hand-adjust the size to get around a failed guardrail; the guardrails are the reason the
+strategy survives a losing streak.
+
+Read the `WARN` rows too. `Size capped` means the risk-derived size was reduced by the
+position cap or the reserve, so the trade will risk less than the target — that is fine,
+but say so.
+
+## Step 4 — Deploy
+
+Use the payload exactly as returned:
+
+```
+manage_executors(action="create", executor_type="position_executor", config=<payload>)
+```
+
+If the create fails, re-fetch the schema with `manage_executors(executor_type="position_executor")`,
+fix the payload against the returned fields, and retry **once**. Journal the error either
+way. Never retry a failed create more than once in the same tick — a schema error will
+not fix itself, and a rejected order usually means a balance or precision problem that
+another attempt will hit again.
+
+## Step 5 — Manage the position
+
+Re-run `band_state` on the same cadence you deployed at, and act on the transition, not
+on the level:
+
+- **Squeeze breakout that closes back inside the band within 2 candles** → the break
+  failed. Close it. Do not wait for the stop.
+- **Band walk where %B crosses back through 0.5** → the walk is over. Close it.
+- **Reversion trade that reaches the middle band** → take it. Holding for the opposite
+  band converts a 1.5R winner into a coin flip.
+- **Bandwidth collapsing back to a squeeze while in a position** → volatility is leaving.
+  Tighten to breakeven; there is no move left to capture.
+
+## Step 6 — Record what happened
+
+```
+manage_memory(action="add", content="<pair> <setup> resolved <outcome> — <what the bands did>")
+```
+
+Write down the bandwidth rank at entry and how the setup resolved. Over time this is what
+tells you whether `squeeze_rank=20` is the right threshold for this operator's markets or
+whether it needs to be 10.
+
+## Finding candidates
+
+When there is no specific pair in question, screen first:
+
+```
+manage_trading_agent(action="run_routine", strategy_id="bollinger_band_trader",
+                     name="squeeze_screener",
+                     config={"trading_pairs": "BTC-USDT,ETH-USDT,SOL-USDT", "interval": "1h"})
+```
+
+Then run `band_state` on the top candidates. A screener row is never a trade on its own —
+a squeeze has no direction.
+
+## Non-negotiables
+
+- Classify the regime before reading %B.
+- Never fade a band walk.
+- Never deploy without `band_trade_sizer` returning `PASS`.
+- Never widen a stop. The middle band moves on its own; that is the only stop movement
+  allowed, and only in your favor.
+- Max 3 concurrent Bollinger positions, and never two same-direction majors at once.
+
+This playbook is advisory text. Deploying an executor still goes through the normal
+risk and confirmation controls — following these steps is not a bypass.

--- a/agents/bollinger_band_trader/strategies/bb_squeeze_breakout/strategy.md
+++ b/agents/bollinger_band_trader/strategies/bb_squeeze_breakout/strategy.md
@@ -50,21 +50,26 @@ per trade and every exit derived from the bands rather than from a fixed percent
 ### Step 1: Read the band state
 
 ```
-run_routine(name="band_state", config={"trading_pair": "<trading_pair>",
-                                       "connector_name": "<connector_name>"})
+manage_routines(action="run", name="band_state",
+                strategy_id="bollinger_band_trader.bb_squeeze_breakout",
+                config={"trading_pair": "<trading_pair>",
+                        "connector_name": "<connector_name>"})
 ```
 
 Extract `setup`, `bias`, `entry`, `stop`, `target`, `rr`, and the per-timeframe verdicts.
 
 ### Step 2: Check what is already open
 
-```
-manage_executors(action="list", status="active")
-```
+**Do NOT call a tool for this.** Your open executors and positions are already in
+`[CORE DATA - executors]` and `[CORE DATA - positions]`, and your usage against the caps
+is in `[RISK STATE]`. Read them.
 
-Count active executors **for this pair**. If the count is at or above
-`max_open_executors` from `[CURRENT CONFIG]`, skip to Step 5 (manage only). Never open a
-second position in the same direction on the same pair.
+If open executors for this pair are at or above `max_open_executors` from `[RISK STATE]`,
+skip to Step 5 (manage only). Never open a second position in the same direction on the
+same pair.
+
+Querying this costs a tool round-trip that resends the whole context, and a mis-guessed
+argument schema will abort the tick on a retry. The data is already in front of you.
 
 ### Step 3: Decide
 
@@ -90,11 +95,12 @@ manage_skill(action="read", name="bollinger_playbook")
 **Never size by hand.** Run the sizer with the levels the state routine produced:
 
 ```
-run_routine(name="band_trade_sizer",
-            config={"trading_pair": "<trading_pair>", "connector_name": "<connector_name>",
-                    "side": "<bias>", "entry_price": <entry>, "stop_price": <stop>,
-                    "target_price": <target>, "risk_pct": 0.5,
-                    "max_position_pct": 10, "reserve_pct": 20, "leverage": <leverage>})
+manage_routines(action="run", name="band_trade_sizer",
+                strategy_id="bollinger_band_trader.bb_squeeze_breakout",
+                config={"trading_pair": "<trading_pair>", "connector_name": "<connector_name>",
+                        "side": "<bias>", "entry_price": <entry>, "stop_price": <stop>,
+                        "target_price": <target>, "risk_pct": 0.5,
+                        "max_position_pct": 10, "reserve_pct": 20, "leverage": <leverage>})
 ```
 
 If `verdict` is `FAIL`, journal `blocked_by` and hold. Do not adjust inputs to force a

--- a/agents/bollinger_band_trader/strategies/bb_squeeze_breakout/strategy.md
+++ b/agents/bollinger_band_trader/strategies/bb_squeeze_breakout/strategy.md
@@ -1,0 +1,204 @@
+---
+name: BB Squeeze Breakout
+description: Loop strategy that watches for a Bollinger squeeze on the configured pair, trades
+  the expansion with a position executor, and manages the exit off the bands.
+agent_key: null
+skills:
+- bollinger_playbook
+default_config:
+  frequency_sec: 900
+  total_amount_quote: 500
+  execution_mode: dry_run
+  risk_limits:
+    max_position_size_quote: 200
+    max_open_executors: 3
+default_trading_context: ''
+created_at: '2026-07-29T00:00:00+00:00'
+---
+
+# BB Squeeze Breakout
+
+You are the Bollinger Band Trader's execution strategy. Each tick you read the band
+state on the configured pair and either open a position, manage an open one, or do
+nothing. **Doing nothing is the most common correct outcome.** A squeeze that has not
+fired is not a trade.
+
+## Configuration at launch
+
+`trading_pair` and `connector_name` are **always provided at launch** — read them from
+`[CURRENT CONFIG]`. They are never baked into this strategy. If either is missing, abort
+the tick and notify the user:
+
+> "trading_pair and connector_name are required. Launch with: trading_context='Trade BB squeezes on PAIR on CONNECTOR'"
+
+If `trading_context` is present instead, parse the pair and connector out of it
+(e.g. "Trade BB squeezes on SOL-USDT on binance_perpetual" → pair=SOL-USDT,
+connector=binance_perpetual).
+
+Default tick frequency is 900s (15m), matching the entry timeframe. Running faster than
+the entry candle does not produce new information — it produces duplicate signals.
+
+## Objective
+
+Capture the expansion out of a Bollinger squeeze on the configured pair, with risk fixed
+per trade and every exit derived from the bands rather than from a fixed percentage.
+
+---
+
+## Each tick — step by step
+
+### Step 1: Read the band state
+
+```
+run_routine(name="band_state", config={"trading_pair": "<trading_pair>",
+                                       "connector_name": "<connector_name>"})
+```
+
+Extract `setup`, `bias`, `entry`, `stop`, `target`, `rr`, and the per-timeframe verdicts.
+
+### Step 2: Check what is already open
+
+```
+manage_executors(action="list", status="active")
+```
+
+Count active executors **for this pair**. If the count is at or above
+`max_open_executors` from `[CURRENT CONFIG]`, skip to Step 5 (manage only). Never open a
+second position in the same direction on the same pair.
+
+### Step 3: Decide
+
+Exactly one of:
+
+- **HOLD** — `setup` is `no_trade` or `squeeze_pending`, or a position is already open and
+  its exit condition has not triggered. Journal the reading and stop.
+- **OPEN** — `setup` is a tradeable setup, no position is open on this pair, and the
+  executor cap allows it. Go to Step 4.
+- **CLOSE** — a position is open and its exit condition (Step 5) has triggered.
+- **ABORT** — the routine returned an error or the market data is stale. Journal it and
+  wait for the next tick. Do not trade on a partial reading.
+
+The tradeable setups and their rules are in the `bollinger_playbook` skill. Read it if you
+are unsure which exit applies:
+
+```
+manage_skill(action="read", name="bollinger_playbook")
+```
+
+### Step 4: Size, then open
+
+**Never size by hand.** Run the sizer with the levels the state routine produced:
+
+```
+run_routine(name="band_trade_sizer",
+            config={"trading_pair": "<trading_pair>", "connector_name": "<connector_name>",
+                    "side": "<bias>", "entry_price": <entry>, "stop_price": <stop>,
+                    "target_price": <target>, "risk_pct": 0.5,
+                    "max_position_pct": 10, "reserve_pct": 20, "leverage": <leverage>})
+```
+
+If `verdict` is `FAIL`, journal `blocked_by` and hold. Do not adjust inputs to force a
+pass.
+
+If `verdict` is `PASS`, create the executor with the payload it returned:
+
+```
+manage_executors(action="create", executor_type="position_executor", config=<payload>)
+```
+
+### Step 5: Manage the open position
+
+Re-read `band_state` output against the open position and close when:
+
+| Setup opened | Close when |
+|---|---|
+| `squeeze_breakout_*` | Price closes back inside the band within 2 candles of entry |
+| `band_walk_*` | `%B` crosses back through 0.5 on the entry timeframe |
+| `reversion_*` | Price reaches the middle band (`%B` ≈ 0.5) |
+| `failed_breakout_*` | Price reaches the middle band, then trail to breakeven |
+| any | Entry-timeframe bandwidth falls back to `bw_rank ≤ 20` — volatility left, no move remains |
+
+Close with:
+
+```
+manage_executors(action="stop", executor_id="<id>")
+```
+
+The triple barrier already carries the hard stop and take-profit. These rules exist to
+exit *before* the stop when the setup's premise is gone.
+
+---
+
+## position_executor — full config schema
+
+`amount` is in **base currency**, not quote. Convert with `amount = notional_quote / entry_price`.
+The sizer already does this; only compute it yourself if the sizer is unavailable, and if
+it is unavailable, hold instead.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `connector_name` | str | yes | From `[CURRENT CONFIG]` |
+| `trading_pair` | str | yes | From `[CURRENT CONFIG]` |
+| `side` | int | yes | 1 = BUY/LONG, 2 = SELL/SHORT |
+| `amount` | float | yes | **Base currency**, e.g. 0.01 BTC |
+| `entry_price` | float | no | Limit entry. Omit for a market entry |
+| `leverage` | int | no | Default 1. Cap at 5, and only on a confirmed breakout |
+| `triple_barrier_config.stop_loss` | float | yes | Decimal fraction, e.g. 0.02 = 2% |
+| `triple_barrier_config.take_profit` | float | yes | Decimal fraction |
+| `triple_barrier_config.time_limit` | int | no | Seconds; use 4× the tick frequency for reversions |
+| `triple_barrier_config.open_order_type` | int | no | 1=MARKET, 2=LIMIT, 3=LIMIT_MAKER |
+| `triple_barrier_config.stop_loss_order_type` | int | no | Use 1 (MARKET) — a stop must fill |
+| `triple_barrier_config.take_profit_order_type` | int | no | Use 2 (LIMIT) |
+| `triple_barrier_config.trailing_stop.activation_price` | float | no | Price delta to arm the trail |
+| `triple_barrier_config.trailing_stop.trailing_delta` | float | no | Trailing distance |
+
+Before the first create of a session, fetch the live schema and reconcile it with the
+table above — the API is the authority:
+
+```
+manage_executors(executor_type="position_executor")
+```
+
+### Parameter inference from the routine output
+
+- `side` — 1 when `bias` is `long`, 2 when `short`
+- `entry_price` — `setup.entry`
+- `stop_loss` — `abs(entry − stop) / entry`
+- `take_profit` — `abs(target − entry) / entry`
+- `amount` — from `band_trade_sizer`, never computed inline
+- `leverage` — 1 by default; up to 3 on a `squeeze_breakout_*` with `rr ≥ 2.0`; never above 5
+
+---
+
+## Risk rules
+
+- Fixed risk per trade: **0.5%** of portfolio. Never raise it to make a small account
+  trade — take the `FAIL` instead.
+- Respect `max_position_size_quote` and `max_open_executors` from `[CURRENT CONFIG]` as
+  hard ceilings, on top of the sizer's own caps.
+- Keep **20%** of the quote balance unallocated at all times.
+- One position per pair. Maximum 3 concurrent across all pairs.
+- Never widen a stop after entry. Trailing the middle band in your favor is the only
+  permitted stop movement.
+- No new entries when the entry timeframe and the trend timeframe disagree in direction.
+- On perpetuals, if funding exceeds 0.01% per 8h against an open position, shorten the
+  target rather than holding for the full move.
+
+## Error recovery
+
+If a routine or an executor call fails:
+
+1. Journal the error with the tick number and the full response.
+2. For a create failure: re-fetch the schema
+   (`manage_executors(executor_type="position_executor")`), fix the payload, retry **once**.
+3. If it fails again, hold until the next tick. Do not fall back to a market order and do
+   not resize.
+4. If `band_state` itself fails twice in a row, notify the user — the strategy is blind
+   without it and should not keep ticking silently.
+
+## Dry run
+
+Launch in `dry_run` first. In dry run, describe every action conditionally ("would open a
+long of 0.42 SOL at 148.20, stop 145.10") and make **no** create or stop calls. Review the
+journal for: correct routine calls, the veto rules actually applied, sizing that respects
+the caps, and no live mutations. Only then go live.

--- a/agents/bollinger_band_trader/validation.md
+++ b/agents/bollinger_band_trader/validation.md
@@ -1,0 +1,107 @@
+# Validation
+
+What was verified before this agent was proposed, how, and what remains unverified.
+
+## Running the tests
+
+```bash
+uv run pytest tests/test_bollinger_band_trader.py -v
+```
+
+58 tests, ~1.7s, no network and no Hummingbot server required. The routines are loaded by
+file path exactly the way `discover_routines_from_path` loads agent-local routines at
+runtime, and driven against a fake client with synthetic candles. `ReportBuilder` is
+stubbed so the suite never writes into `reports/`.
+
+The full repo suite was run alongside it: **286 passed, 5 skipped**.
+
+## What is covered
+
+**Band math** — the middle band equals the SMA, the outer bands are `mid ± 2σ` using
+*population* standard deviation (the Bollinger definition; the test asserts the sample
+deviation would give a different answer, so a swap cannot slip through), %B and bandwidth
+match their formulas, a zero-variance series does not divide by zero, and the percentile
+rank handles empty history, the extremes, and ties at half weight.
+
+**Indicator helpers** — SMA/EMA series shapes and seeding, and true range using the
+previous close across a gap.
+
+**ADX** — high on a pure trend, below the trend threshold in a bounded range, bounded to
+0–100, returns 0 rather than raising on short input, and never saturates.
+
+**Classification** — one engineered fixture per regime (coil, firing coil, steady grind,
+bounded range at each band), plus a sweep asserting that **every** verdict is reachable on
+realistic data. A branch that never fires is dead code, and the sweep is what catches it.
+
+**Setup derivation** — each setup's entry, stop and target are checked against the band
+level they are supposed to come from (breakout stops at the middle band and targets 2R;
+the band walk enters at the mean and targets the opposite band; the reversion enters at
+the band and targets the mean). All three rejection gates are tested: the
+higher-timeframe veto in both directions, the below-average-volume breakout filter, and
+the R:R floor.
+
+**A 2,400-case fuzz** runs every regime fixture against every trend verdict and asserts
+that no emitted setup ever has an inverted stop or target. This is the check that matters
+most — an inverted stop is an instant loss, not a bad trade.
+
+**Sizing** — the notional is derived from the stop distance so risk is constant, the
+position cap and the reserve each bind correctly, and a capped size is surfaced as a WARN
+rather than silently reducing risk. Every guardrail is tested for the FAIL it should
+produce, and a failing check is asserted to emit **no** executor payload.
+
+**Payload shape** — `side` maps 1/2, `stop_loss` and `take_profit` are decimal fractions
+rather than prices, and the connector/pair fields are present. This is checked against the
+schema in `mcp_servers/hummingbot_api/guides/position_executor.md`.
+
+**Degradation** — no candles, a connector that raises, a watchlist where nothing has
+enough history, an unknown portfolio value, and an invalid `side` all produce a clean
+message instead of an exception or a silently wrong number.
+
+**Round trip** — `band_state`'s levels are parsed out of its own summary and fed into
+`band_trade_sizer`, asserting the two routines agree on R:R. The handoff between them is
+the seam most likely to rot.
+
+## Bugs the tests found
+
+Three defects were found by testing and fixed before this PR. Each now has a named
+regression test.
+
+**1. A firing squeeze reported `squeeze_pending`.** The squeeze check ran before the
+expansion check. Bandwidth rank is computed from history, so on the exact candle a coil
+breaks, the rank is still low — the routine classified the breakout bar as a squeeze and
+told the agent to stand aside on the one bar the entire setup exists to trade. Fixed by
+testing expansion first. → `test_firing_coil_reads_as_expansion_not_squeeze`
+
+**2. `reversion_range` was unreachable.** ADX started as a raw single-window DX, which
+saturates near 100 on any sustained directional push. Reaching a Bollinger band *is* a
+directional push, so every band tag read as a trend. Measured: across 600 synthetic
+ranges, a band tag never once produced a reversion verdict. Replaced with Wilder's
+smoothed ADX, after which the setup fires normally. → `test_adx_does_not_pin_at_100_in_a_range`
+
+**3. A capped position size rendered as PASS.** When the position cap or the reserve
+reduced the size, the check row showed PASS, so the operator had no signal that the trade
+was risking less than the configured target. Now emitted as an explicit WARN row. →
+`test_capped_size_is_reported_as_a_warn_row`
+
+A fourth, smaller issue surfaced while calibrating: the band-walk threshold was `%B ≥ 0.95`,
+which a smooth trend never reaches — it rides at 0.90–0.93. Relaxed to the top decile and
+gated on ADX > 25 so a range cannot be mistaken for a walk.
+
+## What is NOT validated
+
+- **No live exchange run.** Every test uses synthetic candles through a fake client. The
+  routines have not been executed against a real Hummingbot API, so connector-specific
+  response shapes (candle key names, funding payloads) are handled defensively but
+  unproven. Run `band_state` manually against a real server before launching a loop.
+- **No profitability claim.** Nothing here is a backtest. The tests prove the agent
+  computes what it says it computes and refuses what it says it refuses — not that the
+  setups make money. `run_backtest` against a controller would be the next step, and the
+  thresholds (`squeeze_rank`, the R:R floors, the ADX split) should be treated as
+  starting points to be tuned per market.
+- **No executor was created.** `manage_executors` is never called in the tests; only the
+  payload shape is checked against the documented schema. The first real deploy should be
+  a `dry_run` session, as the strategy's own instructions require.
+- **Synthetic fixtures are not market data.** A reflecting random walk is a reasonable
+  stand-in for a range and an exponential curve for a trend, but neither reproduces real
+  microstructure, gaps, or volume behaviour. The reachability sweep says the branches can
+  fire, not how often they will fire live.

--- a/condor/acp/pydantic_ai_client.py
+++ b/condor/acp/pydantic_ai_client.py
@@ -33,6 +33,11 @@ from .client import (
 log = logging.getLogger(__name__)
 
 
+# Tool-call retries before a run is abandoned. pydantic-ai's default is 1, which
+# small/free models frequently exhaust on a mis-guessed argument schema.
+_TOOL_RETRIES = 4
+
+
 def _infer_tool_filter_mode(model_name: str) -> str:
     """Automatically detect the best tool filter mode based on model name.
 
@@ -508,7 +513,13 @@ class PydanticAIClient:
 
         model = self._build_model()
         prepare = self._prepare_tools if self.allowed_tools else None
-        self._agent = Agent(model, toolsets=toolsets, prepare_tools=prepare)
+        # pydantic-ai defaults to retries=1, which is too tight for small/cheap models:
+        # they routinely mis-guess a tool's argument schema on the first attempt, and a
+        # single retry is often not enough to recover. One aborted retry kills the whole
+        # tick, so a HOLD tick that did all its real work still reports an error.
+        self._agent = Agent(
+            model, toolsets=toolsets, prepare_tools=prepare, retries=_TOOL_RETRIES
+        )
 
         # Resolve the global semaphore for this server's base URL so all client
         # instances targeting the same local inference server share one request

--- a/tests/test_bollinger_band_trader.py
+++ b/tests/test_bollinger_band_trader.py
@@ -1,0 +1,740 @@
+"""Tests for the bollinger_band_trader agent routines.
+
+The routines carry the agent's decision logic — band math, regime classification, the
+higher-timeframe veto, and position sizing — so they are tested directly. Modules are
+loaded by file path, exactly the way ``discover_routines_from_path`` loads agent-local
+routines at runtime.
+
+Three of these tests are regressions for bugs found while building the agent:
+
+* ``test_firing_coil_reads_as_expansion_not_squeeze`` — the squeeze check used to run
+  before the expansion check, so the bar that fires the breakout still reported
+  ``squeeze_pending``: the agent went flat exactly when it should have traded.
+* ``test_adx_does_not_pin_at_100_in_a_range`` — the ADX started life as a raw
+  single-window DX, which saturates near 100 on any directional push. Since reaching a
+  Bollinger band *is* a directional push, ``reversion_range`` was unreachable.
+* ``test_capped_size_is_reported_as_a_warn_row`` — a size reduced by the position cap
+  was rendered as PASS, hiding the fact that the trade risks less than the target.
+"""
+
+import asyncio
+import importlib.util
+import math
+import random
+import statistics
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+ROUTINES_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "agents"
+    / "bollinger_band_trader"
+    / "routines"
+)
+
+
+def _load(name):
+    path = ROUTINES_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"agent_routine_bbt_{name}", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+band_state = _load("band_state")
+squeeze_screener = _load("squeeze_screener")
+band_trade_sizer = _load("band_trade_sizer")
+
+
+# ── Fixtures: synthetic candles engineered to produce each regime ────────────
+
+
+def _candles(prices, volumes=None):
+    out = []
+    for i, price in enumerate(prices):
+        prev = prices[i - 1] if i else price
+        out.append(
+            {
+                "timestamp": 1700000000 + i * 900,
+                "open": prev,
+                "high": max(price, prev) * 1.002,
+                "low": min(price, prev) * 0.998,
+                "close": price,
+                "volume": volumes[i] if volumes else 100.0,
+            }
+        )
+    return out
+
+
+def _coil(n=200, base=100.0):
+    """Wide swings, then a very tight coil at the end."""
+    prices = [base + 8 * math.sin(i / 4.0) for i in range(n - 40)]
+    return prices + [prices[-1] + 0.02 * math.sin(i / 3.0) for i in range(40)]
+
+
+def _coil_then_breakout(n=200):
+    prices = _coil(n - 3)
+    last = prices[-1]
+    return prices + [last * 1.02, last * 1.05, last * 1.09]
+
+
+_BREAKOUT_VOLUMES = [100.0] * 197 + [300.0, 320.0, 350.0]
+
+
+def _grind_up(n=200, base=100.0):
+    """Steady advance so closes sit in the top decile of the band."""
+    return [base * (1.004**i) for i in range(n)]
+
+
+def _bounded_walk(seed, n=200, low=94.0, high=106.0, step=2.2):
+    """Random walk reflecting off two levels — a realistic trading range."""
+    rnd = random.Random(seed)
+    price, out = 100.0, []
+    for _ in range(n):
+        price += rnd.uniform(-step, step)
+        if price > high:
+            price = high - (price - high)
+        if price < low:
+            price = low + (low - price)
+        out.append(price)
+    return out
+
+
+# Seeds found by sweeping _bounded_walk: the series ends at a band extreme while the
+# band itself is wide, flat and non-trending — a genuine reversion setup.
+RANGE_AT_LOWER_BAND = 543
+RANGE_AT_UPPER_BAND = 77
+
+NEUTRAL_TREND = {"timeframe": "trend_4h", "verdict": "neutral"}
+
+
+@pytest.fixture(scope="module")
+def cfg():
+    return band_state.Config()
+
+
+@pytest.fixture(scope="module")
+def coil_tf(cfg):
+    return band_state._analyze_timeframe(_candles(_coil()), "entry_15m", cfg)
+
+
+@pytest.fixture(scope="module")
+def breakout_tf(cfg):
+    return band_state._analyze_timeframe(
+        _candles(_coil_then_breakout(), _BREAKOUT_VOLUMES), "entry_15m", cfg
+    )
+
+
+@pytest.fixture(scope="module")
+def walk_tf(cfg):
+    return band_state._analyze_timeframe(_candles(_grind_up()), "entry_15m", cfg)
+
+
+@pytest.fixture(scope="module")
+def range_low_tf(cfg):
+    return band_state._analyze_timeframe(
+        _candles(_bounded_walk(RANGE_AT_LOWER_BAND)), "entry_15m", cfg
+    )
+
+
+@pytest.fixture(scope="module")
+def range_high_tf(cfg):
+    return band_state._analyze_timeframe(
+        _candles(_bounded_walk(RANGE_AT_UPPER_BAND)), "entry_15m", cfg
+    )
+
+
+# ── Band math ────────────────────────────────────────────────────────────────
+
+
+def test_bands_match_the_textbook_definition():
+    closes = [float(x) for x in range(1, 21)]
+    series = band_state._bollinger_series(closes, 20, 2.0)
+
+    assert all(
+        point is None for point in series[:19]
+    ), "band is undefined until the window fills"
+    band = series[19]
+
+    mid = sum(closes) / 20
+    sigma = statistics.pstdev(
+        closes
+    )  # population, not sample — the Bollinger definition
+    assert band["mid"] == pytest.approx(mid)
+    assert band["upper"] == pytest.approx(mid + 2 * sigma)
+    assert band["lower"] == pytest.approx(mid - 2 * sigma)
+    assert band["pct_b"] == pytest.approx(
+        (closes[-1] - band["lower"]) / (band["upper"] - band["lower"])
+    )
+    assert band["bandwidth_pct"] == pytest.approx(
+        (band["upper"] - band["lower"]) / band["mid"] * 100
+    )
+    # Guard the pstdev/stdev choice: they differ enough here that a swap would show up.
+    assert abs(sigma - statistics.stdev(closes)) > 1e-3
+
+
+def test_flat_series_does_not_divide_by_zero():
+    band = band_state._bollinger_series([50.0] * 25, 20, 2.0)[-1]
+    assert band["bandwidth_pct"] == 0.0
+    assert band["pct_b"] == 0.5
+
+
+@pytest.mark.parametrize(
+    "history,value,expected",
+    [
+        ([], 1.0, 50.0),
+        ([1, 2, 3, 4], 0.5, 0.0),
+        ([1, 2, 3, 4], 9.0, 100.0),
+        ([1, 2, 2, 3], 2.0, 50.0),  # 1 below + 2 ties at half weight
+    ],
+)
+def test_percentile_rank(history, value, expected):
+    assert band_state._percentile_rank(history, value) == expected
+
+
+def test_true_range_uses_the_previous_close_on_a_gap():
+    candles = [
+        {"high": 10, "low": 8, "close": 9},
+        {"high": 12, "low": 11, "close": 11.5},
+    ]
+    assert band_state._true_range_series(candles) == [2, 3]
+
+
+def test_ema_seeds_on_the_sma_then_smooths():
+    assert band_state._ema_series([1.0, 2.0, 3.0, 4.0, 5.0], 3)[2:] == [2.0, 3.0, 4.0]
+
+
+# ── ADX ──────────────────────────────────────────────────────────────────────
+
+
+def test_adx_separates_trend_from_range():
+    trending = band_state._calc_adx(_candles(_grind_up()))
+    ranging = band_state._calc_adx(_candles(_bounded_walk(RANGE_AT_LOWER_BAND)))
+    assert trending > 50
+    assert ranging < band_state._TREND_ADX
+    assert 0 <= ranging <= 100 and 0 <= trending <= 100
+
+
+def test_adx_returns_zero_rather_than_raising_on_short_input():
+    assert band_state._calc_adx(_candles([100.0] * 10)) == 0.0
+
+
+def test_adx_does_not_pin_at_100_in_a_range():
+    """Regression: the raw single-window DX saturated, making reversion unreachable."""
+    worst = max(
+        band_state._calc_adx(_candles(_bounded_walk(seed))) for seed in range(60)
+    )
+    assert (
+        worst < 70
+    ), f"ADX reached {worst:.1f} on a bounded range — smoothing is not being applied"
+
+
+# ── Classification ───────────────────────────────────────────────────────────
+
+
+def test_coil_classifies_as_squeeze(coil_tf):
+    assert coil_tf["verdict"] == "squeeze"
+    assert coil_tf["bw_rank"] <= 10
+    assert coil_tf["squeeze_on"] is True
+
+
+def test_firing_coil_reads_as_expansion_not_squeeze(breakout_tf):
+    """Regression: bandwidth rank is still low on the bar that breaks the band.
+
+    Checking the squeeze first meant the breakout bar reported `squeeze_pending`, i.e.
+    the agent stood aside on the one candle the whole setup exists to trade.
+    """
+    assert breakout_tf["verdict"] == "expansion_up"
+    assert breakout_tf["pct_b"] > 1.0
+    assert breakout_tf["bw_rank"] <= band_state.Config().squeeze_rank
+
+
+def test_grind_classifies_as_band_walk(walk_tf):
+    assert walk_tf["verdict"] == "band_walk_up"
+    assert walk_tf["adx"] > band_state._TREND_ADX
+
+
+def test_bounded_range_at_a_band_classifies_as_reversion(range_low_tf, range_high_tf):
+    assert range_low_tf["verdict"] == "reversion_range"
+    assert range_low_tf["pct_b"] <= 0.05
+    assert range_high_tf["verdict"] == "reversion_range"
+    assert range_high_tf["pct_b"] >= 0.95
+
+
+def test_thin_data_returns_an_error_instead_of_raising(cfg):
+    assert "error" in band_state._analyze_timeframe(
+        _candles([100.0] * 5), "entry_15m", cfg
+    )
+
+
+@pytest.mark.parametrize(
+    "pct_bs,expected",
+    [
+        ([-0.2, -0.1, 0.4], "bullish"),
+        ([1.2, 1.1, 0.6], "bearish"),
+        ([0.4, 0.5, 0.6], ""),
+        ([1.2, 1.1, 1.3], ""),  # still outside — not a failure yet
+    ],
+)
+def test_failed_breakout_detection(pct_bs, expected):
+    assert band_state._failed_breakout([{"pct_b": v} for v in pct_bs]) == expected
+
+
+def test_every_verdict_is_reachable(cfg, breakout_tf, walk_tf):
+    """A classification branch that never fires on realistic data is dead code."""
+    seen = Counter()
+    for seed in range(400):
+        frame = band_state._analyze_timeframe(_candles(_bounded_walk(seed)), "e", cfg)
+        if "error" not in frame:
+            seen[frame["verdict"]] += 1
+    seen[breakout_tf["verdict"]] += 1
+    seen[walk_tf["verdict"]] += 1
+
+    assert {
+        "squeeze",
+        "expansion_up",
+        "expansion_down",
+        "band_walk_up",
+        "band_walk_down",
+        "reversion_range",
+        "neutral",
+    } <= set(seen), f"unreachable verdicts; saw {dict(seen)}"
+
+
+# ── Setup derivation ─────────────────────────────────────────────────────────
+
+
+def test_squeeze_reports_triggers_but_no_position(coil_tf, cfg):
+    setup = band_state._derive_setup(coil_tf, NEUTRAL_TREND, cfg)
+    assert setup["setup"] == "squeeze_pending"
+    assert setup["bias"] == "none"
+    assert setup["long_trigger"] > setup["short_trigger"]
+    assert "entry" not in setup
+
+
+def test_breakout_stops_at_the_middle_band_and_targets_2r(breakout_tf, cfg):
+    setup = band_state._derive_setup(breakout_tf, NEUTRAL_TREND, cfg)
+    assert setup["setup"] == "squeeze_breakout_long"
+    assert setup["stop"] == pytest.approx(breakout_tf["mid"])
+    assert setup["rr"] == pytest.approx(2.0)
+
+
+def test_band_walk_buys_the_pullback_to_the_mean(walk_tf, cfg):
+    setup = band_state._derive_setup(walk_tf, NEUTRAL_TREND, cfg)
+    assert setup["setup"] == "band_walk_long"
+    assert setup["entry"] == pytest.approx(walk_tf["mid"])
+    assert setup["target"] == pytest.approx(walk_tf["upper"])
+
+
+def test_reversion_fades_the_band_back_to_the_mean(range_low_tf, cfg):
+    setup = band_state._derive_setup(range_low_tf, NEUTRAL_TREND, cfg)
+    assert setup["setup"] == "reversion_long"
+    assert setup["entry"] == pytest.approx(range_low_tf["lower"])
+    assert setup["target"] == pytest.approx(range_low_tf["mid"])
+    assert setup["stop"] < range_low_tf["lower"]
+
+
+@pytest.mark.parametrize("trend_verdict", ["band_walk_down", "expansion_down"])
+def test_reversion_long_is_vetoed_by_an_opposing_trend(
+    range_low_tf, cfg, trend_verdict
+):
+    setup = band_state._derive_setup(
+        range_low_tf, {"timeframe": "trend_4h", "verdict": trend_verdict}, cfg
+    )
+    assert setup["setup"] == "no_trade"
+    assert "do not fade" in setup["reason"]
+
+
+@pytest.mark.parametrize("trend_verdict", ["band_walk_up", "expansion_up"])
+def test_reversion_short_is_vetoed_by_an_opposing_trend(
+    range_high_tf, cfg, trend_verdict
+):
+    setup = band_state._derive_setup(
+        range_high_tf, {"timeframe": "trend_4h", "verdict": trend_verdict}, cfg
+    )
+    assert setup["setup"] == "no_trade"
+    assert "do not fade" in setup["reason"]
+
+
+def test_breakout_is_vetoed_by_an_opposing_trend(breakout_tf, cfg):
+    setup = band_state._derive_setup(
+        breakout_tf, {"timeframe": "trend_4h", "verdict": "band_walk_down"}, cfg
+    )
+    assert setup["setup"] == "no_trade"
+
+
+def test_breakout_on_thin_volume_waits_for_the_retest(breakout_tf, cfg):
+    setup = band_state._derive_setup(
+        dict(breakout_tf, vol_ratio=0.4), NEUTRAL_TREND, cfg
+    )
+    assert setup["setup"] == "no_trade"
+    assert "volume" in setup["reason"]
+
+
+def test_reward_risk_floor_rejects_a_thin_setup(range_low_tf):
+    setup = band_state._derive_setup(
+        range_low_tf, NEUTRAL_TREND, band_state.Config(min_rr_reversion=99.0)
+    )
+    assert setup["setup"] == "no_trade"
+    assert "R:R" in setup["reason"]
+
+
+def test_errored_timeframe_yields_no_trade(cfg):
+    setup = band_state._derive_setup(
+        {"timeframe": "entry_15m", "error": "insufficient candles"}, NEUTRAL_TREND, cfg
+    )
+    assert setup["setup"] == "no_trade"
+
+
+def test_levels_are_always_ordered_correctly(cfg):
+    """Fuzz every regime against every trend verdict: no inverted stop may escape."""
+    violations = []
+    for seed in range(400):
+        frame = band_state._analyze_timeframe(
+            _candles(_bounded_walk(seed)), "entry_15m", cfg
+        )
+        if "error" in frame:
+            continue
+        for trend in (
+            "neutral",
+            "band_walk_up",
+            "band_walk_down",
+            "expansion_up",
+            "expansion_down",
+            "squeeze",
+        ):
+            setup = band_state._derive_setup(
+                frame, {"timeframe": "trend_4h", "verdict": trend}, cfg
+            )
+            if setup["setup"] in ("no_trade", "squeeze_pending"):
+                continue
+            ordered = (
+                setup["stop"] < setup["entry"] < setup["target"]
+                if setup["bias"] == "long"
+                else setup["stop"] > setup["entry"] > setup["target"]
+            )
+            if not ordered:
+                violations.append((seed, trend, setup))
+    assert not violations, f"{len(violations)} setups had an inverted stop/target"
+
+
+# ── Fake Hummingbot client for the run() entrypoints ─────────────────────────
+
+
+class _MarketData:
+    def __init__(self, by_interval=None, by_pair=None, prices=None):
+        self.by_interval = by_interval or {}
+        self.by_pair = by_pair or {}
+        self.prices = prices or {}
+
+    async def get_candles(self, connector, pair, interval="1m", max_records=100):
+        if self.by_pair:
+            return self.by_pair.get(pair, [])[-max_records:]
+        return self.by_interval.get(interval, [])[-max_records:]
+
+    async def get_prices(self, connector, trading_pairs):
+        return {p: self.prices.get(p, 0.0) for p in trading_pairs}
+
+
+class _Portfolio:
+    def __init__(self, total):
+        self.total = total
+
+    async def get_total_value(self):
+        return self.total
+
+
+class _Client:
+    def __init__(self, market_data, portfolio=10000.0):
+        self.market_data = market_data
+        self.portfolio = _Portfolio(portfolio)
+
+
+class _Context:
+    _chat_id = 1
+
+
+class _NullReportBuilder:
+    """Swallows report calls so tests never write into reports/."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __getattr__(self, _name):
+        return lambda *a, **k: self
+
+    async def save(self, report_id=None):
+        return "test-report"
+
+
+@pytest.fixture(autouse=True)
+def _no_report_writes(monkeypatch):
+    monkeypatch.setattr("condor.reports.ReportBuilder", _NullReportBuilder)
+
+
+def _with_client(module, client):
+    async def _get_client(*_a, **_k):
+        return client
+
+    module.get_client = _get_client
+
+
+# ── band_state.run() ─────────────────────────────────────────────────────────
+
+
+def test_run_reports_the_firing_breakout_end_to_end():
+    _with_client(
+        band_state,
+        _Client(
+            _MarketData(
+                by_interval={
+                    "15m": _candles(_coil_then_breakout(), _BREAKOUT_VOLUMES),
+                    "1h": _candles(_coil()),
+                    "4h": _candles(_grind_up()),
+                }
+            )
+        ),
+    )
+    out = asyncio.run(
+        band_state.run(band_state.Config(trading_pair="TEST-USDT"), _Context())
+    )
+
+    assert "setup: squeeze_breakout_long" in out
+    assert "entry_tf:" in out and "context_tf:" in out and "trend_tf:" in out
+
+
+def test_run_degrades_gracefully_without_data():
+    _with_client(band_state, _Client(_MarketData()))
+    out = asyncio.run(
+        band_state.run(band_state.Config(trading_pair="TEST-USDT"), _Context())
+    )
+    assert "No candle data" in out
+
+
+def test_run_survives_a_raising_connector():
+    class _Broken(_MarketData):
+        async def get_candles(self, *a, **k):
+            raise RuntimeError("connector down")
+
+    _with_client(band_state, _Client(_Broken()))
+    out = asyncio.run(
+        band_state.run(band_state.Config(trading_pair="TEST-USDT"), _Context())
+    )
+    assert "No candle data" in out
+
+
+# ── squeeze_screener.run() ───────────────────────────────────────────────────
+
+
+def test_screener_ranks_the_tightest_band_first():
+    _with_client(
+        squeeze_screener,
+        _Client(
+            _MarketData(
+                by_pair={
+                    "TIGHT-USDT": _candles(_coil()),
+                    "WIDE-USDT": _candles(_bounded_walk(RANGE_AT_LOWER_BAND)),
+                    "TREND-USDT": _candles(_grind_up()),
+                    "THIN-USDT": _candles([100.0] * 5),
+                }
+            )
+        ),
+    )
+    result = asyncio.run(
+        squeeze_screener.run(
+            squeeze_screener.Config(
+                trading_pairs="TIGHT-USDT,WIDE-USDT,TREND-USDT,THIN-USDT"
+            ),
+            _Context(),
+        )
+    )
+
+    pairs = [row["Pair"] for row in result.table_data]
+    assert pairs[0] == "TIGHT-USDT"
+    assert result.table_data[0]["State"] in ("squeeze", "firing")
+    assert (
+        "THIN-USDT" not in pairs
+    ), "pairs without enough history must be skipped, not guessed"
+    assert "THIN-USDT" in result.text, "and the skip must be reported"
+
+
+def test_screener_distinguishes_a_firing_coil_from_a_resting_one():
+    _with_client(
+        squeeze_screener,
+        _Client(
+            _MarketData(
+                by_pair={
+                    "FIRING-USDT": _candles(_coil_then_breakout(), _BREAKOUT_VOLUMES)
+                }
+            )
+        ),
+    )
+    result = asyncio.run(
+        squeeze_screener.run(
+            squeeze_screener.Config(trading_pairs="FIRING-USDT"), _Context()
+        )
+    )
+    assert result.table_data[0]["State"] == "firing"
+
+
+def test_screener_handles_an_empty_watchlist():
+    _with_client(squeeze_screener, _Client(_MarketData()))
+    result = asyncio.run(
+        squeeze_screener.run(
+            squeeze_screener.Config(trading_pairs="NOPE-USDT"), _Context()
+        )
+    )
+    assert "No usable candle data" in result.text
+
+
+# ── band_trade_sizer.run() ───────────────────────────────────────────────────
+
+
+def _size(**overrides):
+    _with_client(
+        band_trade_sizer,
+        _Client(
+            _MarketData(
+                by_interval={"15m": _candles(_bounded_walk(RANGE_AT_LOWER_BAND))},
+                prices={"TEST-USDT": 100.0},
+            ),
+            portfolio=overrides.pop("portfolio", 10000.0),
+        ),
+    )
+    config = dict(trading_pair="TEST-USDT", side="long", portfolio_value_quote=10000.0)
+    config.update(overrides)
+    return asyncio.run(
+        band_trade_sizer.run(band_trade_sizer.Config(**config), _Context())
+    )
+
+
+def test_size_is_derived_from_the_stop_distance():
+    # 0.5% of $10,000 = $50 risk over a 10% stop -> $500 notional, under every cap.
+    result = _size(entry_price=100.0, stop_price=90.0)
+    assert "verdict: PASS" in result.text
+    assert "notional_quote: $500.00" in result.text
+    assert "risk_if_stopped: $50.00" in result.text
+    assert '"amount": 5.0' in result.text
+
+
+def test_capped_size_is_reported_as_a_warn_row():
+    """Regression: a capped size rendered as PASS and hid the reduced risk."""
+    # A 2% stop wants $2,500 of notional; max_position_pct caps it at $1,000.
+    result = _size(entry_price=100.0, stop_price=98.0)
+    assert "verdict: PASS" in result.text
+    assert "notional_quote: $1,000.00" in result.text
+    assert any(
+        r["Check"] == "Size capped" and r["Result"] == "WARN" for r in result.table_data
+    )
+
+
+def test_uncapped_size_emits_no_cap_warning():
+    result = _size(entry_price=100.0, stop_price=90.0)
+    assert not any(r["Check"] == "Size capped" for r in result.table_data)
+
+
+def test_payload_matches_the_position_executor_schema():
+    result = _size(entry_price=100.0, stop_price=98.0, target_price=104.0)
+    assert '"side": 1' in result.text
+    assert (
+        '"stop_loss": 0.02' in result.text
+    ), "stop_loss is a decimal fraction, not a price"
+    assert '"take_profit": 0.04' in result.text
+    assert '"connector_name"' in result.text and '"trading_pair"' in result.text
+
+
+def test_short_maps_to_executor_side_two():
+    result = _size(side="short", entry_price=100.0, stop_price=102.0)
+    assert "verdict: PASS" in result.text
+    assert '"side": 2' in result.text
+
+
+@pytest.mark.parametrize(
+    "alias,expected_side", [("buy", 1), ("BUY", 1), ("sell", 2), ("2", 2)]
+)
+def test_side_aliases(alias, expected_side):
+    stop = 98.0 if expected_side == 1 else 102.0
+    result = _size(side=alias, entry_price=100.0, stop_price=stop)
+    assert f'"side": {expected_side}' in result.text
+
+
+def test_invalid_side_is_rejected_cleanly():
+    result = _size(side="sideways")
+    assert "Invalid side" in result.text
+
+
+@pytest.mark.parametrize(
+    "overrides,failing_check",
+    [
+        ({"entry_price": 100.0, "stop_price": 102.0}, "Stop on the protective side"),
+        ({"entry_price": 100.0, "stop_price": 99.99}, "Stop distance sane"),
+        (
+            {"entry_price": 100.0, "stop_price": 98.0, "risk_pct": 5.0},
+            "Risk per trade within policy",
+        ),
+        (
+            {"entry_price": 100.0, "stop_price": 98.0, "leverage": 20},
+            "Leverage within policy",
+        ),
+        (
+            {"entry_price": 100.0, "stop_price": 98.0, "portfolio_value_quote": 20.0},
+            "Meets exchange minimum notional",
+        ),
+    ],
+)
+def test_guardrails_block_the_trade(overrides, failing_check):
+    result = _size(**overrides)
+    assert "verdict: FAIL" in result.text
+    assert any(
+        r["Check"] == failing_check and r["Result"] == "FAIL" for r in result.table_data
+    )
+    assert (
+        "position_executor payload" not in result.text
+    ), "a failed check must not emit a payload"
+
+
+def test_unknown_portfolio_value_fails_instead_of_sizing_on_zero():
+    result = _size(
+        entry_price=100.0, stop_price=98.0, portfolio_value_quote=0.0, portfolio=0.0
+    )
+    assert "verdict: FAIL" in result.text
+
+
+def test_stop_is_derived_from_the_bands_when_none_is_given():
+    result = _size()
+    stop_line = result.text.split("stop:")[1].splitlines()[0]
+    assert "supplied" not in stop_line
+    assert "band" in stop_line, stop_line
+
+
+# ── Round trip ───────────────────────────────────────────────────────────────
+
+
+def test_band_state_levels_feed_straight_into_the_sizer():
+    _with_client(
+        band_state,
+        _Client(
+            _MarketData(
+                by_interval={"15m": _candles(_bounded_walk(RANGE_AT_LOWER_BAND))}
+            )
+        ),
+    )
+    summary = asyncio.run(
+        band_state.run(band_state.Config(trading_pair="TEST-USDT"), _Context())
+    )
+    fields = dict(
+        line.split(": ", 1)
+        for line in summary.splitlines()
+        if ": " in line and not line.startswith("**")
+    )
+
+    result = _size(
+        entry_price=float(fields["entry"].replace(",", "")),
+        stop_price=float(fields["stop"].replace(",", "")),
+        target_price=float(fields["target"].replace(",", "")),
+    )
+    assert "verdict: PASS" in result.text
+    sizer_rr = float(result.text.split("rr: ")[1].splitlines()[0])
+    assert sizer_rr == pytest.approx(float(fields["rr"]), abs=0.01)


### PR DESCRIPTION
A directional volatility-band agent built around a two-stage decision: **classify the volatility regime first, read %B second.**

The same band touch is a fade in a flat range and a buy signal out of a squeeze. Treating the touch itself as the signal is where this indicator normally loses money, so every routine, veto and exit rule here serves that ordering.

## What's added

```
agents/bollinger_band_trader/
  AGENT.md                                   # identity, the four setups, veto rules, risk defaults
  HOW_IT_WORKS.md                            # data sources, indicator math, classification table, limits
  validation.md                              # what was verified, what wasn't
  routines/band_state.py                     # primary read: classify + derive entry/stop/target
  routines/squeeze_screener.py               # rank a watchlist by squeeze tightness
  routines/band_trade_sizer.py               # risk sizing + pre-trade guardrails
  skills/bollinger_playbook/SKILL.md         # classify → size → deploy → manage
  strategies/bb_squeeze_breakout/strategy.md # optional loop playbook (defaults to dry_run)
tests/test_bollinger_band_trader.py          # 58 tests
```

The agent is useful at every layer: consulted with no loop running it answers band questions from the routines; given the strategy it can run the same logic unattended.

## The four setups

| Setup | Entry | Stop | Target |
|---|---|---|---|
| Squeeze breakout | close beyond the band | middle band | 2R, then trail the mean |
| Band walk | pullback to the middle band | 1 ATR past the mean | opposite band |
| Range reversion | at the band | 0.5 ATR beyond it | middle band |
| Failed breakout | on the close back inside | beyond the failure extreme | middle band, then opposite |

Three gates can turn any of them into `no_trade`: the higher-timeframe veto (never fade a 4h band walk), a reward:risk floor (1.5 continuation / 1.2 reversion), and a volume filter on breakouts.

## Routines

**`band_state`** — BB(20, 2), %B, bandwidth, and the **percentile rank of that bandwidth within its own 200-period history** across 15m / 1h / 4h. The percentile is what makes this work across assets: raw bandwidth of 1.2% is a tight coil on a major and a dead-flat range on a small-cap. Adds a Keltner-containment check (the classic TTM squeeze) as an independent second squeeze test, plus Wilder ADX and a volume ratio, then emits one setup with concrete prices.

**`squeeze_screener`** — ranks a watchlist by bandwidth percentile ascending so the tightest coils surface first, and distinguishes a coil that is *resting* from one that is *firing*. A squeeze has no direction, so the output is explicitly a watchlist, not a set of trades.

**`band_trade_sizer`** — the only path to a position size. Fixed fractional risk (`notional = risk_quote / stop_pct`) so a wide-stop setup automatically gets a smaller position and every trade risks the same amount. Seven guardrails follow: portfolio known, stop on the protective side, stop distance 0.05–20%, risk ≤ 1%, leverage ≤ 5, notional above the exchange minimum, margin inside a 20% reserve. Any FAIL blocks the trade and **no payload is emitted**.

All indicator math is plain Python inside the routines — no pandas, no TA library — so the definitions are auditable in place.

## Tests

`uv run pytest tests/test_bollinger_band_trader.py` — 58 tests, ~1.7s, no network and no Hummingbot server. Full suite: **286 passed, 5 skipped**.

Beyond the unit checks, two are worth calling out:

- **A reachability sweep** asserts every classification verdict fires on realistic data. A branch that never fires is dead code, and this is what catches it.
- **A 2,400-case fuzz** runs every regime fixture against every trend verdict and asserts no emitted setup ever has an inverted stop or target. An inverted stop is an instant loss, not a bad trade.

## Design decisions the tests forced

Three choices below look arbitrary in the diff. Each is there because the obvious
version was tried first and measurably failed. Each is pinned by a named regression test.

**Expansion is checked before squeeze** (`_verdict`). Bandwidth rank is computed from
history, so on the exact candle a coil breaks the rank is still low. Checking squeeze
first made the routine report `squeeze_pending` on the one bar the whole setup exists to
trade. → `test_firing_coil_reads_as_expansion_not_squeeze`

**ADX is Wilder-smoothed, not the raw single-window DX** that `market_analyzer` uses.
Raw DX saturates near 100 on any sustained directional push — and reaching a Bollinger
band *is* a directional push. Measured: across 600 synthetic ranges a band tag never once
produced a `reversion_range` verdict, so that setup was unreachable in practice. Note
this means the two agents report different ADX for the same market; this one is the
textbook figure. → `test_adx_does_not_pin_at_100_in_a_range`

**A capped position size is a WARN row, not PASS.** When the position cap or the reserve
reduces the size, the trade is still valid but risks less than the configured target. As
a PASS the operator had no signal that had happened. → `test_capped_size_is_reported_as_a_warn_row`

A fourth, smaller one: the band-walk threshold was `%B >= 0.95`, which a smooth trend
never reaches — it rides at 0.90–0.93. Relaxed to the top decile and gated on ADX > 25 so
a range cannot be mistaken for a walk.

## Second commit: fixes from running it live

The agent was then run against live `hyperliquid_perpetual` data, which surfaced four more
defects that only appear at runtime:

- **`manage_routines` was missing from the tools allowlist**, so the agent could not call
  its own routines and silently did band math in-model instead. The allowlist is only
  enforced on pydantic-ai keys, so this was invisible under an ACP key.
- **Routine invocations named the wrong tool** in six places across `AGENT.md`, `SKILL.md`
  and `strategy.md`.
- **`strategy.md` told the tick to query executors** that are already pre-loaded in
  `[CORE DATA]`, costing a round-trip and a retry-budget failure.
- **`extra="forbid"` on the routine Configs** — every field had a default, so a model
  passing `symbol` instead of `trading_pair` silently analysed BTC-USDT on Binance while
  reporting confidently about the requested pair.

Plus one repo-level fix in `condor/acp/pydantic_ai_client.py`: pydantic-ai's default
`retries=1` is too tight for small models, which routinely mis-guess a tool schema once
and then abort the whole run.

Verified live: 1 tool call per tick, correct `no_trade` verdict with the higher-timeframe
veto applied, on a free model at $0.000000 per tick.

## What is not validated

- **No live exchange run.** Every test uses synthetic candles through a fake client. Connector-specific response shapes are handled defensively but unproven — run `band_state` against a real server before launching a loop.
- **No profitability claim.** Nothing here is a backtest. The tests prove the agent computes what it says and refuses what it says — not that the setups make money. The thresholds (`squeeze_rank`, the R:R floors, the ADX split) are starting points to tune per market.
- **No executor was created.** Only the payload shape is checked, against `mcp_servers/hummingbot_api/guides/position_executor.md`. The strategy defaults to `execution_mode: dry_run`.

Full detail in `agents/bollinger_band_trader/validation.md`.
