### PR TITLE
feat(setup): let users pick their AI model during setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ TELEGRAM_TOKEN=
 # Get your ID: https://t.me/userinfobot
 ADMIN_USER_ID=
 
-# ── AI Brain (set by make setup, Step 2) ─────────────
+# ── AI Model (set by make setup, Step 2) ─────────────
 # Default LLM/agent key for chats. Pick interactively any time with:
 #   uv run python -m condor.setup_llm
 # Examples: claude-code, claude-acp:opus, gemini, ollama:qwen3:32b,

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,16 @@ TELEGRAM_TOKEN=
 # Get your ID: https://t.me/userinfobot
 ADMIN_USER_ID=
 
+# ── AI Brain (set by make setup, Step 2) ─────────────
+# Default LLM/agent key for chats. Pick interactively any time with:
+#   uv run python -m condor.setup_llm
+# Examples: claude-code, claude-acp:opus, gemini, ollama:qwen3:32b,
+#           openrouter:anthropic/claude-sonnet-4-5
+# CONDOR_DEFAULT_AGENT=claude-code
+
+# Required by openrouter:* models
+# OPENROUTER_API_KEY=
+
 # ── Hummingbot API (set by make setup) ───────────────
 # DEPLOY_HUMMINGBOT_API=true
 

--- a/condor/setup_llm.py
+++ b/condor/setup_llm.py
@@ -1,0 +1,337 @@
+"""Interactive AI-brain (LLM) selection for Condor setup.
+
+Step 2 of ``setup-environment.sh`` runs this (``uv run python -m
+condor.setup_llm``); it is equally runnable standalone any time later. The
+chosen agent key is written to ``.env`` as ``CONDOR_DEFAULT_AGENT`` — the top
+of the default-model precedence in ``handlers.agents._shared`` — plus
+``OPENROUTER_API_KEY`` when OpenRouter is picked, since ``openrouter:*``
+models refuse to start without it.
+
+The wizard ends with a readiness report for the chosen brain instead of
+letting setup exit green around an unusable default: an unauthenticated CLI
+is reported with its login command, a stopped local server with its start
+command. Without a TTY (CI, ``curl | bash`` with no terminal) it prints the
+same report for the current default and changes nothing.
+
+Custom OpenAI-compatible endpoints are deliberately not offered here: they
+live in per-user preferences (``condor/preferences.py``), which do not exist
+at install time. The wizard points users at ``/agent → Change LLM`` instead.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from getpass import getpass
+from pathlib import Path
+from shutil import which
+
+ENV_FILE = Path(".env")  # setup runs from the project root, like setup-environment.sh
+
+OPENROUTER_BASE = "https://openrouter.ai/api/v1"
+LOCAL_BASES = {
+    "ollama": "http://localhost:11434/v1",
+    "lmstudio": "http://localhost:1234/v1",
+}
+LOCAL_START_HINTS = {
+    "ollama": "start it with `ollama serve` (https://ollama.com)",
+    "lmstudio": "open LM Studio and enable its local server (Developer tab)",
+}
+PROBE_TIMEOUT_S = 3
+
+READY = "ready"
+UNVERIFIED = "unverified"
+MISSING = "missing"
+
+_STATE_BADGE = {READY: "✓", UNVERIFIED: "?", MISSING: "✗"}
+
+
+# ── .env access ──────────────────────────────────────
+
+
+def read_env(path: Path = ENV_FILE) -> dict[str, str]:
+    """Parse simple KEY=VALUE lines; comments and malformed lines are skipped."""
+    values: dict[str, str] = {}
+    if not path.exists():
+        return values
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        values[key.strip()] = value.strip()
+    return values
+
+
+def update_env_var(path: Path, key: str, value: str) -> None:
+    """Replace ``key=`` in place or append it, preserving every other line."""
+    lines = path.read_text().splitlines() if path.exists() else []
+    prefix = f"{key}="
+    for i, line in enumerate(lines):
+        if line.startswith(prefix):
+            lines[i] = f"{key}={value}"
+            break
+    else:
+        lines.append(f"{key}={value}")
+    path.write_text("\n".join(lines) + "\n")
+
+
+# ── detection ────────────────────────────────────────
+
+
+def _http_json(url: str, headers: dict[str, str] | None = None) -> dict:
+    req = urllib.request.Request(url, headers=headers or {})
+    with urllib.request.urlopen(req, timeout=PROBE_TIMEOUT_S) as resp:
+        return json.loads(resp.read().decode())
+
+
+def parse_openai_models(payload: dict) -> list[str]:
+    """Model ids from an OpenAI-compatible ``/models`` response."""
+    return [
+        m["id"] for m in payload.get("data", []) if isinstance(m, dict) and m.get("id")
+    ]
+
+
+def probe_local_models(provider: str) -> list[str] | None:
+    """Models served by a local ollama/lmstudio instance, or None if down."""
+    try:
+        return parse_openai_models(_http_json(f"{LOCAL_BASES[provider]}/models"))
+    except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError):
+        return None
+
+
+def _claude_login_found() -> bool:
+    if (Path.home() / ".claude" / ".credentials.json").exists():
+        return True
+    if sys.platform == "darwin":
+        probe = subprocess.run(
+            ["security", "find-generic-password", "-s", "Claude Code-credentials"],
+            capture_output=True,
+        )
+        return probe.returncode == 0
+    return False
+
+
+def detect(base: str, env: dict[str, str]) -> tuple[str, str]:
+    """Readiness of one provider base → (state, human detail/fix)."""
+    import os
+
+    if base in ("claude-code", "claude-acp"):
+        if not which("claude-agent-acp"):
+            return (
+                MISSING,
+                "ACP bridge not on PATH — npm install -g @agentclientprotocol/claude-agent-acp",
+            )
+        if _claude_login_found():
+            return READY, "bridge installed, Claude login found"
+        return (
+            UNVERIFIED,
+            "bridge installed; if first chat fails, run `claude` once and log in",
+        )
+
+    if base in ("gemini", "copilot", "codex"):
+        if not which("npx"):
+            return MISSING, "needs Node.js (npx not on PATH)"
+        if base == "gemini":
+            if (
+                Path.home() / ".gemini" / "oauth_creds.json"
+            ).exists() or os.environ.get("GEMINI_API_KEY"):
+                return READY, "login found"
+            return UNVERIFIED, "run `npx @google/gemini-cli` once and authenticate"
+        if base == "codex":
+            if (Path.home() / ".codex" / "auth.json").exists():
+                return READY, "login found"
+            return UNVERIFIED, "log in with the Codex CLI (`codex login`)"
+        return UNVERIFIED, "run `npx @github/copilot` once and /login"
+
+    if base in LOCAL_BASES:
+        models = probe_local_models(base)
+        if models is None:
+            return (
+                MISSING,
+                f"no server at {LOCAL_BASES[base]} — {LOCAL_START_HINTS[base]}",
+            )
+        return READY, f"{len(models)} model(s) available"
+
+    if base == "openrouter":
+        if env.get("OPENROUTER_API_KEY") or os.environ.get("OPENROUTER_API_KEY"):
+            return READY, "API key set"
+        return MISSING, "needs an API key (entered here)"
+
+    return UNVERIFIED, "unknown provider"
+
+
+# ── choices ──────────────────────────────────────────
+
+
+def menu_options() -> list[tuple[str, str]]:
+    """(agent_key, label) pairs offered at setup, in AGENT_OPTIONS order.
+
+    Picker sentinels are excluded except ``openrouter:``, which this wizard
+    can complete (key + model). ``custom:`` needs the per-user preference
+    store and is offered at runtime instead.
+    """
+    from handlers.agents._shared import AGENT_OPTIONS
+
+    options = []
+    for key, meta in AGENT_OPTIONS.items():
+        if meta.get("picker") and key != "openrouter:":
+            continue
+        options.append((key, meta["label"]))
+    return options
+
+
+def current_default(env: dict[str, str]) -> str:
+    from handlers.agents._shared import DEFAULT_AGENT
+
+    return env.get("CONDOR_DEFAULT_AGENT") or DEFAULT_AGENT
+
+
+def persist_choice(
+    agent_key: str, extra_env: dict[str, str] | None = None, path: Path = ENV_FILE
+) -> None:
+    for key, value in (extra_env or {}).items():
+        update_env_var(path, key, value)
+    update_env_var(path, "CONDOR_DEFAULT_AGENT", agent_key)
+
+
+# ── interactive flows ────────────────────────────────
+
+
+def _ask(prompt: str) -> str:
+    return input(prompt).strip()
+
+
+def _pick_local_model(provider: str) -> str | None:
+    """Resolve ``ollama:``/``lmstudio:`` to a concrete or bare key; None to go back."""
+    models = probe_local_models(provider)
+    if models is None:
+        print(
+            f"  ✗ No server at {LOCAL_BASES[provider]} — {LOCAL_START_HINTS[provider]}"
+        )
+        return None
+    print(f"  Models on the local {provider} server:")
+    for i, model in enumerate(models, 1):
+        print(f"    {i}. {model}")
+    raw = _ask(f"  Model [1-{len(models)}, Enter = pick automatically at chat start]: ")
+    if not raw:
+        return f"{provider}:"
+    if raw.isdigit() and 1 <= int(raw) <= len(models):
+        return f"{provider}:{models[int(raw) - 1]}"
+    print("  ✗ Not a listed model number.")
+    return None
+
+
+def _pick_openrouter(env: dict[str, str]) -> tuple[str, dict[str, str]] | None:
+    """Validate an OpenRouter key and model → (agent_key, env-to-write); None to go back."""
+    existing = env.get("OPENROUTER_API_KEY", "")
+    if existing:
+        key = _ask("  OpenRouter API key [Enter = keep the one in .env]: ") or existing
+    else:
+        key = getpass("  OpenRouter API key (hidden): ").strip()
+    if not key:
+        print("  ✗ OpenRouter needs an API key.")
+        return None
+    try:
+        models = parse_openai_models(
+            _http_json(
+                f"{OPENROUTER_BASE}/models", headers={"Authorization": f"Bearer {key}"}
+            )
+        )
+    except urllib.error.HTTPError as e:
+        print(f"  ✗ OpenRouter rejected the key (HTTP {e.code}).")
+        return None
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        print(f"  ✗ Could not reach OpenRouter: {e}")
+        return None
+    model = _ask("  Model id (e.g. anthropic/claude-sonnet-4-5): ")
+    if model not in models:
+        print(f"  ✗ '{model}' is not in OpenRouter's model list.")
+        return None
+    extra = {"OPENROUTER_API_KEY": key} if key != existing or not existing else {}
+    return f"openrouter:{model}", extra
+
+
+def choose(env: dict[str, str]) -> tuple[str, dict[str, str]] | None:
+    """Run the menu until a choice is confirmed; None means keep the default."""
+    options = menu_options()
+    default = current_default(env)
+    while True:
+        print("\nWhich AI brain should Condor use by default?\n")
+        for i, (key, label) in enumerate(options, 1):
+            state, detail = detect(key.partition(":")[0], env)
+            marker = "  ← current default" if key == default else ""
+            print(f"  {i}. {label:<32} [{_STATE_BADGE[state]} {detail}]{marker}")
+        print(f"  s. Skip — keep current default ({default})")
+        raw = _ask(f"\nChoice [1-{len(options)}, s, Enter = keep default]: ").lower()
+        if raw in ("s", "skip", ""):
+            return None
+        if not raw.isdigit() or not 1 <= int(raw) <= len(options):
+            print("  ✗ Not an option.")
+            continue
+        key, _label = options[int(raw) - 1]
+        if key in ("ollama:", "lmstudio:"):
+            picked = _pick_local_model(key[:-1])
+            if picked is None:
+                continue
+            return picked, {}
+        if key == "openrouter:":
+            picked = _pick_openrouter(env)
+            if picked is None:
+                continue
+            return picked
+        return key, {}
+
+
+# ── reporting ────────────────────────────────────────
+
+
+def report(agent_key: str, env: dict[str, str]) -> None:
+    state, detail = detect(agent_key.partition(":")[0], env)
+    if state == READY:
+        print(f"\n  ✓ Default brain: {agent_key} — {detail}")
+    elif state == UNVERIFIED:
+        print(f"\n  ? Default brain: {agent_key} — {detail}")
+    else:
+        print(f"\n  ✗ Default brain: {agent_key} — NOT READY: {detail}")
+        print("    Condor cannot chat until this is fixed.")
+
+
+def status() -> None:
+    env = read_env()
+    default = current_default(env)
+    print("AI brain options:")
+    for key, label in menu_options():
+        state, detail = detect(key.partition(":")[0], env)
+        marker = "  ← current default" if key == default else ""
+        print(f"  [{_STATE_BADGE[state]}] {label:<32} {detail}{marker}")
+    report(default, env)
+
+
+def main(argv: list[str]) -> int:
+    if "--status" in argv or not sys.stdin.isatty():
+        status()
+        return 0
+    env = read_env()
+    try:
+        choice = choose(env)
+    except (KeyboardInterrupt, EOFError):
+        print("\n  Skipped — keeping the current default.")
+        report(current_default(env), env)
+        return 0
+    if choice is None:
+        report(current_default(env), env)
+        return 0
+    agent_key, extra = choice
+    persist_choice(agent_key, extra)
+    print(f"  ✓ Wrote CONDOR_DEFAULT_AGENT={agent_key} to {ENV_FILE}")
+    report(agent_key, read_env())
+    print("    Switch any time: rerun this wizard, or /agent → Change LLM in Telegram.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/condor/setup_llm.py
+++ b/condor/setup_llm.py
@@ -1,4 +1,4 @@
-"""Interactive AI-brain (LLM) selection for Condor setup.
+"""Interactive AI model (LLM) selection for Condor setup.
 
 Step 2 of ``setup-environment.sh`` runs this (``uv run python -m
 condor.setup_llm``); it is equally runnable standalone any time later. The
@@ -7,7 +7,7 @@ of the default-model precedence in ``handlers.agents._shared`` — plus
 ``OPENROUTER_API_KEY`` when OpenRouter is picked, since ``openrouter:*``
 models refuse to start without it.
 
-The wizard ends with a readiness report for the chosen brain instead of
+The wizard ends with a readiness report for the chosen model instead of
 letting setup exit green around an unusable default: an unauthenticated CLI
 is reported with its login command, a stopped local server with its start
 command. Without a TTY (CI, ``curl | bash`` with no terminal) it prints the
@@ -292,18 +292,18 @@ def choose(env: dict[str, str]) -> tuple[str, dict[str, str]] | None:
 def report(agent_key: str, env: dict[str, str]) -> None:
     state, detail = detect(agent_key.partition(":")[0], env)
     if state == READY:
-        print(f"\n  ✓ Default brain: {agent_key} — {detail}")
+        print(f"\n  ✓ Default model: {agent_key} — {detail}")
     elif state == UNVERIFIED:
-        print(f"\n  ? Default brain: {agent_key} — {detail}")
+        print(f"\n  ? Default model: {agent_key} — {detail}")
     else:
-        print(f"\n  ✗ Default brain: {agent_key} — NOT READY: {detail}")
+        print(f"\n  ✗ Default model: {agent_key} — NOT READY: {detail}")
         print("    Condor cannot chat until this is fixed.")
 
 
 def status() -> None:
     env = read_env()
     default = current_default(env)
-    print("AI brain options:")
+    print("AI model options:")
     for key, label in menu_options():
         state, detail = detect(key.partition(":")[0], env)
         marker = "  ← current default" if key == default else ""

--- a/condor/setup_llm.py
+++ b/condor/setup_llm.py
@@ -260,7 +260,7 @@ def choose(env: dict[str, str]) -> tuple[str, dict[str, str]] | None:
     options = menu_options()
     default = current_default(env)
     while True:
-        print("\nWhich AI brain should Condor use by default?\n")
+        print("\nWhich AI model should Condor use by default?\n")
         for i, (key, label) in enumerate(options, 1):
             state, detail = detect(key.partition(":")[0], env)
             marker = "  ← current default" if key == default else ""

--- a/setup-environment.sh
+++ b/setup-environment.sh
@@ -580,9 +580,9 @@ fi
 
 echo ""
 
-# ── Step 2: AI Brain (LLM) ──────────────────────────
+# ── Step 2: AI Model (LLM) ──────────────────────────
 
-echo -e "${BOLD}Step 2: AI Brain (LLM)${RESET}"
+echo -e "${BOLD}Step 2: AI Model (LLM)${RESET}"
 echo ""
 
 # The wizard writes CONDOR_DEFAULT_AGENT (and, for OpenRouter, the API key)
@@ -590,9 +590,9 @@ echo ""
 # `make install` performs right after this script, just earlier.
 if (: </dev/tty) 2>/dev/null; then
     uv run python -m condor.setup_llm < /dev/tty || \
-        msg_warn "Brain selection did not complete -- run 'uv run python -m condor.setup_llm' to pick one later"
+        msg_warn "Model selection did not complete -- run 'uv run python -m condor.setup_llm' to pick one later"
 else
-    msg_info "No terminal available -- skipping brain selection (run 'uv run python -m condor.setup_llm' later)"
+    msg_info "No terminal available -- skipping model selection (run 'uv run python -m condor.setup_llm' later)"
     uv run python -m condor.setup_llm --status || true
 fi
 
@@ -1079,8 +1079,8 @@ echo -e "    • typescript: $(command_exists tsc && tsc --version 2>/dev/null |
 echo ""
 echo -e "  ${BOLD}Configuration:${RESET}"
 echo -e "    • Telegram:   $([ -n "${TELEGRAM_TOKEN:-}" ] && echo 'configured' || echo 'not set')"
-brain_choice=$(grep "^CONDOR_DEFAULT_AGENT=" "$ENV_FILE" 2>/dev/null | cut -d= -f2-)
-echo -e "    • AI brain:   ${brain_choice:-claude-code (default)}"
+model_choice=$(grep "^CONDOR_DEFAULT_AGENT=" "$ENV_FILE" 2>/dev/null | cut -d= -f2-)
+echo -e "    • AI model:   ${model_choice:-claude-code (default)}"
 echo ""
 echo -e "  ${BOLD}Next steps:${RESET}"
 echo -e "  ${BOLD}make install${RESET}      Install Python dependencies"

--- a/setup-environment.sh
+++ b/setup-environment.sh
@@ -105,7 +105,7 @@ command_exists() {
     command -v "$1" >/dev/null 2>&1
 }
 
-# Quick localhost API probe — avoid hanging Step 2 when port 8000 is slow/unreachable
+# Quick localhost API probe — avoid hanging Step 3 when port 8000 is slow/unreachable
 api_health_check() {
     curl -sf --connect-timeout 3 --max-time 5 http://localhost:8000/docs >/dev/null 2>&1
 }
@@ -580,9 +580,27 @@ fi
 
 echo ""
 
-# ── Step 2: Hummingbot API ──────────────────────────
+# ── Step 2: AI Brain (LLM) ──────────────────────────
 
-echo -e "${BOLD}Step 2: Hummingbot API${RESET}"
+echo -e "${BOLD}Step 2: AI Brain (LLM)${RESET}"
+echo ""
+
+# The wizard writes CONDOR_DEFAULT_AGENT (and, for OpenRouter, the API key)
+# to .env. `uv run` syncs project deps on first use — the same sync
+# `make install` performs right after this script, just earlier.
+if (: </dev/tty) 2>/dev/null; then
+    uv run python -m condor.setup_llm < /dev/tty || \
+        msg_warn "Brain selection did not complete -- run 'uv run python -m condor.setup_llm' to pick one later"
+else
+    msg_info "No terminal available -- skipping brain selection (run 'uv run python -m condor.setup_llm' later)"
+    uv run python -m condor.setup_llm --status || true
+fi
+
+echo ""
+
+# ── Step 3: Hummingbot API ──────────────────────────
+
+echo -e "${BOLD}Step 3: Hummingbot API${RESET}"
 echo ""
 
 hb_api_deployed=false
@@ -925,9 +943,9 @@ fi
 
 echo ""
 
-# ── Step 3: Create/Update config.yml ─────────────────
+# ── Step 4: Create/Update config.yml ─────────────────
 
-echo -e "${BOLD}Step 3: Configuration Files${RESET}"
+echo -e "${BOLD}Step 4: Configuration Files${RESET}"
 echo ""
 
 # Get current date
@@ -1036,13 +1054,13 @@ fi
 
 echo ""
 
-# ── Step 4: Data directory ──────────────────────────
+# ── Step 5: Data directory ──────────────────────────
 
 if [ ! -d "$DATA_DIR" ]; then
     mkdir -p "$DATA_DIR"
 fi
 
-# ── Step 5: Summary ────────────────────────────────
+# ── Step 6: Summary ────────────────────────────────
 
 # Source nvm to make node/npm available in current shell
 if [ -s "$HOME/.nvm/nvm.sh" ]; then
@@ -1061,6 +1079,8 @@ echo -e "    • typescript: $(command_exists tsc && tsc --version 2>/dev/null |
 echo ""
 echo -e "  ${BOLD}Configuration:${RESET}"
 echo -e "    • Telegram:   $([ -n "${TELEGRAM_TOKEN:-}" ] && echo 'configured' || echo 'not set')"
+brain_choice=$(grep "^CONDOR_DEFAULT_AGENT=" "$ENV_FILE" 2>/dev/null | cut -d= -f2-)
+echo -e "    • AI brain:   ${brain_choice:-claude-code (default)}"
 echo ""
 echo -e "  ${BOLD}Next steps:${RESET}"
 echo -e "  ${BOLD}make install${RESET}      Install Python dependencies"

--- a/tests/test_setup_llm.py
+++ b/tests/test_setup_llm.py
@@ -1,0 +1,134 @@
+"""Unit tests for condor.setup_llm (setup-time AI brain selection).
+
+Covers the pure parts: .env read/update, menu construction from
+AGENT_OPTIONS, choice persistence, and model-list parsing. Interactive flows
+and network probes are exercised only through their parsing helpers.
+"""
+
+from pathlib import Path
+
+from condor import setup_llm
+
+# ── .env read/update ─────────────────────────────────
+
+
+def test_read_env_parses_values_and_skips_noise(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text(
+        "# comment\nTELEGRAM_TOKEN=abc:123\n\nbroken line\nWEB_URL=http://x:8088\n"
+    )
+    assert setup_llm.read_env(env) == {
+        "TELEGRAM_TOKEN": "abc:123",
+        "WEB_URL": "http://x:8088",
+    }
+
+
+def test_read_env_missing_file(tmp_path):
+    assert setup_llm.read_env(tmp_path / ".env") == {}
+
+
+def test_update_env_var_creates_file(tmp_path):
+    env = tmp_path / ".env"
+    setup_llm.update_env_var(env, "CONDOR_DEFAULT_AGENT", "gemini")
+    assert env.read_text() == "CONDOR_DEFAULT_AGENT=gemini\n"
+
+
+def test_update_env_var_replaces_in_place_preserving_others(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text(
+        "TELEGRAM_TOKEN=abc\nCONDOR_DEFAULT_AGENT=claude-code\nWEB_URL=http://x\n"
+    )
+    setup_llm.update_env_var(env, "CONDOR_DEFAULT_AGENT", "ollama:qwen3:32b")
+    assert env.read_text() == (
+        "TELEGRAM_TOKEN=abc\nCONDOR_DEFAULT_AGENT=ollama:qwen3:32b\nWEB_URL=http://x\n"
+    )
+
+
+def test_update_env_var_appends_when_absent(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("TELEGRAM_TOKEN=abc\n")
+    setup_llm.update_env_var(env, "OPENROUTER_API_KEY", "sk-or-x")
+    assert env.read_text() == "TELEGRAM_TOKEN=abc\nOPENROUTER_API_KEY=sk-or-x\n"
+
+
+# ── menu construction ────────────────────────────────
+
+
+def test_menu_offers_every_startable_option_and_openrouter():
+    from handlers.agents._shared import AGENT_OPTIONS
+
+    keys = [k for k, _ in setup_llm.menu_options()]
+    assert "custom:" not in keys  # needs per-user prefs; runtime-only
+    assert "openrouter:" in keys  # picker the wizard can complete itself
+    for key, meta in AGENT_OPTIONS.items():
+        if not meta.get("picker"):
+            assert key in keys
+
+
+def test_current_default_prefers_env_file_over_fallback():
+    assert setup_llm.current_default({"CONDOR_DEFAULT_AGENT": "gemini"}) == "gemini"
+    from handlers.agents._shared import DEFAULT_AGENT
+
+    assert setup_llm.current_default({}) == DEFAULT_AGENT
+
+
+# ── persistence ──────────────────────────────────────
+
+
+def test_persist_choice_writes_agent_and_extra_env(tmp_path):
+    env = tmp_path / ".env"
+    setup_llm.persist_choice(
+        "openrouter:anthropic/claude-sonnet-4-5",
+        extra_env={"OPENROUTER_API_KEY": "sk-or-x"},
+        path=env,
+    )
+    assert setup_llm.read_env(env) == {
+        "OPENROUTER_API_KEY": "sk-or-x",
+        "CONDOR_DEFAULT_AGENT": "openrouter:anthropic/claude-sonnet-4-5",
+    }
+
+
+# ── model-list parsing ───────────────────────────────
+
+
+def test_parse_openai_models():
+    payload = {
+        "data": [{"id": "llama3.1:8b"}, {"id": "qwen3:32b"}, {"object": "noise"}]
+    }
+    assert setup_llm.parse_openai_models(payload) == ["llama3.1:8b", "qwen3:32b"]
+
+
+def test_parse_openai_models_empty():
+    assert setup_llm.parse_openai_models({}) == []
+
+
+# ── detection states ─────────────────────────────────
+
+
+def test_detect_openrouter_needs_key(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    state, _ = setup_llm.detect("openrouter", {})
+    assert state == setup_llm.MISSING
+    state, _ = setup_llm.detect("openrouter", {"OPENROUTER_API_KEY": "sk-or-x"})
+    assert state == setup_llm.READY
+
+
+def test_detect_local_provider_down(monkeypatch):
+    monkeypatch.setattr(setup_llm, "probe_local_models", lambda provider: None)
+    state, detail = setup_llm.detect("ollama", {})
+    assert state == setup_llm.MISSING
+    assert "ollama serve" in detail
+
+
+def test_detect_local_provider_up(monkeypatch):
+    monkeypatch.setattr(setup_llm, "probe_local_models", lambda provider: ["qwen3:32b"])
+    state, detail = setup_llm.detect("lmstudio", {})
+    assert state == setup_llm.READY
+    assert "1 model(s)" in detail
+
+
+def test_detect_claude_missing_bridge(monkeypatch):
+    monkeypatch.setattr(setup_llm, "which", lambda cmd: None)
+    state, detail = setup_llm.detect("claude-code", {})
+    assert state == setup_llm.MISSING
+    assert "claude-agent-acp" in detail

--- a/tests/test_setup_llm.py
+++ b/tests/test_setup_llm.py
@@ -1,4 +1,4 @@
-"""Unit tests for condor.setup_llm (setup-time AI brain selection).
+"""Unit tests for condor.setup_llm (setup-time AI model selection).
 
 Covers the pure parts: .env read/update, menu construction from
 AGENT_OPTIONS, choice persistence, and model-list parsing. Interactive flows


### PR DESCRIPTION
## Problem

Setup never asks which LLM Condor should think with. It silently `npm install`s the Claude ACP bridge, hardcodes `claude-code` as the default, and assumes a logged-in Claude Code CLI exists — nothing states or verifies that assumption. A user without one hits their first failure at first chat, not during install.

## Approach

Follows the onboarding pattern used by Hermes (`hermes setup`) and OpenClaw (`openclaw onboard`): the installer stays dumb, and onboarding is a first-class, re-runnable command the installer hands off to with stdin wired to `/dev/tty` so it can prompt under `curl | bash`.

## Changes

- **New `condor/setup_llm.py`** — interactive wizard, runnable any time via `uv run python -m condor.setup_llm`:
  - Menu renders `AGENT_OPTIONS` (the same source of truth as the runtime pickers) with live readiness per option: ACP bridge + Claude login detection (credentials file / macOS keychain), Gemini/Codex auth files, Ollama & LM Studio server probes with model listing, OpenRouter key validated against its live `/models` endpoint before anything is written.
  - Persists the choice as `CONDOR_DEFAULT_AGENT` in `.env` — already the top of the default-model precedence in `handlers/agents/_shared.py` — plus `OPENROUTER_API_KEY` when OpenRouter is picked (required by `openrouter:*` models).
  - Ends with a readiness report (Hermes-style gate) instead of exiting green around an unusable default: an unauthenticated CLI is reported with its login command, a stopped local server with its start command.
  - No TTY (CI, headless) → prints the same report for the current default and changes nothing. `--status` does the same on demand.
- **`setup-environment.sh`** — new Step 2 "AI Model (LLM)" between Telegram and Hummingbot API; later steps renumbered; summary now shows the chosen model.
- **`.env.example`** — documents `CONDOR_DEFAULT_AGENT` / `OPENROUTER_API_KEY`.
- **`tests/test_setup_llm.py`** — 14 tests over the pure parts: env read/update, menu construction, persistence, model-list parsing, detection states.

Custom OpenAI-compatible endpoints are deliberately not offered at setup: they live in per-user preferences, which don't exist at install time. The wizard points at `/agent → Change LLM` instead. Per-user runtime switching is unchanged.

## Testing

- `uv run python -m pytest` — 715 passed (701 pre-existing + 14 new)
- Live `--status` run correctly detected: Claude bridge + login ✓, Gemini ✓, Codex ✓, Copilot unverified, Ollama/LM Studio down with start hints, OpenRouter key present
- Interactive flow exercised with scripted input: pick, skip, invalid→valid
- `bash -n setup-environment.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)