### PR TITLE
fix(agents): calculate executor risk in quote units

### DIFF
--- a/condor/agents/engine.py
+++ b/condor/agents/engine.py
@@ -578,7 +578,7 @@ class TickEngine:
             self._pending_directives.clear()
 
         # 6. Create a fresh agent client per tick (clean context window)
-        acp_client = await self._create_client(risk_state)
+        acp_client = await self._create_client(risk_state, client)
         self._active_client = acp_client
 
         response_chunks: list[str] = []
@@ -835,7 +835,7 @@ class TickEngine:
     # ------------------------------------------------------------------
 
     async def _create_client(
-        self, risk_state: RiskState
+        self, risk_state: RiskState, price_client: Any
     ) -> "ACPClient | PydanticAIClient":
         """Build an ACP or PydanticAI client (does NOT start it).
 
@@ -863,6 +863,7 @@ class TickEngine:
             execution_mode=mode,
             ledger=self.ledger,
             agent_id=self.agent_id,
+            price_client=price_client,
         )
 
         agent_key = self._agent_key()

--- a/condor/agents/risk.py
+++ b/condor/agents/risk.py
@@ -8,6 +8,7 @@ safe tool calls and blocks dangerous ones that violate risk limits.
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -125,7 +126,10 @@ class RiskEngine:
         return state
 
     def check_executor_action(
-        self, tool_call: dict, current_state: RiskState
+        self,
+        tool_call: dict,
+        current_state: RiskState,
+        planned_amount_quote: float | None = None,
     ) -> tuple[bool, str]:
         """Check if an executor creation is within risk limits.
 
@@ -154,11 +158,13 @@ class RiskEngine:
                 f"Max open executors ({self.limits.max_open_executors}) reached",
             )
 
-        # Check position size
-        config = input_data.get("executor_config", {})
-        amount = float(
-            config.get("total_amount_quote", 0) or config.get("amount", 0) or 0
-        )
+        if (
+            planned_amount_quote is None
+            or not math.isfinite(planned_amount_quote)
+            or planned_amount_quote <= 0
+        ):
+            return False, "Planned quote exposure is unavailable"
+        amount = planned_amount_quote
 
         if current_state.total_exposure + amount > self.limits.max_position_size_quote:
             return False, (
@@ -225,6 +231,7 @@ def auto_approve_with_risk_check(
     execution_mode: str = "loop",
     ledger: "BotLedger | None" = None,
     agent_id: str = "",
+    price_client: Any = None,
 ):
     """Build a permission callback that auto-approves safe tools and risk-checks dangerous ones.
 
@@ -301,8 +308,18 @@ def auto_approve_with_risk_check(
                         )
                         return {"outcome": {"outcome": "cancelled"}}
 
+                planned_amount_quote = None
+                if action == "create":
+                    try:
+                        planned_amount_quote = await _planned_amount_quote(
+                            input_data, price_client
+                        )
+                    except Exception as exc:
+                        log.warning("Blocked executor create: %s", exc)
+                        return {"outcome": {"outcome": "cancelled"}}
+
                 allowed, reason = risk_engine.check_executor_action(
-                    tool_call, risk_state
+                    tool_call, risk_state, planned_amount_quote
                 )
                 if not allowed:
                     log.warning("Risk engine blocked tool call: %s", reason)
@@ -358,3 +375,55 @@ def auto_approve_with_risk_check(
         return {"outcome": {"outcome": "cancelled"}}
 
     return callback
+
+
+async def _planned_amount_quote(input_data: dict[str, Any], client: Any) -> float:
+    """Value a supported executor create in its quote token."""
+
+    config = input_data.get("executor_config") or {}
+    executor_type = (
+        input_data.get("executor_type")
+        or config.get("type")
+        or config.get("executor_type")
+    )
+
+    if "total_amount_quote" in config:
+        amount = float(config["total_amount_quote"])
+    elif executor_type == "dca_executor":
+        amounts = [float(value) for value in config.get("amounts_quote", [])]
+        if any(not math.isfinite(value) or value <= 0 for value in amounts):
+            raise ValueError("amounts_quote must contain positive finite numbers")
+        amount = sum(amounts)
+    elif executor_type in {"order_executor", "position_executor", "lp_executor"}:
+        base = float(
+            config.get("base_amount", 0)
+            if executor_type == "lp_executor"
+            else config.get("amount", 0)
+        )
+        quote = float(config.get("quote_amount", 0))
+        if base < 0 or quote < 0:
+            raise ValueError("executor amounts cannot be negative")
+        if base:
+            if client is None:
+                raise ValueError("Hummingbot price client is unavailable")
+            from condor.fetchers.market_data import fetch_current_price
+
+            price = await fetch_current_price(
+                client,
+                config.get("connector_name", ""),
+                config.get("trading_pair", ""),
+            )
+            if price is None:
+                raise ValueError("reference price is unavailable")
+            price = float(price)
+            if not math.isfinite(price) or price <= 0:
+                raise ValueError("reference price must be a positive finite number")
+            amount = quote + base * price
+        else:
+            amount = quote
+    else:
+        raise ValueError(f"unsupported executor type: {executor_type or 'unknown'}")
+
+    if not math.isfinite(amount) or amount <= 0:
+        raise ValueError("planned quote amount must be a positive finite number")
+    return amount

--- a/condor/agents/risk.py
+++ b/condor/agents/risk.py
@@ -387,9 +387,7 @@ async def _planned_amount_quote(input_data: dict[str, Any], client: Any) -> floa
         or config.get("executor_type")
     )
 
-    if "total_amount_quote" in config:
-        amount = float(config["total_amount_quote"])
-    elif executor_type == "dca_executor":
+    if executor_type == "dca_executor":
         amounts = [float(value) for value in config.get("amounts_quote", [])]
         if any(not math.isfinite(value) or value <= 0 for value in amounts):
             raise ValueError("amounts_quote must contain positive finite numbers")
@@ -421,6 +419,8 @@ async def _planned_amount_quote(input_data: dict[str, Any], client: Any) -> floa
             amount = quote + base * price
         else:
             amount = quote
+    elif executor_type in {"grid_executor", "twap_executor"}:
+        amount = float(config["total_amount_quote"])
     else:
         raise ValueError(f"unsupported executor type: {executor_type or 'unknown'}")
 

--- a/tests/test_pydantic_ai_permission_gate.py
+++ b/tests/test_pydantic_ai_permission_gate.py
@@ -226,8 +226,10 @@ def test_dry_run_cannot_execute_a_real_trading_tool():
     )
     args = {
         "action": "create",
+        "executor_type": "grid_executor",
         "executor_config": {
             "controller_id": "test_controller",
+            "type": "grid_executor",
             "total_amount_quote": 100.0,
         },
     }
@@ -258,8 +260,10 @@ def test_risk_limit_denial_prevents_the_create():
     )
     args = {
         "action": "create",
+        "executor_type": "grid_executor",
         "executor_config": {
             "controller_id": "test_controller",
+            "type": "grid_executor",
             "total_amount_quote": 5000.0,
         },
     }

--- a/tests/test_risk_gate.py
+++ b/tests/test_risk_gate.py
@@ -8,10 +8,13 @@ pre-tick numbers.
 
 import asyncio
 
+import pytest
+
 from condor.agents.risk import (
     RiskEngine,
     RiskLimits,
     RiskState,
+    _planned_amount_quote,
     auto_approve_with_risk_check,
 )
 
@@ -29,6 +32,24 @@ def _create_call(amount: float = 100.0) -> dict:
     }
 
 
+def _order_call(amount: str | float) -> dict:
+    config = {
+        "controller_id": "test_controller",
+        "type": "order_executor",
+        "connector_name": "solana-mainnet-beta",
+        "trading_pair": "PUMP-USDC",
+        "amount": amount,
+    }
+    return {
+        "tool": "manage_executors",
+        "input": {
+            "action": "create",
+            "executor_type": "order_executor",
+            "executor_config": config,
+        },
+    }
+
+
 _OPTIONS = [{"kind": "allow_once", "optionId": "allow"}]
 
 
@@ -42,11 +63,11 @@ def test_second_create_blocked_by_executor_count():
     engine = RiskEngine(RiskLimits(max_open_executors=5))
     state = RiskState(executor_count=4)
 
-    allowed, _ = engine.check_executor_action(_create_call(), state)
+    allowed, _ = engine.check_executor_action(_create_call(), state, 100.0)
     assert allowed
     assert state.executor_count == 5
 
-    allowed, reason = engine.check_executor_action(_create_call(), state)
+    allowed, reason = engine.check_executor_action(_create_call(), state, 100.0)
     assert not allowed
     assert "Max open executors" in reason
 
@@ -56,11 +77,11 @@ def test_cumulative_exposure_blocks_second_create():
     engine = RiskEngine(RiskLimits(max_position_size_quote=500.0))
     state = RiskState(total_exposure=300.0)
 
-    allowed, _ = engine.check_executor_action(_create_call(150.0), state)
+    allowed, _ = engine.check_executor_action(_create_call(150.0), state, 150.0)
     assert allowed
     assert state.total_exposure == 450.0
 
-    allowed, reason = engine.check_executor_action(_create_call(150.0), state)
+    allowed, reason = engine.check_executor_action(_create_call(150.0), state, 150.0)
     assert not allowed
     assert "position limit" in reason
 
@@ -69,7 +90,7 @@ def test_rejected_create_does_not_accumulate():
     engine = RiskEngine(RiskLimits(max_position_size_quote=500.0))
     state = RiskState(total_exposure=400.0)
 
-    allowed, _ = engine.check_executor_action(_create_call(200.0), state)
+    allowed, _ = engine.check_executor_action(_create_call(200.0), state, 200.0)
     assert not allowed
     assert state.total_exposure == 400.0
     assert state.executor_count == 0
@@ -84,6 +105,73 @@ def test_non_create_actions_do_not_accumulate():
     assert allowed
     assert state.executor_count == 2
     assert state.total_exposure == 100.0
+
+
+class _MarketData:
+    def __init__(self, price):
+        self.price = price
+
+    async def get_prices(self, connector_name, trading_pairs):
+        return {"prices": {trading_pairs: self.price} if self.price else {}}
+
+
+class _PriceClient:
+    def __init__(self, price):
+        self.market_data = _MarketData(price)
+
+
+@pytest.mark.parametrize(
+    ("executor_type", "config", "expected"),
+    [
+        ("grid_executor", {"total_amount_quote": 12}, 12),
+        ("twap_executor", {"total_amount_quote": 13}, 13),
+        ("dca_executor", {"amounts_quote": [4, 5]}, 9),
+        ("order_executor", {"amount": 3}, 6),
+        ("position_executor", {"amount": 4}, 8),
+        ("lp_executor", {"base_amount": 3, "quote_amount": 4}, 10),
+    ],
+)
+def test_planned_amount_quote_uses_each_executor_capital_field(
+    executor_type, config, expected
+):
+    config.update(connector_name="solana-mainnet-beta", trading_pair="PUMP-USDC")
+
+    amount = asyncio.run(
+        _planned_amount_quote(
+            {"executor_type": executor_type, "executor_config": config},
+            _PriceClient(2),
+        )
+    )
+
+    assert amount == pytest.approx(expected)
+
+
+def test_oracle_prices_market_order_before_risk_check():
+    state = RiskState()
+    callback = auto_approve_with_risk_check(
+        RiskEngine(RiskLimits(max_position_size_quote=10.0)),
+        state,
+        price_client=_PriceClient(0.002285209543),
+    )
+
+    result = asyncio.run(callback(_order_call("653.238363"), _OPTIONS))
+
+    assert result["outcome"]["outcome"] == "selected"
+    assert state.total_exposure == pytest.approx(653.238363 * 0.002285209543)
+
+
+def test_missing_oracle_price_blocks_market_order():
+    state = RiskState()
+    callback = auto_approve_with_risk_check(
+        RiskEngine(RiskLimits(max_position_size_quote=10.0)),
+        state,
+        price_client=_PriceClient(None),
+    )
+
+    result = asyncio.run(callback(_order_call("653.238363"), _OPTIONS))
+
+    assert result["outcome"]["outcome"] == "cancelled"
+    assert state.total_exposure == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_risk_gate.py
+++ b/tests/test_risk_gate.py
@@ -26,6 +26,7 @@ def _create_call(amount: float = 100.0) -> dict:
             "action": "create",
             "executor_config": {
                 "controller_id": "test_controller",
+                "type": "grid_executor",
                 "total_amount_quote": amount,
             },
         },
@@ -125,10 +126,14 @@ class _PriceClient:
     [
         ("grid_executor", {"total_amount_quote": 12}, 12),
         ("twap_executor", {"total_amount_quote": 13}, 13),
-        ("dca_executor", {"amounts_quote": [4, 5]}, 9),
-        ("order_executor", {"amount": 3}, 6),
-        ("position_executor", {"amount": 4}, 8),
-        ("lp_executor", {"base_amount": 3, "quote_amount": 4}, 10),
+        ("dca_executor", {"amounts_quote": [4, 5], "total_amount_quote": 1}, 9),
+        ("order_executor", {"amount": 3, "total_amount_quote": 1}, 6),
+        ("position_executor", {"amount": 4, "total_amount_quote": 0}, 8),
+        (
+            "lp_executor",
+            {"base_amount": 3, "quote_amount": 4, "total_amount_quote": 1},
+            10,
+        ),
     ],
 )
 def test_planned_amount_quote_uses_each_executor_capital_field(


### PR DESCRIPTION
## Summary

- Calculate planned executor exposure in quote units instead of treating every `amount` as quote currency.
- Reuse Condor's existing Hummingbot market-data price path for base-denominated Order, Position, and LP executors.
- Use native quote fields for Grid, TWAP, and DCA executors, and fail closed when exposure or a required reference price is unavailable.

## Problem

The risk gate previously fell back from `total_amount_quote` to `amount`. For Order and Position executors, `amount` represents base-token units, so an order for 653.238363 PUMP was incorrectly counted as 653.24 quote units instead of approximately 1.49 USDC. This could reject a valid executor as exceeding the configured quote exposure limit.

Other executor types also represent planned capital differently: DCA uses `amounts_quote`, while LP splits capital between `base_amount` and `quote_amount`.

## Fix

- Pass the existing authenticated Hummingbot client into the executor permission gate.
- Derive planned quote exposure from each supported executor's existing configuration:
  - Grid/TWAP: `total_amount_quote`
  - DCA: sum of `amounts_quote`
  - Order/Position: `amount * reference_price`
  - LP: `quote_amount + base_amount * reference_price`
- Fetch a reference price only when base-token valuation is required.
- Reject the create request when its exposure is non-positive, non-finite, unsupported, or cannot be priced.
- Keep `RiskEngine.check_executor_action` synchronous and leave executor payloads unchanged.

## Verification

- Focused risk-gate tests: 28 passed
- Full test suite: 1,421 passed
