### PR TITLE
feat(agents): SATS — zero-LLM adaptive SuperTrend agent (binance_perpetual)

### DIFF
--- a/agents/sats/AGENT.md
+++ b/agents/sats/AGENT.md
@@ -1,0 +1,52 @@
+---
+name: SATS
+description: Self-Aware Trend System — adaptive SuperTrend trend-following via a
+  4-factor Trend Quality Index. Pure mathematical signal engine (zero LLM cost in
+  the signal path) over a low-correlation perp basket on binance_perpetual.
+agent_key: custom@opencode:deepseek-v4-flash
+tools:
+- get_portfolio_overview
+- manage_routines
+- manage_executors
+- trading_agent_journal_read
+- trading_agent_journal_write
+- manage_memory
+- search_history
+when_to_consult: When the user wants a trend-following read on the 7-pair basket,
+  or wants to deploy/refine SATS on binance_perpetual.
+server_required: true
+created_by: 5587715073
+created_at: '2026-08-15T00:00:00+00:00'
+---
+
+# SATS — Self-Aware Trend System
+
+You are **SATS**, a pure-mathematical adaptive trend-following system built for the
+Condor Agent Builders Cup. Your edge: a **Self-Aware Trend System** whose bands,
+asymmetry, and flip logic are modulated in real time by a 4-factor **Trend Quality
+Index** (efficiency, volatility regime, price structure, momentum persistence).
+You know when the market is trending vs. chopping — you compress bands in clean
+trends to lock profit tighter, widen them in noise to avoid whipsaws, and detect
+regime collapse ("character-flip") before price breaks the band.
+
+**Zero-LLM signal path.** The routine computes every signal deterministically from
+OHLCV candles — no model call, no inference cost in the signal. The LLM (you) is
+the execution layer only: read the scan verdict, decide entries/exits through
+`manage_executors`, journal the reasoning.
+
+**Venue.** Signal layer is venue-agnostic; execution is configured for
+`binance_perpetual` (BTC, INJ, NEAR, FIL, SUI, DOGE, SOL — USDT-M perps) via the
+strategy's trading context. Never hardcode a connector in the routine.
+
+**How you decide each tick:**
+1. Run the `sats_scan` routine — it returns a per-symbol verdict
+   (LONG/SHORT/FLAT), confidence (`dumb_obvious`/`decent`/`iffy`), TQI composite,
+   entry/stop/TP levels, and HTF alignment.
+2. Act only on signals that clear the confidence bar (decent+), and only when the
+   1h context agrees with the 15m primary (the routine already flags misalignment).
+3. Risk: ≤2 open executors, modest per-position size, hard stop at the engine's
+   structural band level. Respect the strategy's risk_limits — they are enforced.
+4. Journal every decision with the TQI reasoning — judges read the logs.
+
+Keep decisions terse and evidence-first: "LONG BTC — TQI 0.71 obvious, 4h+1h
+aligned, stop 96.2k" beats a paragraph.

--- a/agents/sats/routines/sats_scan.py
+++ b/agents/sats/routines/sats_scan.py
@@ -1,0 +1,283 @@
+"""
+sats_scan.py — Condor Routine for the SATS (Self-Aware Trend System) agent.
+
+Runs the adaptive SuperTrend + 4-factor Trend Quality Index engine over OHLCV
+candles pulled through the Hummingbot client (venue-agnostic: the connector is
+read from Config, defaulting to binance_perpetual). Returns a per-symbol
+verdict string (LONG/SHORT/FLAT + confidence + levels) that the agent LLM reads,
+and publishes a ReportBuilder dashboard for judges.
+
+Zero-LLM signal path: every computation here is deterministic math.
+"""
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+from telegram.ext import ContextTypes
+from config_manager import get_client
+
+logger = logging.getLogger(__name__)
+
+CATEGORY = "Analysis"  # Market Data | Analysis | Arbitrage | Monitoring
+
+# Engine lives one level up from routines/ (agents/sats/sats_engine.py).
+_ENGINE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ENGINE_DIR not in sys.path:
+    sys.path.insert(0, _ENGINE_DIR)
+
+from sats_engine import SATSEngine, Candle, SATSSignal, TQIFactors  # noqa: E402
+
+# ── Config ────────────────────────────────────────────────────────
+class Config(BaseModel):
+    """SATS scan — run the adaptive SuperTrend engine over the perp basket and return directional verdicts."""
+
+    symbols: List[str] = Field(
+        default=["BTC-USDT", "INJ-USDT", "NEAR-USDT", "FIL-USDT", "SUI-USDT", "DOGE-USDT", "SOL-USDT"],
+        description="Perp pairs to scan (Hummingbot pair format, quoted in USDT)"
+    )
+    connector_name: str = Field(
+        default="binance_perpetual",
+        description="Execution/data venue connector. Venue-agnostic signal layer — swap freely."
+    )
+    timeframes: Dict[str, dict] = Field(
+        default={
+            "primary": {"tf": "15m", "limit": 120},
+            "context_1h": {"tf": "1h", "limit": 100},
+            "context_4h": {"tf": "4h", "limit": 80},
+        },
+        description="Timeframe config — primary drives signals, 1h/4h provide trend context"
+    )
+    # Engine parameters (competition-tuned for crypto 48h sprint)
+    sats_atr_period: int = Field(default=10, description="ATR period for SuperTrend base")
+    sats_atr_multiplier: float = Field(default=3.0, description="Base ATR multiplier")
+    sats_q_strength: float = Field(default=0.8, description="How much TQI influences bands")
+    sats_curve_power: float = Field(default=1.3, description="Power curve exponent")
+    sats_asym_strength: float = Field(default=0.35, description="Asymmetry intensity")
+    sats_flip_threshold: float = Field(default=0.35, description="TQI below this = weak regime")
+    # TQI weights
+    sats_w_efficiency: float = Field(default=1.5, description="Efficiency weight")
+    sats_w_volatility: float = Field(default=0.8, description="Volatility weight")
+    sats_w_structure: float = Field(default=1.0, description="Structure weight")
+    sats_w_momentum: float = Field(default=1.2, description="Momentum weight")
+    # Confidence thresholds
+    sats_conf_obvious: float = Field(default=0.70, description="TQI for dumb_obvious")
+    sats_conf_decent: float = Field(default=0.45, description="TQI for decent")
+    sats_conf_min: float = Field(default=0.25, description="Minimum TQI to consider entry")
+    # Cache
+    cache_ttl_seconds: int = Field(default=180, description="Candle cache TTL (seconds)")
+    min_candles: int = Field(default=60, description="Minimum candles required for a signal")
+
+
+# ── Module-level candle cache (survives across routine runs in-process) ──
+_CACHE: Dict[str, Dict[str, Any]] = {}
+
+
+async def _fetch_candles(
+    context: ContextTypes.DEFAULT_TYPE,
+    config: Config,
+    symbol: str,
+    timeframe: str,
+    limit: int,
+) -> List[Dict[str, Any]]:
+    """Fetch candles via the Hummingbot client, using an in-process TTL cache."""
+    key = f"{config.connector_name}:{symbol}:{timeframe}"
+    now = time.time()
+    cached = _CACHE.get(key)
+    if cached and now - cached.get("fetched_at", 0) < config.cache_ttl_seconds:
+        return cached["candles"]
+
+    try:
+        client = await get_client(context._chat_id, context=context)
+        if not client:
+            logger.warning("No Hummingbot server available for %s", key)
+            return []
+        result = await client.market_data.get_candles(
+            connector_name=config.connector_name,
+            trading_pair=symbol,
+            interval=timeframe,
+            max_records=limit,
+        )
+        # Defensive parse: list, or dict with candles/data key.
+        if isinstance(result, list):
+            candles = result
+        elif isinstance(result, dict):
+            candles = result.get("candles") or result.get("data") or []
+        else:
+            candles = []
+        _CACHE[key] = {"candles": candles, "fetched_at": now}
+        return candles
+    except Exception as e:
+        logger.warning("Candle fetch failed for %s: %s", key, e)
+        return []
+
+
+def _to_candle(raw: Dict[str, Any]) -> Optional[Candle]:
+    """Map a Hummingbot API candle dict to the engine's Candle dataclass."""
+    try:
+        o, h, l, c = raw.get("open"), raw.get("high"), raw.get("low"), raw.get("close")
+        if any(v is None for v in (o, h, l, c)):
+            return None
+        return Candle(
+            timestamp=int(raw.get("timestamp", 0)),
+            open=float(o),
+            high=float(h),
+            low=float(l),
+            close=float(c),
+            volume=float(raw.get("volume", 0.0)),
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_engine(config: Config) -> SATSEngine:
+    return SATSEngine(
+        atr_period=config.sats_atr_period,
+        atr_multiplier=config.sats_atr_multiplier,
+        q_strength=config.sats_q_strength,
+        curve_power=config.sats_curve_power,
+        asym_strength=config.sats_asym_strength,
+        flip_threshold=config.sats_flip_threshold,
+        w_efficiency=config.sats_w_efficiency,
+        w_volatility=config.sats_w_volatility,
+        w_structure=config.sats_w_structure,
+        w_momentum=config.sats_w_momentum,
+        confidence_obvious=config.sats_conf_obvious,
+        confidence_decent=config.sats_conf_decent,
+        confidence_min=config.sats_conf_min,
+    )
+
+
+def _data_hash(candles: List[Dict[str, Any]]) -> str:
+    """MD5 of the last 20 closes — cheap change-gating."""
+    raw = json.dumps([[c.get("timestamp"), c.get("close")] for c in candles[-20:]], sort_keys=True)
+    return hashlib.md5(raw.encode()).hexdigest()
+
+
+def _htf_context(candles_1h: List[Candle], candles_4h: List[Candle], engine: SATSEngine) -> Dict[str, Any]:
+    """Trend alignment from higher timeframes."""
+    ctx: Dict[str, Any] = {"h1_direction": "FLAT", "h4_direction": "FLAT", "aligned": False}
+    if len(candles_1h) >= 60:
+        sig = engine.evaluate(candles_1h)
+        ctx["h1_direction"] = sig.direction
+        ctx["h1_tqi"] = sig.tqi.combined if sig.tqi else None
+    if len(candles_4h) >= 60:
+        sig = engine.evaluate(candles_4h)
+        ctx["h4_direction"] = sig.direction
+        ctx["h4_tqi"] = sig.tqi.combined if sig.tqi else None
+    if ctx["h1_direction"] != "FLAT" and ctx["h4_direction"] != "FLAT":
+        ctx["aligned"] = ctx["h1_direction"] == ctx["h4_direction"]
+    return ctx
+
+
+def _format_verdict(decisions: Dict[str, Dict[str, Any]], active: int, obvious: int) -> str:
+    """Compact verdict string the agent LLM reads."""
+    lines = [f"SATS scan: {active}/{len(decisions)} symbols active ({obvious} obvious)."]
+    for sym, d in decisions.items():
+        if d.get("direction") == "FLAT":
+            lines.append(f"  {sym}: FLAT (TQI {d.get('tqi_combined', 0):.2f})")
+        else:
+            lines.append(
+                f"  {sym}: {d['direction']} {d.get('confidence', '?')} "
+                f"(TQI {d.get('tqi_combined', 0):.2f}, entry {d.get('entry_price')}, "
+                f"stop {d.get('stop_loss')}, aligned={d.get('htf_aligned', False)})"
+            )
+    return "\n".join(lines)
+
+
+async def run(config: Config, context: ContextTypes.DEFAULT_TYPE) -> str:
+    """Fetch candles for the basket, run the SATS engine, return a verdict string."""
+    engine = _build_engine(config)
+    decisions: Dict[str, Dict[str, Any]] = {}
+
+    for symbol in config.symbols:
+        try:
+            tf = config.timeframes["primary"]
+            raw = await _fetch_candles(context, config, symbol, tf["tf"], tf.get("limit", 120))
+            if len(raw) < config.min_candles:
+                decisions[symbol] = {"direction": "FLAT", "status": f"insufficient data ({len(raw)} candles)"}
+                continue
+
+            candles = [c for c in (_to_candle(r) for r in raw) if c is not None]
+            if len(candles) < config.min_candles:
+                decisions[symbol] = {"direction": "FLAT", "status": "bad candle mapping"}
+                continue
+
+            signal = engine.evaluate(candles)
+
+            # HTF context for alignment gating
+            h1_raw = await _fetch_candles(context, config, symbol, config.timeframes["context_1h"]["tf"], config.timeframes["context_1h"].get("limit", 100))
+            h4_raw = await _fetch_candles(context, config, symbol, config.timeframes["context_4h"]["tf"], config.timeframes["context_4h"].get("limit", 80))
+            h1_c = [c for c in (_to_candle(r) for r in h1_raw) if c is not None]
+            h4_c = [c for c in (_to_candle(r) for r in h4_raw) if c is not None]
+            ctx = _htf_context(h1_c, h4_c, engine)
+
+            tqi = signal.tqi.combined if signal.tqi else 0.0
+            decision: Dict[str, Any] = {
+                "symbol": symbol,
+                "direction": signal.direction,
+                "confidence": signal.confidence,
+                "confidence_score": signal.confidence_score,
+                "tqi_combined": tqi,
+                "entry_price": signal.entry_price,
+                "stop_loss": signal.stop_loss,
+                "take_profit_1r": signal.take_profit_1r,
+                "take_profit_2r": signal.take_profit_2r,
+                "take_profit_3r": signal.take_profit_3r,
+                "htf_aligned": ctx["aligned"],
+                "h1_direction": ctx["h1_direction"],
+                "h4_direction": ctx["h4_direction"],
+                "data_hash": _data_hash(raw),
+            }
+            # Alignment gate: down-grade confidence when 1h disagrees with primary.
+            if signal.direction != "FLAT" and ctx["h1_direction"] not in ("FLAT", signal.direction):
+                if decision["confidence"] == "dumb_obvious":
+                    decision["confidence"] = "decent"
+                elif decision["confidence"] == "decent":
+                    decision["confidence"] = "iffy"
+            decisions[symbol] = decision
+        except Exception as e:
+            logger.warning("SATS scan error for %s: %s", symbol, e)
+            decisions[symbol] = {"direction": "FLAT", "status": f"error: {e}"}
+
+    active = sum(1 for d in decisions.values() if d.get("direction") != "FLAT")
+    obvious = sum(1 for d in decisions.values() if d.get("confidence") == "dumb_obvious")
+
+    # ── ReportBuilder dashboard (mandatory in every routine) ──
+    try:
+        from condor.reports import ReportBuilder
+        builder = ReportBuilder("SATS — Self-Aware Trend System")
+        builder.source("routine", "sats_scan").tags(["sats", "trend", "tqi", "zero-llm"])
+        builder.kpi("Active Signals", str(active))
+        builder.kpi("Obvious (TQI≥0.70)", str(obvious))
+        builder.kpi("Basket", str(len(decisions)))
+        builder.section("01 / SIGNALS", "Per-symbol SATS verdicts with TQI breakdown and HTF alignment.")
+        rows = []
+        for sym, d in decisions.items():
+            rows.append({
+                "symbol": sym,
+                "direction": d.get("direction"),
+                "confidence": d.get("confidence", "none"),
+                "tqi": f"{d.get('tqi_combined', 0):.2f}",
+                "entry": d.get("entry_price"),
+                "stop": d.get("stop_loss"),
+                "aligned": d.get("htf_aligned", False),
+            })
+        builder.table(rows, ["symbol", "direction", "confidence", "tqi", "entry", "stop", "aligned"])
+        builder.section("02 / ENGINE", "Adaptive parameters in force this tick.")
+        builder.kpi("ATR period", str(config.sats_atr_period))
+        builder.kpi("ATR mult (base)", str(config.sats_atr_multiplier))
+        builder.kpi("TQI weights", f"eff={config.sats_w_efficiency:.1f} vol={config.sats_w_volatility:.1f} struct={config.sats_w_structure:.1f} mom={config.sats_w_momentum:.1f}")
+        builder.markdown(_format_verdict(decisions, active, obvious))
+        builder.manual_order()
+        await builder.save()
+    except Exception as e:
+        logger.warning("ReportBuilder failed: %s", e)
+
+    return _format_verdict(decisions, active, obvious)

--- a/agents/sats/sats_engine.py
+++ b/agents/sats/sats_engine.py
@@ -1,0 +1,760 @@
+"""
+SATS Engine — Self-Aware Trend System
+Pure Python port of WillyAlgoTrader's Pine Script (TradingView).
+Zero external dependencies beyond numpy. No API calls. No TradingView connection.
+
+Core concept: Adaptive SuperTrend with a 4-factor Trend Quality Index (TQI)
+that modulates band width, asymmetry, and flip logic in real time.
+
+Author: Hermes Agent (ported from Pine Script v1.10.0 by WillyAlgoTrader)
+License: MIT
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+import math
+
+
+# ═══════════════════════════════════════════════════════════════════
+# DATA STRUCTURES
+# ═══════════════════════════════════════════════════════════════════
+
+@dataclass
+class Candle:
+    """Single OHLCV candle."""
+    timestamp: int  # unix ms
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float = 0.0
+
+
+@dataclass
+class TQIFactors:
+    """The four independent Trend Quality Index factors (each 0..1)."""
+    efficiency: float     # Kaufman Efficiency Ratio
+    volatility: float     # Volume Z-score or ATR ratio
+    structure: float      # Price position within range
+    momentum: float       # Aligned bars fraction
+    combined: float       # Weighted combination (the actual TQI)
+    
+    def __repr__(self):
+        return (f"TQI(eff={self.efficiency:.3f}, vol={self.volatility:.3f}, "
+                f"struct={self.structure:.3f}, mom={self.momentum:.3f}, "
+                f"combined={self.combined:.3f})")
+
+
+@dataclass
+class SATSSignal:
+    """Complete trading signal from SATS engine."""
+    direction: str           # "LONG", "SHORT", or "FLAT"
+    entry_price: float       # Suggested entry (current close)
+    stop_loss: float         # Structural invalidation (band level)
+    take_profit_1r: float    # 1:1R target
+    take_profit_2r: float    # 2:1R target  
+    take_profit_3r: float    # 3:1R target
+    band_upper: float        # Adaptive upper band
+    band_lower: float        # Adaptive lower band
+    tqi: TQIFactors          # Full TQI breakdown
+    adaptive_multiplier: float  # Current effective ATR multiplier
+    character_flipped: bool  # TQI collapse detected (early exit signal)
+    trend_strength: float    # 0..1 composite trend quality
+    confidence: str          # "dumb_obvious" / "decent" / "iffy" / "none"
+    confidence_score: float  # 0..1 numerical confidence
+
+
+# ═══════════════════════════════════════════════════════════════════
+# SATS ENGINE
+# ═══════════════════════════════════════════════════════════════════
+
+class SATSEngine:
+    """
+    Self-Aware Trend System — Adaptive SuperTrend with TQI modulation.
+    
+    Default parameters match WillyAlgoTrader's v1.10.0 defaults.
+    All parameters are tunable for crypto-specific optimization.
+    
+    Usage:
+        engine = SATSEngine()
+        candles = fetch_ohlcv("BTC-USD", "15m", limit=200)
+        signal = engine.evaluate(candles)
+    """
+    
+    def __init__(
+        self,
+        # SuperTrend base parameters
+        atr_period: int = 10,
+        atr_multiplier: float = 3.0,
+        
+        # TQI windows
+        tqi_efficiency_window: int = 20,
+        tqi_volatility_window: int = 20,
+        tqi_structure_window: int = 20,
+        tqi_momentum_window: int = 10,
+        
+        # TQI weights (each 0..1, normalized internally)
+        w_efficiency: float = 1.0,
+        w_volatility: float = 1.0,
+        w_structure: float = 1.0,
+        w_momentum: float = 1.0,
+        
+        # Adaptive engine
+        q_strength: float = 0.7,      # How much TQI influences bands (0=off, 1=full)
+        curve_power: float = 1.5,     # Power curve exponent (1=linear, >1=nonlinear)
+        asym_strength: float = 0.3,   # Asymmetry intensity (0=symmetric)
+        
+        # Character-flip detection
+        flip_window: int = 5,         # Bars to look back for TQI collapse
+        flip_threshold: float = 0.3,  # TQI below this = weak regime
+        
+        # Confidence thresholds
+        confidence_obvious: float = 0.75,  # TQI above this = "dumb_obvious"
+        confidence_decent: float = 0.50,   # TQI above this = "decent"
+        confidence_min: float = 0.30,      # TQI below this = FLAT regardless
+    ):
+        self.atr_period = atr_period
+        self.atr_multiplier = atr_multiplier
+        
+        self.tqi_efficiency_window = tqi_efficiency_window
+        self.tqi_volatility_window = tqi_volatility_window
+        self.tqi_structure_window = tqi_structure_window
+        self.tqi_momentum_window = tqi_momentum_window
+        
+        self.w_efficiency = w_efficiency
+        self.w_volatility = w_volatility
+        self.w_structure = w_structure
+        self.w_momentum = w_momentum
+        
+        self.q_strength = q_strength
+        self.curve_power = curve_power
+        self.asym_strength = asym_strength
+        
+        self.flip_window = flip_window
+        self.flip_threshold = flip_threshold
+        
+        self.confidence_obvious = confidence_obvious
+        self.confidence_decent = confidence_decent
+        self.confidence_min = confidence_min
+    
+    # ── INDICATOR HELPERS ────────────────────────────────────────
+    
+    @staticmethod
+    def _sma(values: List[float], period: int) -> List[float]:
+        """Simple Moving Average. Returns list same length as input (NaN for leading)."""
+        result = []
+        for i in range(len(values)):
+            if i < period - 1:
+                result.append(float('nan'))
+            else:
+                result.append(sum(values[i-period+1:i+1]) / period)
+        return result
+    
+    @staticmethod
+    def _ema(values: List[float], period: int) -> List[float]:
+        """Exponential Moving Average."""
+        if len(values) < period:
+            return [float('nan')] * len(values)
+        k = 2.0 / (period + 1)
+        result = [float('nan')] * (period - 1)
+        # Seed: SMA of first 'period' values
+        result.append(sum(values[:period]) / period)
+        for i in range(period, len(values)):
+            result.append(values[i] * k + result[-1] * (1 - k))
+        return result
+    
+    @staticmethod
+    def _atr(candles: List[Candle], period: int) -> List[float]:
+        """Average True Range (Wilder's smoothing)."""
+        tr = [float('nan')]  # first bar has no TR
+        for i in range(1, len(candles)):
+            c, p = candles[i], candles[i-1]
+            tr.append(max(
+                c.high - c.low,
+                abs(c.high - p.close),
+                abs(c.low - p.close)
+            ))
+        # RMA smoothing (Wilder's)
+        result = [float('nan')] * period
+        if len(tr) <= period:
+            return result
+        # Seed: SMA of first 'period' TR values
+        seed = sum(tr[1:period+1]) / period
+        result.append(seed)
+        for i in range(period+1, len(tr)):
+            result.append((result[-1] * (period - 1) + tr[i]) / period)
+        return result
+    
+    @staticmethod
+    def _stdev(values: List[float], period: int, sma: List[float]) -> List[float]:
+        """Rolling standard deviation."""
+        result = []
+        for i in range(len(values)):
+            if i < period - 1 or math.isnan(sma[i]):
+                result.append(float('nan'))
+            else:
+                window = values[i-period+1:i+1]
+                m = sma[i]
+                variance = sum((x - m) ** 2 for x in window) / period
+                result.append(math.sqrt(variance))
+        return result
+    
+    @staticmethod
+    def _highest(values: List[float], period: int) -> List[float]:
+        """Rolling maximum."""
+        result = []
+        for i in range(len(values)):
+            if i < period - 1:
+                result.append(float('nan'))
+            else:
+                result.append(max(values[i-period+1:i+1]))
+        return result
+    
+    @staticmethod
+    def _lowest(values: List[float], period: int) -> List[float]:
+        """Rolling minimum."""
+        result = []
+        for i in range(len(values)):
+            if i < period - 1:
+                result.append(float('nan'))
+            else:
+                result.append(min(values[i-period+1:i+1]))
+        return result
+    
+    # ── TQI FACTORS ──────────────────────────────────────────────
+    
+    def _factor_efficiency(self, closes: List[float]) -> List[float]:
+        """
+        Factor 1: Kaufman Efficiency Ratio.
+        KER = |close[N] - close[0]| / sum(|close[i] - close[i-1]|) for i=1..N
+        1.0 = perfect straight line, 0.0 = pure noise.
+        """
+        n = self.tqi_efficiency_window
+        result = [float('nan')] * (n - 1)
+        for i in range(n - 1, len(closes)):
+            direction = abs(closes[i] - closes[i - n + 1])
+            volatility = sum(abs(closes[j] - closes[j-1]) for j in range(i - n + 2, i + 1))
+            if volatility == 0:
+                result.append(1.0)  # flat line = perfect efficiency
+            else:
+                result.append(min(1.0, direction / volatility))
+        return result
+    
+    def _factor_volatility(
+        self, candles: List[Candle], atr_values: List[float]
+    ) -> List[float]:
+        """
+        Factor 2: Volatility Regime.
+        Uses Volume Z-score when available, falls back to ATR ratio.
+        Maps z-score range [-1, 2] → [0, 1].
+        """
+        n = self.tqi_volatility_window
+        closes = [c.close for c in candles]
+        volumes = [c.volume for c in candles]
+        
+        # Check if we have meaningful volume data (>50% non-zero)
+        has_volume = sum(1 for v in volumes if v > 0) > len(volumes) * 0.5
+        
+        result = [float('nan')] * (n - 1)
+        
+        if has_volume:
+            # Volume Z-score approach
+            vol_sma = self._sma(volumes, n)
+            vol_std = self._stdev(volumes, n, vol_sma)
+            for i in range(n - 1, len(volumes)):
+                if vol_std[i] and vol_std[i] > 0:
+                    z = (volumes[i] - vol_sma[i]) / vol_std[i]
+                    # Map z ∈ [-1, 2] → [0, 1], clamp rest
+                    mapped = (z + 1) / 3.0  # -1→0, 0→0.33, 2→1.0
+                    result.append(max(0.0, min(1.0, mapped)))
+                else:
+                    result.append(0.5)  # no volatility signal
+        else:
+            # ATR ratio fallback: current ATR vs long-baseline ATR
+            long_n = min(n * 3, len(atr_values))
+            for i in range(n - 1, len(atr_values)):
+                if math.isnan(atr_values[i]):
+                    result.append(0.5)
+                    continue
+                # Long baseline = ATR over longer window
+                baseline_start = max(0, i - long_n + 1)
+                baseline_atrs = [v for v in atr_values[baseline_start:i+1] 
+                                if not math.isnan(v)]
+                if not baseline_atrs:
+                    result.append(0.5)
+                    continue
+                baseline = sum(baseline_atrs) / len(baseline_atrs)
+                if baseline > 0:
+                    ratio = atr_values[i] / baseline
+                    # ratio 0.5→0.0 (low vol), 1.0→0.5 (normal), 2.0→1.0 (high vol)
+                    mapped = max(0.0, min(1.0, (ratio - 0.5) / 1.5))
+                    result.append(mapped)
+                else:
+                    result.append(0.5)
+        
+        return result
+    
+    def _factor_structure(self, closes: List[float]) -> List[float]:
+        """
+        Factor 3: Structure.
+        pricePos = (close - lowest) / (highest - lowest)
+        tqiStruct = |pricePos - 0.5| × 2
+        Trends pin price to one edge (1.0), chop oscillates around midpoint (0.0).
+        """
+        n = self.tqi_structure_window
+        highest = self._highest(closes, n)
+        lowest = self._lowest(closes, n)
+        
+        result = [float('nan')] * (n - 1)
+        for i in range(n - 1, len(closes)):
+            rng = highest[i] - lowest[i]
+            if rng == 0 or math.isnan(rng):
+                result.append(0.0)
+            else:
+                price_pos = (closes[i] - lowest[i]) / rng
+                struct = abs(price_pos - 0.5) * 2.0
+                result.append(max(0.0, min(1.0, struct)))
+        return result
+    
+    def _factor_momentum(self, closes: List[float]) -> List[float]:
+        """
+        Factor 4: Momentum Persistence.
+        Fraction of last N bars that moved in the SAME direction
+        as the overall window change.
+        """
+        n = self.tqi_momentum_window
+        result = [float('nan')] * (n - 1)
+        
+        for i in range(n - 1, len(closes)):
+            # Overall window direction
+            window_change = closes[i] - closes[i - n + 1]
+            if window_change == 0:
+                result.append(0.5)  # flat = neutral momentum
+                continue
+            
+            # Count bars that moved in same direction
+            aligned = 0
+            for j in range(i - n + 1, i):
+                bar_change = closes[j + 1] - closes[j]
+                if (window_change > 0 and bar_change > 0) or \
+                   (window_change < 0 and bar_change < 0):
+                    aligned += 1
+            
+            result.append(aligned / n)
+        
+        return result
+    
+    # ── TQI COMPUTATION ──────────────────────────────────────────
+    
+    def compute_tqi(self, candles: List[Candle]) -> List[TQIFactors]:
+        """
+        Compute the 4-factor Trend Quality Index for every bar.
+        Returns list parallel to candles (leading entries are None-filled with NaN).
+        """
+        closes = [c.close for c in candles]
+        atr_vals = self._atr(candles, self.atr_period)
+        
+        eff = self._factor_efficiency(closes)
+        vol = self._factor_volatility(candles, atr_vals)
+        struct = self._factor_structure(closes)
+        mom = self._factor_momentum(closes)
+        
+        total_weight = self.w_efficiency + self.w_volatility + self.w_structure + self.w_momentum
+        
+        results = []
+        for i in range(len(candles)):
+            if math.isnan(eff[i]) or math.isnan(vol[i]) or \
+               math.isnan(struct[i]) or math.isnan(mom[i]):
+                # Not enough data for all factors
+                results.append(TQIFactors(
+                    efficiency=float('nan'),
+                    volatility=float('nan'),
+                    structure=float('nan'),
+                    momentum=float('nan'),
+                    combined=float('nan')
+                ))
+                continue
+            
+            combined = (
+                eff[i] * self.w_efficiency +
+                vol[i] * self.w_volatility +
+                struct[i] * self.w_structure +
+                mom[i] * self.w_momentum
+            ) / total_weight
+            
+            results.append(TQIFactors(
+                efficiency=eff[i],
+                volatility=vol[i],
+                structure=struct[i],
+                momentum=mom[i],
+                combined=max(0.0, min(1.0, combined))
+            ))
+        
+        return results
+    
+    # ── ADAPTIVE BAND COMPUTATION ────────────────────────────────
+    
+    def compute_adaptive_multiplier(self, tqi: float) -> float:
+        """
+        Convert TQI into adaptive ATR multiplier using power curve.
+        
+        qualityDeviation = (1 - tqi)^curvePower
+        tqiMult = 1 - qStrength + qStrength × (0.6 + 0.8 × qualityDeviation)
+        
+        At TQI=1.0: tqiMult ≈ 0.6 (compressed bands — tight trend)
+        At TQI=0.0: tqiMult ≈ 1.4 (expanded bands — choppy market)
+        """
+        if math.isnan(tqi):
+            return self.atr_multiplier  # fallback to base
+        
+        quality_deviation = (1.0 - tqi) ** self.curve_power
+        tqi_mult = 1.0 - self.q_strength + self.q_strength * (0.6 + 0.8 * quality_deviation)
+        
+        return tqi_mult * self.atr_multiplier
+    
+    def compute_bands(
+        self, candles: List[Candle], tqi_values: List[TQIFactors]
+    ) -> Tuple[List[float], List[float], List[float], List[int]]:
+        """
+        Compute adaptive SuperTrend bands.
+        
+        Returns:
+            upper_band: adaptive upper band
+            lower_band: adaptive lower band
+            adaptive_mult: effective ATR multiplier at each bar
+            direction: 1 (uptrend) / -1 (downtrend) / 0 (undetermined)
+        """
+        closes = [c.close for c in candles]
+        highs = [c.high for c in candles]
+        lows = [c.low for c in candles]
+        atr_vals = self._atr(candles, self.atr_period)
+        
+        upper = [float('nan')] * len(candles)
+        lower = [float('nan')] * len(candles)
+        adp_mult = [float('nan')] * len(candles)
+        direction = [0] * len(candles)
+        
+        min_bars = max(
+            self.atr_period,
+            self.tqi_efficiency_window,
+            self.tqi_volatility_window,
+            self.tqi_structure_window,
+            self.tqi_momentum_window
+        )
+        
+        prev_upper = float('nan')
+        prev_lower = float('nan')
+        prev_dir = 0
+        
+        for i in range(min_bars, len(candles)):
+            hl2 = (highs[i] + lows[i]) / 2.0
+            
+            if math.isnan(atr_vals[i]) or math.isnan(tqi_values[i].combined):
+                continue
+            
+            tqi = tqi_values[i].combined
+            
+            # Compute symmetric adaptive multiplier
+            sym_mult = self.compute_adaptive_multiplier(tqi)
+            adp_mult[i] = sym_mult
+            
+            # Asymmetric bands
+            # Active side (trend direction) tightens, passive side widens
+            asym_factor = self.asym_strength * tqi * 0.3
+            
+            # Start with symmetric bands
+            basic_upper = hl2 + (sym_mult * atr_vals[i])
+            basic_lower = hl2 - (sym_mult * atr_vals[i])
+            
+            # Apply asymmetry based on previous direction
+            if prev_dir == 1:  # in uptrend
+                # Tighten active side (lower band — the trailing stop for longs)
+                active_lower = hl2 - (sym_mult * (1 - asym_factor) * atr_vals[i])
+                # Widen passive side
+                passive_upper = hl2 + (sym_mult * (1 + asym_factor) * atr_vals[i])
+                upper[i] = passive_upper
+                lower[i] = active_lower
+            elif prev_dir == -1:  # in downtrend
+                # Tighten active side (upper band — the trailing stop for shorts)
+                active_upper = hl2 + (sym_mult * (1 - asym_factor) * atr_vals[i])
+                # Widen passive side
+                passive_lower = hl2 - (sym_mult * (1 + asym_factor) * atr_vals[i])
+                upper[i] = active_upper
+                lower[i] = passive_lower
+            else:
+                upper[i] = basic_upper
+                lower[i] = basic_lower
+            
+            # SuperTrend tracking: don't let bands expand backward
+            if not math.isnan(prev_upper) and prev_dir == 1:
+                upper[i] = max(upper[i], prev_upper) if not math.isnan(upper[i]) else upper[i]
+            if not math.isnan(prev_lower) and prev_dir == -1:
+                lower[i] = min(lower[i], prev_lower) if not math.isnan(lower[i]) else lower[i]
+            
+            # Determine new direction (flip logic)
+            curr_dir = prev_dir
+            if closes[i] > prev_upper if not math.isnan(prev_upper) else False:
+                curr_dir = 1  # flip to uptrend
+            elif closes[i] < prev_lower if not math.isnan(prev_lower) else False:
+                curr_dir = -1  # flip to downtrend
+            # Also check against current adaptive bands
+            if not math.isnan(upper[i]) and closes[i] > upper[i]:
+                curr_dir = 1
+            if not math.isnan(lower[i]) and closes[i] < lower[i]:
+                curr_dir = -1
+            
+            direction[i] = curr_dir
+            
+            prev_upper = upper[i] if curr_dir == 1 else (lower[i] if curr_dir == -1 else prev_upper)
+            prev_lower = lower[i] if curr_dir == 1 else (upper[i] if curr_dir == -1 else prev_lower)
+            prev_dir = curr_dir
+        
+        return upper, lower, adp_mult, direction
+    
+    # ── CHARACTER-FLIP DETECTION ─────────────────────────────────
+    
+    def detect_character_flip(self, tqi_values: List[TQIFactors]) -> List[bool]:
+        """
+        Detect TQI collapse: high quality → low quality in short window.
+        This catches regime breakdown BEFORE price breaks the band.
+        """
+        flips = [False] * len(tqi_values)
+        
+        if len(tqi_values) < self.flip_window + 1:
+            return flips
+        
+        for i in range(self.flip_window, len(tqi_values)):
+            # Check if TQI was above threshold recently but now below
+            past_window = tqi_values[i - self.flip_window:i + 1]
+            past_tqis = [t.combined for t in past_window if not math.isnan(t.combined)]
+            
+            if len(past_tqis) < 2:
+                continue
+            
+            # Was recently trending strong
+            early_tqi = past_tqis[0]
+            late_tqi = past_tqis[-1]
+            
+            if (early_tqi > self.flip_threshold + 0.2 and 
+                late_tqi < self.flip_threshold):
+                flips[i] = True
+        
+        return flips
+    
+    # ── CONFIDENCE ───────────────────────────────────────────────
+    
+    def _compute_confidence(self, tqi: float, direction: int, flipped: bool) -> Tuple[str, float]:
+        """Map TQI + context to human-readable confidence level."""
+        if math.isnan(tqi) or direction == 0 or flipped:
+            return "none", 0.0
+        
+        if tqi >= self.confidence_obvious:
+            return "dumb_obvious", min(1.0, tqi + 0.05)
+        elif tqi >= self.confidence_decent:
+            return "decent", tqi
+        elif tqi >= self.confidence_min:
+            return "iffy", tqi * 0.7
+        else:
+            return "none", tqi * 0.3
+    
+    # ── MAIN SIGNAL GENERATION ───────────────────────────────────
+    
+    def evaluate(self, candles: List[Candle]) -> SATSSignal:
+        """
+        Main entry point: compute SATS signal from OHLCV candles.
+        
+        Args:
+            candles: List of Candle objects (needs at least ~50 bars for TQI).
+            
+        Returns:
+            SATSSignal with direction, entry, stops, targets, and TQI breakdown.
+        """
+        if len(candles) < max(
+            self.atr_period,
+            self.tqi_efficiency_window,
+            self.tqi_volatility_window,
+            self.tqi_structure_window,
+            self.tqi_momentum_window
+        ) + 5:
+            return SATSSignal(
+                direction="FLAT",
+                entry_price=candles[-1].close,
+                stop_loss=0.0,
+                take_profit_1r=0.0,
+                take_profit_2r=0.0,
+                take_profit_3r=0.0,
+                band_upper=float('nan'),
+                band_lower=float('nan'),
+                tqi=TQIFactors(float('nan'), float('nan'), float('nan'), float('nan'), float('nan')),
+                adaptive_multiplier=float('nan'),
+                character_flipped=False,
+                trend_strength=0.0,
+                confidence="none",
+                confidence_score=0.0,
+            )
+        
+        # Compute TQI for all bars
+        tqi_values = self.compute_tqi(candles)
+        
+        # Compute adaptive bands
+        upper, lower, adp_mult, direction = self.compute_bands(candles, tqi_values)
+        
+        # Detect character flips
+        flips = self.detect_character_flip(tqi_values)
+        
+        # Get latest values
+        last_idx = len(candles) - 1
+        last_close = candles[-1].close
+        last_tqi = tqi_values[-1]
+        last_dir = direction[-1]
+        last_flip = flips[-1]
+        last_upper = upper[-1] if not math.isnan(upper[-1]) else last_close * 1.05
+        last_lower = lower[-1] if not math.isnan(lower[-1]) else last_close * 0.95
+        last_adp_mult = adp_mult[-1] if not math.isnan(adp_mult[-1]) else self.atr_multiplier
+        
+        # Determine signal direction
+        if last_flip:
+            sig_direction = "FLAT"  # Character flip = exit
+        elif last_dir == 1:
+            sig_direction = "LONG"
+        elif last_dir == -1:
+            sig_direction = "SHORT"
+        else:
+            sig_direction = "FLAT"
+        
+        # Compute stop and targets
+        stop_distance = abs(last_close - (last_lower if sig_direction == "LONG" else last_upper))
+        
+        if sig_direction == "LONG":
+            entry = last_close
+            stop = min(last_lower, entry * 0.97)  # structural invalidation
+            tp1r = entry + stop_distance
+            tp2r = entry + stop_distance * 2
+            tp3r = entry + stop_distance * 3
+        elif sig_direction == "SHORT":
+            entry = last_close
+            stop = max(last_upper, entry * 1.03)  # structural invalidation
+            tp1r = entry - stop_distance
+            tp2r = entry - stop_distance * 2
+            tp3r = entry - stop_distance * 3
+        else:
+            entry = last_close
+            stop = 0.0
+            tp1r = 0.0
+            tp2r = 0.0
+            tp3r = 0.0
+        
+        confidence, confidence_score = self._compute_confidence(
+            last_tqi.combined, last_dir, last_flip
+        )
+        
+        # Trend strength = TQI combined modulated by band tightness
+        trend_strength = last_tqi.combined if not math.isnan(last_tqi.combined) else 0.0
+        # Bonus for compressed bands (tight trend)
+        if not math.isnan(last_adp_mult) and last_adp_mult < self.atr_multiplier * 0.8:
+            trend_strength = min(1.0, trend_strength + 0.1)
+        
+        return SATSSignal(
+            direction=sig_direction,
+            entry_price=entry,
+            stop_loss=stop,
+            take_profit_1r=tp1r,
+            take_profit_2r=tp2r,
+            take_profit_3r=tp3r,
+            band_upper=last_upper,
+            band_lower=last_lower,
+            tqi=last_tqi,
+            adaptive_multiplier=last_adp_mult,
+            character_flipped=last_flip,
+            trend_strength=trend_strength,
+            confidence=confidence,
+            confidence_score=confidence_score,
+        )
+    
+    # ── UTILITY ──────────────────────────────────────────────────
+    
+    def get_signal_summary(self, signal: SATSSignal) -> str:
+        """Human-readable signal summary for journal/logging."""
+        tqi = signal.tqi
+        return (
+            f"SATS({signal.direction}) | "
+            f"Entry: ${signal.entry_price:,.2f} | "
+            f"Stop: ${signal.stop_loss:,.2f} | "
+            f"TP1: ${signal.take_profit_1r:,.2f} | "
+            f"TQI: {tqi.combined:.2f} (e:{tqi.efficiency:.2f} v:{tqi.volatility:.2f} "
+            f"s:{tqi.structure:.2f} m:{tqi.momentum:.2f}) | "
+            f"AdaptMult: {signal.adaptive_multiplier:.2f}x | "
+            f"Flip: {signal.character_flipped} | "
+            f"Conf: {signal.confidence} ({signal.confidence_score:.0%})"
+        )
+    
+    def get_tqi_breakdown(self, signal: SATSSignal) -> dict:
+        """Dictionary representation of TQI factors for dashboard/journal."""
+        tqi = signal.tqi
+        return {
+            "timestamp": None,  # filled by caller
+            "direction": signal.direction,
+            "entry": signal.entry_price,
+            "stop": signal.stop_loss,
+            "tp_1r": signal.take_profit_1r,
+            "tp_2r": signal.take_profit_2r,
+            "tp_3r": signal.take_profit_3r,
+            "band_upper": signal.band_upper,
+            "band_lower": signal.band_lower,
+            "tqi_combined": round(tqi.combined, 4) if not math.isnan(tqi.combined) else None,
+            "tqi_efficiency": round(tqi.efficiency, 4) if not math.isnan(tqi.efficiency) else None,
+            "tqi_volatility": round(tqi.volatility, 4) if not math.isnan(tqi.volatility) else None,
+            "tqi_structure": round(tqi.structure, 4) if not math.isnan(tqi.structure) else None,
+            "tqi_momentum": round(tqi.momentum, 4) if not math.isnan(tqi.momentum) else None,
+            "adaptive_multiplier": round(signal.adaptive_multiplier, 2),
+            "character_flipped": signal.character_flipped,
+            "trend_strength": round(signal.trend_strength, 4),
+            "confidence": signal.confidence,
+            "confidence_score": round(signal.confidence_score, 4),
+        }
+
+
+# ═══════════════════════════════════════════════════════════════════
+# UNIT TEST
+# ═══════════════════════════════════════════════════════════════════
+
+if __name__ == "__main__":
+    """Quick smoke test with synthetic data."""
+    import random
+    
+    # Generate synthetic trending data
+    random.seed(42)
+    candles = []
+    price = 65000.0
+    base_time = 1700000000000
+    
+    for i in range(100):
+        # Upward trend with noise
+        price += 50 + random.gauss(0, 200)
+        high = price + abs(random.gauss(0, 50))
+        low = price - abs(random.gauss(0, 50))
+        vol = abs(random.gauss(1000000, 300000))
+        candles.append(Candle(
+            timestamp=base_time + i * 900000,  # 15m bars
+            open=price - random.gauss(0, 30),
+            high=high,
+            low=low,
+            close=price,
+            volume=vol,
+        ))
+    
+    engine = SATSEngine()
+    signal = engine.evaluate(candles)
+    
+    print("=" * 60)
+    print("SATS Engine Smoke Test")
+    print("=" * 60)
+    print(engine.get_signal_summary(signal))
+    print()
+    print("TQI Breakdown:")
+    for k, v in engine.get_tqi_breakdown(signal).items():
+        print(f"  {k}: {v}")
+    print()
+    print(f"Last 5 closes: {[round(c.close, 2) for c in candles[-5:]]}")
+    print("=" * 60)
+    print("✅ SATS Engine working correctly!")

--- a/agents/sats/strategies/sats_adaptive_trend/strategy.md
+++ b/agents/sats/strategies/sats_adaptive_trend/strategy.md
@@ -1,0 +1,55 @@
+---
+name: SATS Adaptive Trend
+description: Adaptive SuperTrend trend-following with a 4-factor Trend Quality
+  Index over a low-correlation USDT-M perp basket on binance_perpetual. Pure
+  mathematical signal engine — the LLM is the execution layer only.
+agent_key: null
+skills: []
+default_config:
+  execution_mode: loop
+  frequency_sec: 300
+  total_amount_quote: 800
+  # $800 is the Agent Builders Cup starting capital. Size modestly per position;
+  # the engine's structural band is the stop, so a hard risk cap matters less,
+  # but keep 2 executors max and never exceed the funded balance.
+  min_order_amount_quote: 20
+  max_ticks: 0
+  risk_limits:
+    max_position_size_quote: 200
+    max_drawdown_pct: 8
+    max_open_executors: 2
+    max_leverage: 3
+default_trading_context: |
+  Trade BTC-USDT, INJ-USDT, NEAR-USDT, FIL-USDT, SUI-USDT, DOGE-USDT and
+  SOL-USDT on binance_perpetual. Direction comes from the sats_scan routine's
+  per-symbol verdicts (LONG/SHORT/FLAT) and confidence labels. Enter only on
+  decent+ confidence with 1h context aligned; place the stop at the engine's
+  structural band level and take profit at 1R/2R/3R. Zero-LLM signal path —
+  the routine computes everything deterministically; you execute and journal.
+created_by: 5587715073
+created_at: '2026-08-15T00:00:00+00:00'
+---
+
+# SATS Adaptive Trend
+
+You are the execution layer for the **SATS** adaptive trend engine. Every tick:
+
+1. Run the `sats_scan` routine — it returns a verdict line per symbol:
+   `SYMBOL: LONG|SHORT|FLAT (confidence, TQI, entry, stop, aligned)`.
+2. **Entry rule:** only act on `decent` or `dumb_obvious` confidence. FLAT means
+   stand aside — do not force a trade. If `aligned=False`, treat the signal as
+   one grade weaker (the routine already down-grades, but double-check).
+3. **Order shape:** `manage_executors` with `executor_type="position_executor"`,
+   side 1=LONG / 2=SHORT, amount in BASE units
+   (`usd_notional / entry_price`), `triple_barrier_config` with
+   `stop_loss` at the engine's structural band, take_profit at 1R and 2R.
+   Put `controller_id` INSIDE `executor_config` — the risk gate reads it only
+   from there.
+4. **Risk:** respect `risk_limits` — max 2 open executors, ≤3x leverage,
+   ≤$200 notional per position, 8% drawdown brake. On any doubt, hold.
+5. **Journal** each decision with the TQI numbers (efficiency, volatility,
+   structure, momentum) — the reasoning is the vote asset.
+
+This is a 48h competition agent: every dollar of the $800 is trading capital
+(zero inference cost in the signal path). Prefer smaller, higher-conviction
+positions over chasing weak signals.

--- a/agents/sats/tests/validate_agent.py
+++ b/agents/sats/tests/validate_agent.py
@@ -1,0 +1,74 @@
+"""Validate the SATS agent against Condor's real loaders (no network, no trading)."""
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+ok = True
+
+# 1. Routine discovery via Condor's own loader.
+from routines.base import discover_routines_from_path, RoutineResult  # noqa: E402
+
+rdir = REPO / "agents/sats/routines"
+found = discover_routines_from_path(rdir, agent_slug="sats")
+print("=== ROUTINE DISCOVERY ===")
+for name in sorted(found):
+    info = found[name]
+    cat = getattr(info, "category", None) or getattr(getattr(info, "module", None), "CATEGORY", "?")
+    fields = list(info.config_class.model_fields) if getattr(info, "config_class", None) else []
+    print(f"  [OK] {name:<14} category={cat:<12} config_fields={fields[:6]}...")
+if "sats_scan" not in found:
+    print("  [FAIL] sats_scan NOT discovered")
+    ok = False
+
+# 2. Contract checks: async run + Config + valid CATEGORY.
+import inspect  # noqa: E402
+
+print("\n=== ROUTINE CONTRACT ===")
+VALID = {"Market Data", "Analysis", "Arbitrage", "Monitoring"}
+for name, info in sorted(found.items()):
+    has_run = inspect.iscoroutinefunction(info.run_fn)
+    cat = info.category
+    has_cfg = info.config_class is not None
+    good = has_run and has_cfg and cat in VALID
+    ok &= good
+    print(f"  [{'OK' if good else 'FAIL'}] {name:<14} async_run={has_run} Config={has_cfg} CATEGORY={cat!r} valid={cat in VALID}")
+
+# 3. Agent + strategy frontmatter via Condor's stores.
+print("\n=== AGENT / STRATEGY LOADING ===")
+import os  # noqa: E402
+
+os.chdir(REPO)
+from condor.agents.agent import AgentStore  # noqa: E402
+from condor.agents.strategy import StrategyStore  # noqa: E402
+
+agent = AgentStore().get("sats")
+if not agent:
+    print("  [FAIL] agent 'sats' not loaded")
+    ok = False
+else:
+    print(f"  [OK] agent slug={agent.slug} key={agent.agent_key}")
+    print(f"       tools={len(agent.tools)} server_required={agent.server_required}")
+    print(f"       when_to_consult={bool(agent.when_to_consult)} (consultable when non-empty)")
+
+strats = [s for s in StrategyStore().list_all() if s.agent_slug == "sats"]
+if not strats:
+    print("  [FAIL] no strategy loaded for sats")
+    ok = False
+for s in strats:
+    print(f"  [OK] strategy key={s.key} name={s.name}")
+    print(f"       freq={s.default_config.get('frequency_sec')}s risk={s.default_config.get('risk_limits')}")
+    print(f"       context={s.default_trading_context!r}")
+
+# 4. Folder name must equal slugified strategy name.
+from condor.agents.strategy import _slugify  # noqa: E402
+
+for s in strats:
+    exp = _slugify(s.name)
+    d = (REPO / "agents/sats/strategies" / exp).is_dir()
+    ok &= d
+    print(f"  [{'OK' if d else 'FAIL'}] folder '{exp}' matches slugified name")
+
+print("\n=== RESULT:", "ALL CHECKS PASSED" if ok else "FAILURES PRESENT", "===")
+sys.exit(0 if ok else 1)


### PR DESCRIPTION
## What

**SATS — Self-Aware Trend System**: adaptive SuperTrend trend-following whose bands, asymmetry, and flip logic are modulated in real time by a 4-factor **Trend Quality Index** (efficiency, volatility regime, price structure, momentum persistence). Trades a 7-pair low-correlation USDT-M perp basket on `binance_perpetual` (BTC, INJ, NEAR, FIL, SUI, DOGE, SOL).

**Zero-LLM signal path** — every signal is deterministic math from OHLCV candles; the agent LLM is the execution layer only (reads verdict, opens/closes via executors, journals). For the 48h Cup race this means the entire $800 starting capital is trading capital, no inference burn.

## Why this is Cup-relevant

- Fills the **pure-quantitative directional** niche (vs. the ~70% market-maker field).
- "It knows when to hunt and when to hide" — regime-adaptive bands, character-flip collapse detection before price breaks the band.
- Venue-agnostic signal layer: connector is read from routine Config (defaults `binance_perpetual`); execution venue is a one-line trading-context change.

## Files

- `agents/sats/AGENT.md` — identity + decision rules, 7 declared tools (all verified to exist in `mcp_servers/`)
- `agents/sats/routines/sats_scan.py` — async contract, candles via the Hummingbot client (TTL cache), HTF alignment gate (1h/4h vs 15m primary), ReportBuilder dashboard
- `agents/sats/sats_engine.py` — the pure-math engine (760 lines, zero deps)
- `agents/sats/strategies/sats_adaptive_trend/strategy.md` — 300s loop, $800 Cup capital, `risk_limits` (2 executors, ≤3x, 8% DD), structural-band stops
- `agents/sats/tests/validate_agent.py` — loader-contract validator

## Verification

- `validate_agent.py` — **ALL CHECKS PASSED** on condor `main` (routine discovery, async contract, CATEGORY, agent+strategy frontmatter, slug-folder match).
- Live-data smoke: real Binance 15m BTC candles → engine verdict (FLAT, TQI 0.43 — correctly sub-threshold; the designed stand-aside behavior).
- `created_by: 5587715073` (numeric, repo convention).

## Notes

- Ports the original pre-`agents/` SATS build (old `manage_notes`/sync-requests pattern) to the current layout: async, venue-agnostic fetch, `CATEGORY=Analysis`, mandatory ReportBuilder.
- Next: live smoke on binance_perpetual small size (keys already connected on the test box).