### PR TITLE
feat(agents): load registered MCP add-ons

### DIFF
--- a/handlers/agents/_shared.py
+++ b/handlers/agents/_shared.py
@@ -495,6 +495,60 @@ def _hummingbot_mcp_args(server: dict[str, Any], server_name: str) -> list[str]:
     ] + _bot_id_args()
 
 
+def _registered_addon_mcp_servers() -> list[dict[str, Any]]:
+    """Load additive MCP registrations from ``mcp_addons/*.json``.
+
+    Add-ons use the same ``mcpServers`` mapping as ``.mcp.json``. The loader
+    converts environment mappings to ACP's name/value list and rejects malformed
+    registrations rather than starting a session with a silently incomplete
+    tool plane.
+    """
+    registry = Path(get_project_dir()) / "mcp_addons"
+    if not registry.is_dir():
+        return []
+
+    servers: list[dict[str, Any]] = []
+    for path in sorted(registry.glob("*.json")):
+        document = json.loads(path.read_text(encoding="utf-8"))
+        configured = document.get("mcpServers")
+        if not isinstance(configured, dict):
+            raise ValueError(f"{path} must contain an mcpServers mapping")
+        for name, raw in sorted(configured.items()):
+            if not isinstance(name, str) or not name or not isinstance(raw, dict):
+                raise ValueError(f"{path} contains an invalid MCP server entry")
+            command = raw.get("command")
+            args = raw.get("args", [])
+            environment = raw.get("env", {})
+            if not isinstance(command, str) or not command:
+                raise ValueError(f"{path} MCP server {name!r} needs a command")
+            if not isinstance(args, list) or not all(
+                isinstance(arg, str) for arg in args
+            ):
+                raise ValueError(f"{path} MCP server {name!r} args must be strings")
+            if not isinstance(environment, dict):
+                raise ValueError(f"{path} MCP server {name!r} env must be a mapping")
+            servers.append(
+                {
+                    "name": name,
+                    "command": command,
+                    "args": args,
+                    "env": _env_entries(**environment),
+                }
+            )
+    return servers
+
+
+def _with_registered_addons(core: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    combined = [*core, *_registered_addon_mcp_servers()]
+    seen: set[str] = set()
+    for server in combined:
+        name = server["name"]
+        if name in seen:
+            raise ValueError(f"add-on duplicates MCP server name {name!r}")
+        seen.add(name)
+    return combined
+
+
 def build_mcp_servers_for_session(
     user_id: int,
     chat_id: int | str,
@@ -557,7 +611,7 @@ def build_mcp_servers_for_session(
             user_id,
             chat_id,
         )
-        return [condor]
+        return _with_registered_addons([condor])
 
     server = cm.get_server(server_name)
     if not server:
@@ -567,7 +621,7 @@ def build_mcp_servers_for_session(
             server_name,
             user_id,
         )
-        return [condor]
+        return _with_registered_addons([condor])
 
     # Credentials go in env, not argv: the API username/password used to sit on
     # the command line, where any local `ps` recovered them (SEC-095). The
@@ -583,7 +637,7 @@ def build_mcp_servers_for_session(
         ),
     }
 
-    return [mcp_hummingbot, condor]
+    return _with_registered_addons([mcp_hummingbot, condor])
 
 
 def build_initial_context(
@@ -596,11 +650,7 @@ def build_initial_context(
 ) -> str:
     """Build an initial context prompt telling the agent about server, permissions, and formatting rules."""
     from condor.acp.pydantic_ai_client import is_pydantic_ai_model
-    from config_manager import (
-        ServerPermission,
-        get_config_manager,
-        get_effective_server,
-    )
+    from config_manager import get_config_manager, get_effective_server
 
     cm = get_config_manager()
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -7,7 +7,10 @@ skill library, and the pydantic-ai tool allowlist.
 """
 
 import asyncio
+import json
 from types import SimpleNamespace
+
+import pytest
 
 from condor.acp.pydantic_ai_client import PydanticAIClient
 from condor.agents import agent as agent_module
@@ -721,6 +724,75 @@ def test_session_mcp_servers_carry_agent_slug(monkeypatch):
     servers = build_mcp_servers_for_session(42, 42)
     condor = next(s for s in servers if s["name"] == "condor")
     assert "--agent-slug" not in condor["args"]
+
+
+def test_session_mcp_servers_include_registered_addons(monkeypatch, tmp_path):
+    import config_manager
+    import handlers.agents._shared as shared
+
+    class _NoServers:
+        def get_accessible_servers(self, user_id):
+            return []
+
+        def get_server(self, name):
+            return None
+
+    addon_dir = tmp_path / "mcp_addons"
+    addon_dir.mkdir()
+    (addon_dir / "research-os.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "research-os": {
+                        "command": "/opt/research-os/python",
+                        "args": ["-m", "research_os.condor_addon.server"],
+                        "env": {"RESEARCH_OS_API_URL": "http://127.0.0.1:8100"},
+                    }
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(config_manager, "get_config_manager", lambda: _NoServers())
+    monkeypatch.setattr(config_manager, "get_effective_server", lambda *a, **k: None)
+    monkeypatch.setattr(shared, "get_project_dir", lambda: str(tmp_path))
+
+    servers = shared.build_mcp_servers_for_session(42, 42)
+
+    research = next(server for server in servers if server["name"] == "research-os")
+    assert research["command"] == "/opt/research-os/python"
+    assert research["env"] == [
+        {"name": "RESEARCH_OS_API_URL", "value": "http://127.0.0.1:8100"}
+    ]
+
+
+def test_addon_registry_rejects_core_name_collision(monkeypatch, tmp_path):
+    import config_manager
+    import handlers.agents._shared as shared
+
+    class _NoServers:
+        def get_accessible_servers(self, user_id):
+            return []
+
+        def get_server(self, name):
+            return None
+
+    addon_dir = tmp_path / "mcp_addons"
+    addon_dir.mkdir()
+    (addon_dir / "collision.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "condor": {"command": "false", "args": []},
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(config_manager, "get_config_manager", lambda: _NoServers())
+    monkeypatch.setattr(config_manager, "get_effective_server", lambda *a, **k: None)
+    monkeypatch.setattr(shared, "get_project_dir", lambda: str(tmp_path))
+
+    with pytest.raises(ValueError, match="duplicates MCP server name 'condor'"):
+        shared.build_mcp_servers_for_session(42, 42)
 
 
 def test_numeric_credentials_reach_the_subprocess_as_strings(monkeypatch):


### PR DESCRIPTION
## Summary
- load registered MCP add-on servers into agent sessions
- preserve core server precedence and reject name collisions
- add focused coverage for add-on discovery and collision behavior

## Motivation
Research OS installs as a Condor add-on and needs its bounded MCP server to be discovered without forking Condor or changing core ownership.

## Validation
- `uv run pytest tests/test_agents.py -q` — 34 passed
- `git diff origin/main...HEAD --check`

## Safety
This hook only extends MCP server registration. It adds no exchange credentials, real-order tool, or gate-bypass authority.