### PR TITLE
fix/honor WEB_PORT first then parsed port from URL

### DIFF
--- a/utils/config.py
+++ b/utils/config.py
@@ -47,7 +47,13 @@ _web_port_raw = os.environ.get("WEB_PORT", "").strip()
 if _web_url_raw:
     WEB_URL = _web_url_raw.rstrip("/")
     _parsed = urlparse(WEB_URL)
-    WEB_PORT = _parsed.port or (443 if _parsed.scheme == "https" else 80)
+
+    if _web_port_raw:
+        WEB_PORT = int(_web_port_raw)
+    elif _parsed.port:
+        WEB_PORT = _parsed.port
+    else:
+        WEB_PORT = 443 if _parsed.scheme == "https" else 80
 else:
     WEB_PORT = int(_web_port_raw) if _web_port_raw else 8088
     WEB_URL = f"http://localhost:{WEB_PORT}"

--- a/utils/config.py
+++ b/utils/config.py
@@ -40,7 +40,6 @@ TELEGRAM_TOKEN = os.environ.get("TELEGRAM_TOKEN")
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 
 # Single WEB_URL param: full URL including port if needed (e.g. http://myserver.com:8088)
-# Falls back to WEB_PORT for backward compat, then default 8088
 _web_url_raw = os.environ.get("WEB_URL", "").strip()
 _web_port_raw = os.environ.get("WEB_PORT", "").strip()
 


### PR DESCRIPTION
Honor WEB_PORT first if defined, then parsed port from URL.
With this fix and thanks to commit https://github.com/hummingbot/condor/commit/446e4b761c415359321db54f39a079b981281c35, PR [#160](https://github.com/hummingbot/condor/pull/160) could be closed.