### PR TITLE
fix(portfolio): count unified Hyperliquid collateral once in history and Telegram totals

### DIFF
--- a/condor/web/routes/portfolio.py
+++ b/condor/web/routes/portfolio.py
@@ -17,6 +17,7 @@ from condor.web.models import (
     WebUser,
 )
 from config_manager import get_config_manager
+from utils.portfolio_dedupe import UNIFIED_NOTE, dedupe_hyperliquid_unified
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +71,11 @@ async def get_portfolio(
             + ("" if registered else " (fetch not registered — try restarting)"),
         )
 
+    # Valuation-only dedup, on a copy: the SDS-cached state is shared with
+    # trading views (handlers/cex/trade.py), which must keep seeing the raw
+    # perp collateral. It is tradable; it just must not be VALUED twice.
+    state, unified_accounts = dedupe_hyperliquid_unified(state)
+
     # Parse portfolio state into structured response
     # API returns: {account_name: {connector_name: [balance_dicts]}}
     connectors: list[ConnectorBalance] = []
@@ -121,48 +127,17 @@ async def get_portfolio(
                         connector=connector_name,
                         balances=balances,
                         total_usd=connector_total,
+                        note=(
+                            UNIFIED_NOTE
+                            if connector_name == "hyperliquid_perpetual"
+                            and account_name in unified_accounts
+                            else None
+                        ),
                     )
                 )
 
-    _dedupe_hyperliquid_unified(connectors)
     total_usd = sum(c.total_usd for c in connectors)
     return PortfolioResponse(server=name, connectors=connectors, total_usd=total_usd)
-
-
-# Hyperliquid stable/quote symbols (perp margin reports "USD", spot holds "USDC").
-_HL_STABLES = {"USD", "USDC"}
-
-
-def _dedupe_hyperliquid_unified(connectors: list[ConnectorBalance]) -> None:
-    """Avoid double-counting Hyperliquid balances for unified / portfolio-margin accounts.
-
-    In unified or portfolio-margin mode the SAME USDC collateral is reported by BOTH the spot
-    (``hyperliquid``) and perp (``hyperliquid_perpetual``) clearinghouse states, which inflates the
-    portfolio. Hyperliquid exposes no account-mode flag, so detect the unified case by the near-equal
-    shared stable balance and drop the perp duplicate — Hyperliquid's own guidance is to use the spot
-    clearinghouse state as the unified account balance. No-op in standard mode, where the spot and
-    perp balances are separate and differ. Mutates ``connectors`` in place.
-    """
-    spot = next((c for c in connectors if c.connector == "hyperliquid"), None)
-    perp = next((c for c in connectors if c.connector == "hyperliquid_perpetual"), None)
-    if spot is None or perp is None:
-        return
-
-    spot_stable = sum(b.usd_value for b in spot.balances if b.token in _HL_STABLES)
-    perp_stable = sum(b.usd_value for b in perp.balances if b.token in _HL_STABLES)
-    if spot_stable <= 0 or perp_stable <= 0:
-        return
-
-    # Unified when the perp stable collateral matches the spot stable within ~1% (one shared pool).
-    if abs(perp_stable - spot_stable) > max(0.01, 0.01 * spot_stable):
-        return
-
-    # Drop the duplicated stable collateral from the perp side; keep any non-stable (perp-only) items.
-    perp.balances = [b for b in perp.balances if b.token not in _HL_STABLES]
-    perp.total_usd = sum(b.usd_value for b in perp.balances)
-    perp.note = (
-        "Unified account — USDC balance is reflected in the hyperliquid (spot) balance."
-    )
 
 
 @router.get(
@@ -196,18 +171,30 @@ async def get_portfolio_history(
 
     entries, keyed = _extract_snapshot_entries(history)
 
+    # Resolve each snapshot to its state and dedupe unified-Hyperliquid
+    # collateral for valuation. Stored snapshots (and any precomputed totals
+    # in them) predate the dedup, so whenever it bites the total is recomputed
+    # from the adjusted state, which is also what fixes already-recorded
+    # (double-counted) history at read time.
+    resolved: list[tuple[float, Any, Any, bool]] = []
+    for ts, snapshot in entries:
+        state, unified = dedupe_hyperliquid_unified(_snapshot_state(snapshot, keyed))
+        resolved.append((ts, snapshot, state, bool(unified)))
+
     # Forward-fill: track per-connector totals so missing exchanges
     # carry forward their last known value instead of dropping to 0.
     points: list[PortfolioHistoryPoint] = []
     prev_connector_totals: dict[str, float] = {}
-    for ts, snapshot in entries:
+    for ts, snapshot, state, unified in resolved:
         total = (
-            0 if keyed else snapshot.get("total_value", snapshot.get("total_usd", 0))
+            0
+            if keyed or unified
+            else snapshot.get("total_value", snapshot.get("total_usd", 0))
         )
         if total == 0:
             # Sum token values from nested structure
             # API returns {timestamp, state: {account: {connector: [balances]}}}
-            cur_totals = _extract_connector_totals(_snapshot_state(snapshot, keyed))
+            cur_totals = _extract_connector_totals(state)
             if cur_totals and prev_connector_totals:
                 # Forward-fill: for connectors seen before but missing now, use previous value
                 for key, prev_val in prev_connector_totals.items():
@@ -225,7 +212,9 @@ async def get_portfolio_history(
 
     top_tokens: list[str] = []
     if breakdown and points:
-        top_tokens = _build_token_breakdown(entries, keyed, points)
+        top_tokens = _build_token_breakdown(
+            [(ts, state) for ts, _snap, state, _u in resolved], points
+        )
 
     return PortfolioHistoryResponse(
         server=name, points=points, interval=interval, top_tokens=top_tokens
@@ -279,19 +268,20 @@ def _extract_snapshot_entries(history: Any) -> tuple[list[tuple[float, Any]], bo
 
 
 def _build_token_breakdown(
-    entries: list[tuple[float, Any]],
-    keyed: bool,
+    states: list[tuple[float, Any]],
     points: list[PortfolioHistoryPoint],
 ) -> list[str]:
     """Populate each point's per-token values, collapsing beyond the top 8 into "Other".
 
-    Mutates ``point.tokens`` in place and returns the top token names.
+    ``states`` holds (timestamp, portfolio state) pairs, already resolved from
+    their snapshots and deduped for valuation. Mutates ``point.tokens`` in
+    place and returns the top token names.
     """
     # Build token values per timestamp (with forward-fill for missing exchanges)
     ts_token_map: dict[float, dict[str, float]] = {}
     prev_token_vals: dict[str, float] = {}
-    for ts, snapshot in entries:
-        token_vals = _extract_token_values(_snapshot_state(snapshot, keyed))
+    for ts, state in states:
+        token_vals = _extract_token_values(state)
         if not token_vals:
             continue
         # Forward-fill: tokens present before but missing now keep previous value

--- a/handlers/portfolio.py
+++ b/handlers/portfolio.py
@@ -12,6 +12,7 @@ from handlers import is_gateway_network
 from handlers.config import clear_config_state
 from handlers.config.user_preferences import get_all_enabled_networks
 from utils.auth import hummingbot_api_required, restricted
+from utils.portfolio_dedupe import dedupe_hyperliquid_unified
 from utils.telegram_formatters import (
     escape_markdown_v2,
     format_connector_detail,
@@ -236,6 +237,8 @@ async def portfolio_command(update: Update, context: ContextTypes.DEFAULT_TYPE) 
 
         # Filter balances by enabled networks from wallet preferences
         if balances:
+            # Valuation view: don't count unified-Hyperliquid collateral twice.
+            balances, _ = dedupe_hyperliquid_unified(balances)
             enabled_networks = get_all_enabled_networks(context.user_data)
             if enabled_networks:
                 balances = _filter_balances_by_networks(balances, enabled_networks)
@@ -481,6 +484,8 @@ async def refresh_portfolio_dashboard(
 
         # Filter balances by enabled networks
         if balances:
+            # Valuation view: don't count unified-Hyperliquid collateral twice.
+            balances, _ = dedupe_hyperliquid_unified(balances)
             enabled_networks = get_all_enabled_networks(context.user_data)
             if enabled_networks:
                 balances = _filter_balances_by_networks(balances, enabled_networks)

--- a/tests/test_portfolio_dedupe.py
+++ b/tests/test_portfolio_dedupe.py
@@ -1,0 +1,161 @@
+"""Unit tests for the valuation-only Hyperliquid unified-account dedup."""
+
+import copy
+
+import pytest
+
+from utils.portfolio_dedupe import UNIFIED_NOTE, dedupe_hyperliquid_unified
+
+
+def _state(spot_value=2646.7851, perp_value=2646.79, extra_perp=None):
+    """Raw portfolio state in the Hummingbot API shape, from the real incident."""
+    perp_balances = [
+        {
+            "token": "USD",
+            "units": perp_value,
+            "price": 1.0,
+            "value": perp_value,
+            "available_units": 0.0,
+        }
+    ]
+    if extra_perp:
+        perp_balances.append(extra_perp)
+    return {
+        "master_account": {
+            "hyperliquid": [
+                {
+                    "token": "USDC",
+                    "units": spot_value,
+                    "price": 1.0,
+                    "value": spot_value,
+                    "available_units": spot_value,
+                }
+            ],
+            "hyperliquid_perpetual": perp_balances,
+            "binance": [
+                {
+                    "token": "USDT",
+                    "units": 2229.0,
+                    "price": 1.0,
+                    "value": 2229.0,
+                    "available_units": 2229.0,
+                }
+            ],
+        }
+    }
+
+
+def _total(state):
+    """Sum values the way format_portfolio_overview does."""
+    return sum(
+        b.get("value", 0)
+        for connectors in state.values()
+        for balances in connectors.values()
+        for b in balances
+        if b.get("value", 0) > 0
+    )
+
+
+def test_unified_collateral_counted_once():
+    state = _state()
+    doubled = _total(state)
+    out, adjusted = dedupe_hyperliquid_unified(state)
+
+    assert adjusted == {"master_account"}
+    # The overlap (min of the two stables) is removed: the perp side keeps
+    # only its 0.0049 excess over the spot balance.
+    perp = out["master_account"]["hyperliquid_perpetual"]
+    assert perp[0]["value"] == pytest.approx(0.0049, abs=1e-6)
+    assert _total(out) == pytest.approx(doubled - 2646.7851, abs=1e-6)
+    # Spot and unrelated connectors untouched.
+    assert out["master_account"]["hyperliquid"][0]["value"] == 2646.7851
+    assert out["master_account"]["binance"][0]["value"] == 2229.0
+
+
+def test_input_is_not_mutated():
+    state = _state()
+    snapshot = copy.deepcopy(state)
+    dedupe_hyperliquid_unified(state)
+    assert state == snapshot
+
+
+def test_open_position_drift_stands_down():
+    # Perp equity drifted >1% from spot collateral (open position): no dedup.
+    state = _state(spot_value=2646.79, perp_value=2800.0)
+    out, adjusted = dedupe_hyperliquid_unified(state)
+    assert adjusted == set()
+    assert out == state
+
+
+def test_missing_leg_is_noop():
+    state = _state()
+    del state["master_account"]["hyperliquid"]
+    out, adjusted = dedupe_hyperliquid_unified(state)
+    assert adjusted == set()
+    assert out == state
+
+
+def test_non_stable_perp_balance_survives():
+    hype = {"token": "HYPE", "units": 10.0, "price": 40.0, "value": 400.0}
+    state = _state(extra_perp=hype)
+    out, adjusted = dedupe_hyperliquid_unified(state)
+    assert adjusted == {"master_account"}
+    perp = out["master_account"]["hyperliquid_perpetual"]
+    assert [b for b in perp if b["token"] == "HYPE"][0]["value"] == 400.0
+
+
+def test_within_tolerance_keeps_the_excess():
+    # 2670 vs 2646.79 is inside the 1% band; only the overlap is removed.
+    state = _state(spot_value=2646.79, perp_value=2670.0)
+    out, adjusted = dedupe_hyperliquid_unified(state)
+    assert adjusted == {"master_account"}
+    perp_stable = sum(
+        b["value"]
+        for b in out["master_account"]["hyperliquid_perpetual"]
+        if b["token"] == "USD"
+    )
+    assert perp_stable == pytest.approx(2670.0 - 2646.79, abs=1e-6)
+
+
+def test_idempotent():
+    once, _ = dedupe_hyperliquid_unified(_state())
+    twice, adjusted = dedupe_hyperliquid_unified(once)
+    assert adjusted == set()  # perp stable is ~0 now, the gate stands down
+    assert twice == once
+
+
+def test_alias_keys_usd_value_and_asset():
+    state = {
+        "master_account": {
+            "hyperliquid": [{"asset": "USDC", "usd_value": 100.0, "total_balance": 100.0}],
+            "hyperliquid_perpetual": [{"asset": "USD", "usd_value": 100.0, "total_balance": 100.0}],
+        }
+    }
+    out, adjusted = dedupe_hyperliquid_unified(state)
+    assert adjusted == {"master_account"}
+    assert out["master_account"]["hyperliquid_perpetual"][0]["usd_value"] == pytest.approx(0.0)
+    assert out["master_account"]["hyperliquid_perpetual"][0]["total_balance"] == pytest.approx(0.0)
+
+
+def test_accounts_are_independent():
+    state = _state()
+    state["other_account"] = {
+        "hyperliquid": [{"token": "USDC", "value": 500.0, "units": 500.0}],
+        "hyperliquid_perpetual": [{"token": "USD", "value": 900.0, "units": 900.0}],
+    }
+    out, adjusted = dedupe_hyperliquid_unified(state)
+    assert adjusted == {"master_account"}
+    assert out["other_account"]["hyperliquid_perpetual"][0]["value"] == 900.0
+
+
+def test_non_dict_state_passes_through():
+    for state in (None, [], "oops", 42):
+        out, adjusted = dedupe_hyperliquid_unified(state)
+        assert out == state
+        assert adjusted == set()
+
+
+def test_note_text_matches_frontend_expectation():
+    assert UNIFIED_NOTE == (
+        "Unified account — USDC balance is reflected in the hyperliquid (spot) balance."
+    )

--- a/utils/portfolio_dedupe.py
+++ b/utils/portfolio_dedupe.py
@@ -1,0 +1,118 @@
+"""Valuation-only dedup of Hyperliquid unified-account collateral.
+
+In unified / portfolio-margin mode the SAME USDC collateral is reported by BOTH
+the spot (``hyperliquid``) and perp (``hyperliquid_perpetual``) clearinghouse
+states, so any view that VALUES the portfolio counts it twice. Hyperliquid
+exposes no account-mode flag, so the unified case is detected by the near-equal
+shared stable balance; Hyperliquid's own guidance is to use the spot
+clearinghouse state as the unified account balance.
+
+This is deliberately PURE and presentation-only: it returns an adjusted deep
+copy and never mutates its input. The raw state must stay intact because
+trading views (handlers/cex/trade.py reads the same SDS PORTFOLIO cache) show
+the perp collateral as what is available to trade -- for trading it is real,
+it is only the portfolio TOTAL that must not count it twice.
+"""
+
+import copy
+from typing import Any
+
+# Hyperliquid stable/quote symbols (perp margin reports "USD", spot holds "USDC").
+_HL_STABLES = {"USD", "USDC"}
+_SPOT_CONNECTOR = "hyperliquid"
+_PERP_CONNECTOR = "hyperliquid_perpetual"
+
+UNIFIED_NOTE = (
+    "Unified account — USDC balance is reflected in the hyperliquid (spot) balance."
+)
+
+
+def _token(item: dict) -> str:
+    return item.get("token", item.get("asset", ""))
+
+
+def _value(item: dict) -> float:
+    return float(item.get("value", item.get("usd_value", 0)) or 0)
+
+
+def _stable_total(balances: list) -> float:
+    return sum(
+        _value(item)
+        for item in balances
+        if isinstance(item, dict) and _token(item) in _HL_STABLES
+    )
+
+
+def dedupe_hyperliquid_unified(state: Any) -> tuple[Any, set[str]]:
+    """Return (adjusted deep copy of ``state``, names of accounts adjusted).
+
+    ``state`` is the raw portfolio shape ``{account: {connector: [balance
+    dicts]}}``; anything else passes through unchanged. Per account, when both
+    Hyperliquid legs hold stable value and the perp stable total matches the
+    spot's within ~1% (one shared pool), the OVERLAP -- min of the two -- is
+    removed from the perp side, scaling units along with value so a small
+    genuine difference survives rather than being written off with the
+    duplicate. No-op in standard mode, where the two balances differ.
+
+    Caveat: with an open Hyperliquid perp position, perp equity (margin plus
+    unrealized PnL) can drift more than 1% from the spot collateral, and the
+    dedup stands down until the position closes. The equality gate is what
+    keeps this safe for genuinely separate accounts; the drift is accepted
+    rather than dedup applied on a guess.
+    """
+    if not isinstance(state, dict):
+        return state, set()
+
+    out = copy.deepcopy(state)
+    adjusted: set[str] = set()
+
+    for account, connectors in out.items():
+        if not isinstance(connectors, dict):
+            continue
+        spot = connectors.get(_SPOT_CONNECTOR)
+        perp = connectors.get(_PERP_CONNECTOR)
+        if not isinstance(spot, list) or not isinstance(perp, list):
+            continue
+
+        spot_stable = _stable_total(spot)
+        perp_stable = _stable_total(perp)
+        if spot_stable <= 0 or perp_stable <= 0:
+            continue
+        # Unified when the perp stable collateral matches the spot stable
+        # within ~1% (one shared pool).
+        if abs(perp_stable - spot_stable) > max(0.01, 0.01 * spot_stable):
+            continue
+
+        remaining = min(spot_stable, perp_stable)
+        stable_items = sorted(
+            (
+                item
+                for item in perp
+                if isinstance(item, dict) and _token(item) in _HL_STABLES
+            ),
+            key=_value,
+            reverse=True,
+        )
+        for item in stable_items:
+            if remaining <= 0:
+                break
+            value = _value(item)
+            if value <= 0:
+                continue
+            take = min(value, remaining)
+            remaining -= take
+            scale = (value - take) / value
+            for key in ("value", "usd_value"):
+                if key in item and item[key] is not None:
+                    item[key] = float(item[key]) * scale
+            for key in (
+                "units",
+                "total_balance",
+                "available_units",
+                "available_balance",
+            ):
+                if key in item and item[key] is not None:
+                    item[key] = float(item[key]) * scale
+        adjusted.add(account)
+
+    return out, adjusted


### PR DESCRIPTION
## Problem

For unified Hyperliquid accounts, the spot connector (`hyperliquid`) and the perp connector (`hyperliquid_perpetual`) report the same USDC collateral. `GET /servers/{name}/portfolio` already drops the duplicate via `_dedupe_hyperliquid_unified`, so the Portfolio tile and the holdings table are correct.

Two other views still count that collateral twice:

* `GET /servers/{name}/portfolio/history` sums stored snapshots as they are. The Portfolio Evolution chart shows an inflated total and disagrees with the tile right above it.
* The Telegram `/portfolio` command totals the raw `get_state()` payload.

Example from a live unified account holding 2,646 USDC: the tile shows $9,471 while the chart and Telegram show $12,118.

## Fix

* Move the dedup into `utils/portfolio_dedupe.py` as `dedupe_hyperliquid_unified(state)`. It works on the raw `{account: {connector: [balances]}}` shape, so every consumer shares one implementation.
* The function is pure and returns an adjusted copy. Trading views read the same SDS-cached state and must keep seeing the real perp collateral. That money is tradable. It just must not be valued twice.
* Only the overlap (min of the two stable totals) is removed from the perp side, with units scaled along with value. A small genuine difference between the legs survives.
* Live endpoint: dedupe the raw state before parsing. The UNIFIED note on `hyperliquid_perpetual` is unchanged.
* History endpoint: dedupe each snapshot at read time and recompute the total whenever the dedup applies. Stored snapshots predate the fix, so this also corrects history that was recorded with the double count. No migration needed.
* Telegram `/portfolio`: dedupe after both fetches (initial and Refresh).

Detection is unchanged from the existing helper: both legs hold stable value and the perp total matches the spot total within 1%. Known limit, same as before: with an open Hyperliquid perp position, perp equity can drift outside the band and the dedup stands down until the position closes.

## Testing

* New unit tests in `tests/test_portfolio_dedupe.py`: 11 cases covering the numbers above, purity, idempotency, alias keys, per-account independence, and the drift guard.
* `tests/test_portfolio_history_sds.py` still passes, so the history payload is unchanged for non-Hyperliquid data.
* Full suite: 2469 passed, 5 skipped.
* Verified against a live unified account: the state total went from $12,119.47 to $9,472.69 and now matches the tile. History points dedupe the same way, including old snapshots.
