### PR TITLE
README: claims that hold, and the Local → Telegram → Server route

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,29 @@ dashboard.
 Local mode logs in as `ADMIN_USER_ID` — the same id `config.yml`, your servers,
 preferences and defaults already key on. `make setup` writes `ADMIN_USER_ID=1`
 for an install that never had a Telegram id; an install that has one **keeps
-it**, so switching modes keeps everything you had.
+it**, so a Telegram install switching to local keeps everything it had.
 
 Switching later is a `make setup` re-run — it shows the current mode and offers
 the other one — or editing `CONDOR_MODE` in `.env`. Your `TELEGRAM_TOKEN` is left
 in place either way, so switching back is one line.
+
+**Start local, grow later.** The usual route is Local first, Telegram once you
+want alerts reaching your phone, and a server once real capital is involved:
+
+- **Add Telegram:** re-run `make setup` and pick Telegram, with a bot token and
+  your user id. An install that never had Telegram runs as user id `1`, and
+  adding a bot switches your login to your Telegram id — configured servers
+  carry over, but dashboard preferences and agent conversations are keyed per
+  user and stay behind, so make this hop early.
+- **Add a server without moving Condor:** bots and executors run on the
+  Hummingbot API host, so a laptop Condor driving a VPS API keeps strategies
+  running while the laptop sleeps. Deploy the API on the VPS with Tailscale
+  ([Install only Hummingbot API](#install-only-hummingbot-api)), then add it
+  under **Settings → Servers** in the dashboard (or `/servers` in Telegram).
+- **Move Condor too:** install on the VPS the same way, then copy `.env`,
+  `config.yml`, `data/` and `condor/.runtime/` over from the old machine, and
+  stop the old install so two Condors are not driving the same accounts. Full
+  steps: [Start local, grow later](https://condor.hummingbot.org/getting-started/installing#start-local-grow-later).
 
 A mode that cannot work stops at boot, in `make run`, naming the `.env` line to
 fix: telegram mode with no token, an `ADMIN_USER_ID` that is not a positive
@@ -359,7 +377,7 @@ make tailscale-status   # confirm hummingbot-api appears on your tailnet
 ### On the Condor machine
 
 1. Install [Tailscale](https://tailscale.com/download) and sign in to the **same account**
-2. In Telegram, open **`/servers`** and add the API with:
+2. In Telegram, open **`/servers`** — or in Local mode, **Settings → Servers** in the dashboard — and add the API with:
    - **Host**: `hummingbot-api` (MagicDNS name, not a public IP)
    - **Port**: `8000`
    - **Username / Password**: same as the API `.env`
@@ -406,7 +424,7 @@ tailscale status
 
 Both `condor` and `hummingbot-api` should appear as connected peers.
 
-**Do not open port 8000 on your public firewall** when Tailscale is enabled. Allow SSH (port 22) for server administration only.
+**Do not open port 8000 on your public firewall** when Tailscale is enabled. Allow SSH (port 22) for server administration only. Close 8000 in your **cloud provider's firewall / security group** rather than with `ufw`: Docker publishes the API's port on every interface, and published ports bypass `ufw` rules — a provider firewall is enforced off-host, so it actually holds.
 
 ## Troubleshooting
 
@@ -420,6 +438,7 @@ Both `condor` and `hummingbot-api` should appear as connected peers.
 | Connection refused | Check server host:port in `/servers`; use `hummingbot-api` (not `localhost`) when API is on another machine via Tailscale |
 | Auth error | Verify server credentials match the API `.env` |
 | DEX features unavailable | Ensure Gateway is configured and running |
+| After an update, `make run` fails building the frontend | A newly added frontend dependency is missing from a stale `node_modules` — `cd frontend && npm install`, then `make run` |
 | Tailscale: name `hummingbot-api` does not work | Enable **MagicDNS** in [Tailscale DNS settings](https://login.tailscale.com/admin/dns) |
 | Tailscale: can't reach API | Run `tailscale status` — confirm both peers are connected; on API server run `make tailscale-status` |
 | Tailscale: auth key rejected | Key must start with `tskey-auth-`, check expiry in Tailscale admin |


### PR DESCRIPTION
README-only companion to #213 and to the docs audit in [condor-docs#8](https://github.com/hummingbot/condor-docs/pull/8). No code changes.

## What changed

**One claim corrected.** *"Switching modes keeps everything you had"* is only true in one direction. Telegram → Local keeps your `ADMIN_USER_ID`, and with it servers, preferences and history. A Local-only install runs as user id `1`; adding a bot switches the login to your Telegram id — configured servers are shared and carry over, but dashboard preferences and agent conversations (`condor/.runtime/conversations/{user_id}/`) are keyed per user and stay behind. The README now states the asymmetry instead of papering over it.

**New: "Start local, grow later."** The route we expect most users to take — Local first, Telegram when they want alerts on their phone, a server when real capital is involved — with what each hop takes and what carries over:

- **Add Telegram** — `make setup`, with the id caveat above front and center (make the hop early).
- **Add a server without moving Condor** — bots and executors run on the Hummingbot API host, so a laptop Condor driving a VPS API already survives the laptop sleeping. Points Local-mode users at **Settings → Servers** in the dashboard, since `/servers` needs a bot they don't have.
- **Move Condor too** — and stop the old install so two Condors aren't driving the same accounts. Full steps live in the docs ([Start local, grow later](https://condor.hummingbot.org/getting-started/installing#start-local-grow-later); the anchor lands with condor-docs#8).

**Firewall advice that actually holds.** "Do not open port 8000" now says *where* to close it: Docker publishes the API's port on every interface and published ports bypass `ufw`, so the cloud provider's firewall / security group — enforced off-host — is the one that works.

**One troubleshooting row added**, from a failure we hit for real: after an update, `make run` fails its frontend build because `make run` only installs frontend packages when `node_modules` is missing entirely — a *stale* `node_modules` missing a newly added dependency needs `cd frontend && npm install`.

## Relationship to #213

Merge-tested clean against `feature/doctor-command-install-ux` in both orders — the two PRs touch disjoint hunks of README.md. This PR deliberately does not mention `make doctor` in its additions, so it can land before or after #213.

## Verified

Every behavioral claim checked against the code on `main`: the id-1 default and keep-existing-id logic in `setup-environment.sh`, per-user conversation storage in `condor/runtime/conversations.py`, `ServersSettings` + the `add_server` route for Local mode, the `npm ci`-only-when-missing guard in the Makefile's `build-frontend`, and hummingbot-api's unconditional `8000:8000` publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
