### PR TITLE
fix(prompts): tell agents which connectors actually use Gateway

### DIFF
--- a/condor/agents/prompts.py
+++ b/condor/agents/prompts.py
@@ -167,6 +167,22 @@ MEMORY (about the user, NOT operational learnings):
 
 NOTIFICATIONS:
 - Use send_notification(text="...") to message the user on Telegram.
+
+CONNECTOR BOUNDARIES:
+- Gateway is only for EVM/Solana chain connectors (ethereum-*, solana-* networks)
+  and the CLMM/AMM DEXs on them (Meteora, Raydium, Uniswap). Native Hummingbot
+  exchange connectors — binance, kraken, xrpl and the rest — are self-contained and
+  never touch Gateway for anything: balances, prices, order placement or token config.
+- So for a pricing, balance or trading problem on a native connector, do NOT call
+  manage_gateway_config or manage_gateway_container. Gateway being up or down is
+  irrelevant to it, and its status is not evidence about the problem. Look at the
+  connector: its config map, its credentials, get_market_data, manage_executors.
+- Gateway connectors are named "<chain>-<network>" (e.g. "solana-mainnet-beta").
+  Anything named after the venue itself (e.g. "xrpl", "binance") is native. Check
+  with list_connectors when unsure.
+- xrpl in particular is an on-ledger CLOB plus AMM, not a Gateway chain. It serves
+  order books and balances but has no candles endpoint — use
+  explore_geckoterminal(network="xrpl") for OHLCV.
 """
 
 # Journal guidance. In experiment modes (dry_run / run_once) the engine keeps NO

--- a/condor/agents/prompts.py
+++ b/condor/agents/prompts.py
@@ -170,7 +170,8 @@ NOTIFICATIONS:
 
 CONNECTOR BOUNDARIES:
 - Gateway is only for EVM/Solana chain connectors (ethereum-*, solana-* networks)
-  and the CLMM/AMM DEXs on them (Meteora, Raydium, Uniswap). Native Hummingbot
+  and the CLMM/AMM DEXs on them — Meteora, Orca, Raydium, Uniswap, PancakeSwap and
+  any other pool-based venue reached through a chain. Native Hummingbot
   exchange connectors — binance, kraken, xrpl and the rest — are self-contained and
   never touch Gateway for anything: balances, prices, order placement or token config.
 - So for a pricing, balance or trading problem on a native connector, do NOT call

--- a/tests/test_connector_boundaries_prompt.py
+++ b/tests/test_connector_boundaries_prompt.py
@@ -1,0 +1,49 @@
+"""Agents must not go looking in Gateway for a native connector's problem.
+
+Asked why a token showed $0.00 on xrpl, an agent called the Gateway config and container
+tools five times, found Gateway returning 503, and concluded "the issue is that Gateway
+is down, which is why FUZZY isn't showing a proper value in your portfolio" — plausible,
+confidently stated, and wrong. xrpl is a native connector and never touches Gateway.
+
+Nothing in the shared prompt distinguished the two kinds of connector, while the tool
+surface pushes the other way: manage_gateway_config describes itself as covering
+"chains, networks, tokens, connectors, pools, wallets", and nearly every other
+DEX-flavoured tool really is Gateway-mediated. So the model generalises "xrpl is a DEX"
+into "DEXs go through Gateway". The only place the boundary was written down was one
+specialist agent's own AGENT.md, which no other persona ever sees.
+"""
+from condor.agents.prompts import BASE_PROMPT_COMMON
+
+
+def test_the_boundary_is_stated_in_the_shared_prompt():
+    assert "CONNECTOR BOUNDARIES:" in BASE_PROMPT_COMMON
+
+
+def test_it_names_the_gateway_tools_not_to_reach_for():
+    """A rule the model cannot map onto a tool name is a rule it will not follow."""
+    assert "manage_gateway_config" in BASE_PROMPT_COMMON
+    assert "manage_gateway_container" in BASE_PROMPT_COMMON
+
+
+def test_it_names_native_connectors_explicitly():
+    boundaries = BASE_PROMPT_COMMON.split("CONNECTOR BOUNDARIES:")[1]
+    for connector in ("xrpl", "binance", "kraken"):
+        assert connector in boundaries
+
+
+def test_it_gives_a_rule_for_telling_them_apart():
+    boundaries = BASE_PROMPT_COMMON.split("CONNECTOR BOUNDARIES:")[1]
+    assert "<chain>-<network>" in boundaries
+    assert "list_connectors" in boundaries
+
+
+def test_it_carries_the_xrpl_caveat_that_was_stranded_in_one_agent():
+    """No candles endpoint — previously only xrpl_market_maker knew this."""
+    boundaries = BASE_PROMPT_COMMON.split("CONNECTOR BOUNDARIES:")[1]
+    assert "candles" in boundaries
+    assert "explore_geckoterminal" in boundaries
+
+
+def test_the_rest_of_the_shared_prompt_is_intact():
+    for section in ("GENERAL:", "SKILLS & ROUTINES:", "MEMORY", "NOTIFICATIONS:"):
+        assert section in BASE_PROMPT_COMMON

--- a/tests/test_connector_boundaries_prompt.py
+++ b/tests/test_connector_boundaries_prompt.py
@@ -31,6 +31,15 @@ def test_it_names_native_connectors_explicitly():
         assert connector in boundaries
 
 
+def test_the_gateway_venues_named_are_not_a_short_exhaustive_list():
+    """Naming only some supported venues steers an agent away from Gateway for the rest,
+    so the ones listed are followed by an explicit catch-all."""
+    boundaries = BASE_PROMPT_COMMON.split("CONNECTOR BOUNDARIES:")[1]
+    for venue in ("Meteora", "Orca", "Raydium", "Uniswap", "PancakeSwap"):
+        assert venue in boundaries
+    assert "any other pool-based venue" in boundaries
+
+
 def test_it_gives_a_rule_for_telling_them_apart():
     boundaries = BASE_PROMPT_COMMON.split("CONNECTOR BOUNDARIES:")[1]
     assert "<chain>-<network>" in boundaries


### PR DESCRIPTION
## Summary

Agents reach for Gateway to debug connectors that never use it.

Asked why a token showed $0.00 on xrpl, an agent called the Gateway config and container tools five times, found Gateway returning 503, and concluded:

> "the issue is that Gateway is down, which is why FUZZY isn't showing a proper value in your portfolio"

Plausible, confidently stated, and wrong. xrpl is a native connector and never touches Gateway — the real cause was in the connector's own pricing path (fixed in hummingbot/hummingbot-api#227).

`BASE_PROMPT_COMMON` had no mention of Gateway, connectors, DEX or CEX, while the tool surface pushes the other way: `manage_gateway_config` describes itself as covering *"chains, networks, tokens, **connectors**, pools, wallets"*, and nearly every other DEX-flavoured tool genuinely is Gateway-mediated. So the model generalises "xrpl is a DEX" into "DEXs go through Gateway".

The boundary was written down in exactly one place — `agents/xrpl_market_maker/AGENT.md` — which no other persona ever sees. This moves it into the shared prompt every agent turn includes, along with the xrpl no-candles caveat that was stranded there.

The venue list is deliberately open-ended (`...and any other pool-based venue reached through a chain`) rather than a closed list, so it stays correct as venues are added — a test asserts the catch-all is present.

## Scope change

This PR originally also carried an enum-coercion fix for `executor_config`, repairing a quoted `"1"` before it reached the backend's int-valued `Enum` fields. **That commit has been dropped — the executor refactor on `main` fixed the root cause properly.**

The untyped `executor_config: dict[str, Any]` is gone; the five `create_*_executor` tools now take typed parameters:

```python
side: Literal[1, 2],
open_order_type: Literal[1, 2, 3] | None = None,
```

Verified `Literal[1, 2]` rejects `"1"` at the tool boundary with a clear error naming the allowed values, which is strictly better than repairing it in the middle. Coercing there would now be dead code — creation moved to `executor_create.py`, and no untyped executor-config path remains.

## Verification

Rebased onto current `main` (526 commits since this branch was cut). Full suite on the rebased branch: **5126 passed, 23 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)