### PR TITLE
Find the API node when TAILSCALE_HOSTNAME names the desk, not a number

### DIFF
--- a/setup-environment.sh
+++ b/setup-environment.sh
@@ -421,13 +421,21 @@ tailnet_node_name() {
 }
 
 # Peers on this tailnet whose name looks like a hummingbot-api node, newline
-# separated. Matches the requested name and the -1/-2 suffixes Tailscale adds,
-# so the machine we are looking for is found under whichever one it got.
+# separated.
+#
+# The suffix is deliberately `-.+` and not `-[0-9]+`. Tailscale's own
+# de-duplication only ever appends numbers, but TAILSCALE_HOSTNAME is a
+# setting, and a deployment that names its API per desk -- hummingbot-api-cornell,
+# hummingbot-api-eu -- is the normal way to run more than one. Matching only
+# numbers found nothing for those, and "nothing" is the branch that warns
+# "deploy it on that machine first" about a node sitting right there in
+# `tailscale status`, then asks the operator to type the name it just declined
+# to recognise.
 tailnet_api_peers() {
     local want="${1:-hummingbot-api}"
     tailscale status --peers 2>/dev/null \
         | awk '{print $2}' \
-        | grep -E "^${want}(-[0-9]+)?$" || true
+        | grep -E "^${want}(-.+)?$" || true
 }
 
 # Make sure a tailscaled is running, then `tailscale up`.


### PR DESCRIPTION
`tailnet_api_peers` (added in #231) matched `hummingbot-api` plus a **numeric** suffix, because that is the only suffix Tailscale itself appends when a name is taken. But `TAILSCALE_HOSTNAME` is a setting, and naming the API per desk — `hummingbot-api-cornell`, `hummingbot-api-eu` — is the ordinary way to run more than one.

For those the search found nothing, and *nothing* is the branch that warns:

```
! No hummingbot-api node is visible on this tailnet yet.
→ Deploy it on that machine first (its setup joins the tailnet), or
→ enter the name/address it is reachable at.
```

…about a node sitting in plain sight in `tailscale status`, and then asks the operator to type the name it had just declined to recognise.

## Verification

Driven end to end through the real wizard in a container, against a tailnet whose only API node was `hummingbot-api-cornell` (`tailscale` stubbed, a stand-in API bound off-loopback so the localhost probe could not see it). Before:

```
! No hummingbot-api node is visible on this tailnet yet.
  hummingbot-api host [hummingbot-api]: hummingbot-api-cornell
```

After:

```
✓ Found it on your tailnet: hummingbot-api-cornell
```

…and it asks nothing. Both runs end with `✓ API reachable and credentials accepted` and the same `config.yml`.

Widening the suffix cannot make the earlier silent-wrong-node failure worse: more matches means the operator is shown the list and picks, which is the one outcome that is never wrong. Plus 13 stubbed assertions over the helper, and the full suite (5093 passed, 23 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)